### PR TITLE
Add 'box-sizing border-box' to List.LinkItems

### DIFF
--- a/packages/yoga/src/List/web/LinkItem.jsx
+++ b/packages/yoga/src/List/web/LinkItem.jsx
@@ -7,6 +7,8 @@ const StyledLinkItem = styled.a`
   width: 100%;
   height: 100%;
 
+  box-sizing: border-box;
+
   text-decoration: none;
 
   ${({

--- a/packages/yoga/src/List/web/ListItem.jsx
+++ b/packages/yoga/src/List/web/ListItem.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 const StyledItem = styled.li`
+  box-sizing: border-box;
+
   ${({
     theme: {
       yoga: {
@@ -9,7 +11,11 @@ const StyledItem = styled.li`
       },
     },
   }) => `
-    padding: ${list.listItem.padding.top}px ${list.listItem.padding.right}px ${list.listItem.padding.bottom}px ${list.listItem.padding.left}px;
+    padding:
+      ${list.listItem.padding.top}px
+      ${list.listItem.padding.right}px
+      ${list.listItem.padding.bottom}px
+      ${list.listItem.padding.left}px;
   `}
 `;
 

--- a/packages/yoga/src/List/web/__snapshots__/List.test.jsx.snap
+++ b/packages/yoga/src/List/web/__snapshots__/List.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<List /> Snapshots Without props should match snapshot with a default list 1`] = `
 .c1 {
+  box-sizing: border-box;
   padding: 20px 24px 20px 24px;
 }
 
@@ -44,6 +45,7 @@ exports[`<List /> Snapshots Without props should match snapshot with a default l
 
 exports[`<List /> Snapshots Without props should match snapshot with a default list and multiple items 1`] = `
 .c1 {
+  box-sizing: border-box;
   padding: 20px 24px 20px 24px;
 }
 
@@ -96,6 +98,7 @@ exports[`<List /> Snapshots Without props should match snapshot with a default l
   display: inline-block;
   width: 100%;
   height: 100%;
+  box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 20px 24px 20px 24px;
@@ -142,6 +145,7 @@ exports[`<List /> Snapshots Without props should match snapshot with a default l
 
 exports[`<List /> Snapshots Without props should match snapshot with a default list, multiple items and no dividers 1`] = `
 .c1 {
+  box-sizing: border-box;
   padding: 20px 24px 20px 24px;
 }
 
@@ -187,6 +191,7 @@ exports[`<List /> Snapshots Without props should match snapshot with a default l
 
 exports[`<List /> Snapshots Without props should match snapshot with a horizontal list 1`] = `
 .c1 {
+  box-sizing: border-box;
   padding: 20px 24px 20px 24px;
 }
 
@@ -231,6 +236,7 @@ exports[`<List /> Snapshots Without props should match snapshot with a horizonta
 
 exports[`<List /> Snapshots Without props should match snapshot with a horizontal list and multiple items 1`] = `
 .c1 {
+  box-sizing: border-box;
   padding: 20px 24px 20px 24px;
 }
 
@@ -280,6 +286,7 @@ exports[`<List /> Snapshots Without props should match snapshot with a horizonta
 
 exports[`<List /> Snapshots Without props should match snapshot with a horizontal list, multiple items and no dividers 1`] = `
 .c1 {
+  box-sizing: border-box;
   padding: 20px 24px 20px 24px;
 }
 


### PR DESCRIPTION
We should add `box-sizing: border-box;`to the list elements.

Before:
![image](https://user-images.githubusercontent.com/9873486/76771773-9b768f00-677e-11ea-99de-fb9f6ba6c4e1.png)

After:
![image](https://user-images.githubusercontent.com/9873486/76771717-8863bf00-677e-11ea-96fe-edf2e16fa76d.png)
