### PR TITLE
[Partners] Theme colors update

### DIFF
--- a/packages/tokens/src/global/colors.js
+++ b/packages/tokens/src/global/colors.js
@@ -30,7 +30,7 @@ const saoPaulo = ['#B5DAD5', '#55A99E', '#2B9486', '#22766B'];
 /**
  * @type {Color}
  */
-const newYork = ['#606CD2', '#3847C7', '#2D399F', '#232C7B'];
+const newYork = ['#D7DAF3', '#5F6BD2', '#3847C7', '#27318B'];
 
 /**
  * @type {Color}

--- a/packages/yoga/src/Theme/themes/Gyms.js
+++ b/packages/yoga/src/Theme/themes/Gyms.js
@@ -2,8 +2,8 @@ import BaseTheme from './BaseTheme';
 
 const Gyms = tokens => {
   const colors = {
-    primary: tokens.colors.milan,
-    secondary: tokens.colors.paris,
+    primary: tokens.colors.newYork,
+    secondary: tokens.colors.saoPaulo,
   };
 
   return { colors, ...BaseTheme(colors) };


### PR DESCRIPTION
### 🎨 Updating Partners colors
The colors of the partner theme are out of date in relation to what our PDs have been using in the prototypes.

According to them our theme must be composed by New York as primary our primary color scheme and São Paulo as secondary.

![image](https://user-images.githubusercontent.com/20416768/84529658-3583a000-acb8-11ea-978a-60ad19c66d20.png) ![image](https://user-images.githubusercontent.com/20416768/84529642-2c92ce80-acb8-11ea-85f0-886bd0836606.png)

✅ Also updated New York color scheme according to the new pallet :wink: 