### PR TITLE
[DS-87] ThemeProvider Documentation

### DIFF
--- a/packages/doc/content/components/components/themeprovider/index.mdx
+++ b/packages/doc/content/components/components/themeprovider/index.mdx
@@ -44,6 +44,6 @@ and specific locale like `zh-cn` (china) for instance, but for this to happen
 We have to combine `theme` prop with the optional `locale` prop, from type
 `string` as well.
 
-Although Yoga supports `locale`, We don't have any design definitions for
+Although Yoga supports `locale`, we don't have any design definitions for
 specific locale design-tokens yet, so the `ThemeProvider` components only uses
 global theming for now.

--- a/packages/doc/content/components/components/themeprovider/index.mdx
+++ b/packages/doc/content/components/components/themeprovider/index.mdx
@@ -1,0 +1,35 @@
+---
+title: 'ThemeProvider'
+metaTitle: 'ThemeProvider'
+metaDescription: 'ThemeProvider Component'
+---
+
+## Getting Started
+
+Gympass design-system's follows design guidelines specification, we developed a React and React Native UI library that contains a set of high quality components that defines our interfaces.
+
+### Installing
+
+In order to install our design-system just run:
+
+```
+yarn add @gympass/yoga
+
+// or
+
+npm install @gympass/yoga
+```
+
+### Usage
+
+An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
+
+```
+import { ThemeProvider, Button } from '@gympass/yoga';
+
+const App = () => (
+  <ThemeProvider>
+    <Button>Find an activity</Button>
+  </ThemeProvider>
+);
+```

--- a/packages/doc/content/components/components/themeprovider/index.mdx
+++ b/packages/doc/content/components/components/themeprovider/index.mdx
@@ -4,25 +4,19 @@ metaTitle: 'ThemeProvider'
 metaDescription: 'ThemeProvider Component'
 ---
 
-## Getting Started
+# ThemeProvider
 
-Gympass design-system's follows design guidelines specification, we developed a React and React Native UI library that contains a set of high quality components that defines our interfaces.
+### Reference
 
-### Installing
-
-In order to install our design-system just run:
-
-```
-yarn add @gympass/yoga
-
-// or
-
-npm install @gympass/yoga
-```
+ThemeProvider component extends from styled-component `ThemeProvider`, you can
+check it out [here.](https://www.styled-components.com/docs/advanced#theming)
+Our component adds some extra features to `ThemeProvider` like global and
+specific locale design-tokens merge.
 
 ### Usage
 
-An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
+An important point in using it is that your whole application **must** be
+wrapped in our `ThemeProvider` component:
 
 ```
 import { ThemeProvider, Button } from '@gympass/yoga';
@@ -33,3 +27,23 @@ const App = () => (
   </ThemeProvider>
 );
 ```
+
+### Props
+
+In this component we have 2 props, both are very important. The first one is the
+very known `theme` prop from type `string`.
+
+In this prop you can pass one of our 3 available themes:
+
+- `endUser`
+- `corporate`
+- `gyms`
+
+These themes apply all global branding rules merging them with culture rules of
+and specific locale like `zh-cn` (china) for instance, but for this to happen
+We have to combine `theme` prop with the optional `locale` prop, from type
+`string` as well.
+
+Although Yoga supports `locale`, We don't have any design definitions for
+specific locale design-tokens yet, so the `ThemeProvider` components only uses
+global theming for now.

--- a/packages/yoga/src/Theme/Provider/ThemeProvider.jsx
+++ b/packages/yoga/src/Theme/Provider/ThemeProvider.jsx
@@ -11,7 +11,7 @@ const getTheme = ({ theme, locale }) => {
   return appTheme(token);
 };
 
-/** Yoga has full theming support by exporting a ThemeProvider wrapper component. This component provides a theme to all React components underneath itself via the context API. */
+/** This component provides a theme to all React components underneath itself via the context API. */
 const ThemeProvider = ({ children, ...theme }) => (
   <SCThemeProvider theme={{ yoga: getTheme(theme) }}>
     {children}

--- a/packages/yoga/src/Theme/Provider/ThemeProvider.jsx
+++ b/packages/yoga/src/Theme/Provider/ThemeProvider.jsx
@@ -11,6 +11,7 @@ const getTheme = ({ theme, locale }) => {
   return appTheme(token);
 };
 
+/** Yoga has full theming support by exporting a ThemeProvider wrapper component. This component provides a theme to all React components underneath itself via the context API. */
 const ThemeProvider = ({ children, ...theme }) => (
   <SCThemeProvider theme={{ yoga: getTheme(theme) }}>
     {children}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4368481/70930090-2c6c8b80-2013-11ea-81f1-c33cfbab1bc4.png)

This PR adds the documentation for `ThemeProvider` component.
The component documentation contains:
- Reference (what this component does)
- Usage (when and how to use it)
- Props (properties you can pass to change it behavior)

