### PR TITLE
Change Input and Dropdown value proptypes so they accept numbers

### DIFF
--- a/packages/yoga/src/Dropdown/native/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/native/Dropdown.jsx
@@ -1,6 +1,14 @@
 import React, { useState } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { arrayOf, func, shape, string, bool } from 'prop-types';
+import {
+  arrayOf,
+  func,
+  shape,
+  number,
+  string,
+  bool,
+  oneOfType,
+} from 'prop-types';
 import { TouchableWithoutFeedback } from 'react-native';
 import { ArrowDown } from '@gympass/yoga-icons';
 
@@ -136,7 +144,7 @@ Dropdown.propTypes = {
   options: arrayOf(
     shape({
       label: string,
-      value: string,
+      value: oneOfType([string, number]),
       selected: bool,
     }),
   ).isRequired,

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 import Downshift from 'downshift';
-import { arrayOf, func, shape, string, bool } from 'prop-types';
+import {
+  arrayOf,
+  func,
+  shape,
+  string,
+  number,
+  bool,
+  oneOfType,
+} from 'prop-types';
 import { ArrowDown } from '@gympass/yoga-icons';
 
 const Wrapper = styled.div`
@@ -323,7 +331,7 @@ Dropdown.propTypes = {
   options: arrayOf(
     shape({
       label: string,
-      value: string,
+      value: oneOfType([string, number]),
       selected: bool,
     }),
   ).isRequired,

--- a/packages/yoga/src/Input/native/Input.jsx
+++ b/packages/yoga/src/Input/native/Input.jsx
@@ -360,7 +360,7 @@ Input.propTypes = {
   maxLength: number,
   readOnly: bool,
   textContentType: string,
-  value: string,
+  value: oneOfType([string, number]),
   style: oneOfType([shape({}), arrayOf(shape({}))]),
   onBlur: func,
   onChangeText: func,

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
-import { func, string, bool, number, shape } from 'prop-types';
+import { func, string, bool, number, shape, oneOfType } from 'prop-types';
 import { Close } from '@gympass/yoga-icons';
 
 import Wrapper from './Wrapper';
@@ -126,7 +126,7 @@ Input.propTypes = {
   maxLength: number,
   readOnly: bool,
   style: shape({}),
-  value: string,
+  value: oneOfType([string, number]),
   onChange: func,
   /** callback invoked when close icon is clicked, it returns a empty string to update your state */
   onClean: func,


### PR DESCRIPTION
## Description

In this PR, I'm changing the propTypes for the Input and Dropdown components, so they are able to accept numbers without throwing warnings.

## Steps to reproduce

### For Input
* Create a Input component like so 
```jsx
import React from 'react';
import ReactDOM from 'react-dom';
import { Input, ThemeProvider } from '@gympass/yoga';

const App = () => 
    <ThemeProvider>
      <Input
        label="Find an activity"
        helper="Helper text"
        maxLength={20}
        value={1}
        onChange={e => setValue(e.target.value)}
        onClean={cleaned => setValue(cleaned)}
      />
    </ThemeProvider>

ReactDOM.render(
  <App />,
  document.getElementById('root')
);
``` 
* Check the browser's console. There should be the following warning:
```Warning: Failed prop type: Invalid prop `value` of type `number` supplied to `ForwardRef`, expected `string`.```

* [Example](https://5w6dr.csb.app/)

### For Dropdown

* Create a Dropdown component like so 
```jsx
import React from 'react';
import ReactDOM from 'react-dom';
import { Dropdown, ThemeProvider } from '@gympass/yoga';

const App = () =>
<ThemeProvider >
  <Dropdown
    label="Search by your City"
    options={[
      { label: 'San Diego', value: 1, selected: true },
      { label: 'San Francisco', value: 2 },
      { label: 'Los Angeles', value: 3 },
      { label: 'Northridge', value: 4 },
      { label: 'Santa Monica', value: 5 },
    ]}
  />
</ThemeProvider>

ReactDOM.render(
  <App />,
  document.getElementById('root')
);
``` 
* Check the browser's console. There should be the following warning:
```Invalid prop `options[0].value` of type `number` supplied to `Dropdown`, expected `string`.```

* [Example](https://dnpbb.csb.app/)
