### PR TITLE
Fix Input and TextArea width issues

### DIFF
--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -43,10 +43,10 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
 
 .c4 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -277,10 +277,10 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
 
 .c4 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -409,7 +409,7 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 .c3 {
@@ -511,10 +511,10 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
 
 .c4 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -860,10 +860,10 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 
 .c4 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -1005,7 +1005,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 .c3 {

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -24,8 +24,10 @@ const labelTransition = css`
 
 const Field = styled.input`
   width: 100%;
-  appearance: none;
+
   background-color: transparent;
+
+  appearance: none;
   outline: none;
 
   ${({

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { func, string, bool, number, shape, oneOfType } from 'prop-types';
 import { Close } from '@gympass/yoga-icons';
 
+import { theme } from '../../Theme';
 import Wrapper from './Wrapper';
 import Field from './Field';
 import Label from './Label';
@@ -10,16 +11,12 @@ import Helper from './Helper';
 
 const Control = styled.div`
   box-sizing: border-box;
-  ${({
-    full,
-    theme: {
-      yoga: {
-        components: { input },
-      },
-    },
-  }) => `
-    width: ${full ? '100%' : `${input.width}px`};
-  `}
+  width: ${({ full }) =>
+    full
+      ? '100%'
+      : css`
+          ${theme.components.input.width}px
+        `};
 `;
 
 const Input = React.forwardRef(

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -10,8 +10,15 @@ import Helper from './Helper';
 
 const Control = styled.div`
   box-sizing: border-box;
-  ${({ full }) => `
-    width: ${full ? '100%' : 'auto'};
+  ${({
+    full,
+    theme: {
+      yoga: {
+        components: { input },
+      },
+    },
+  }) => `
+    width: ${full ? '100%' : `${input.width}px`};
   `}
 `;
 

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -43,10 +43,10 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -175,7 +175,7 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -43,10 +43,10 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -175,7 +175,7 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>
@@ -268,10 +268,10 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -401,7 +401,7 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>
@@ -491,10 +491,10 @@ exports[`<Input /> Snapshots should match with error 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -638,7 +638,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>
@@ -728,10 +728,10 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -941,10 +941,10 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -1091,7 +1091,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>
@@ -1189,10 +1189,10 @@ exports[`<Input /> Snapshots should match with label 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -1321,7 +1321,7 @@ exports[`<Input /> Snapshots should match with label 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -43,10 +43,10 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -175,7 +175,7 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -43,10 +43,10 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
 
 .c4 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -175,7 +175,7 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 .c3 input {
@@ -311,10 +311,10 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
 
 .c4 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -444,7 +444,7 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 .c3 input {
@@ -576,10 +576,10 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
 
 .c4 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -43,10 +43,10 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;
@@ -175,7 +175,7 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  width: auto;
+  width: 320px;
 }
 
 <div>

--- a/packages/yoga/src/TextArea/web/TextArea.jsx
+++ b/packages/yoga/src/TextArea/web/TextArea.jsx
@@ -26,6 +26,7 @@ const StyledWrapper = styled(Wrapper)`
     },
   }) => `
     height: 88px;
+    box-sizing: border-box;
 
     padding-top: ${textarea.padding.top}px;
     padding-right: ${textarea.padding.right}px;

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`<TextArea /> should match snapshot 1`] = `
   border-style: solid;
   border-color: #D3D3E2;
   height: 88px;
+  box-sizing: border-box;
   padding-top: 16px;
   padding-right: 16px;
   padding-bottom: 16px;
@@ -67,10 +68,10 @@ exports[`<TextArea /> should match snapshot 1`] = `
 
 .c2 {
   width: 100%;
+  background-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: transparent;
   outline: none;
   height: 100%;
   padding-top: 16px;

--- a/packages/yoga/src/Theme/helpers/themeReader/native/native.test.jsx
+++ b/packages/yoga/src/Theme/helpers/themeReader/native/native.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { render } from '@testing-library/react-native';
 
 import ThemeProvider, { theme } from '../../../index.native';
@@ -16,6 +16,39 @@ describe('themeReader - web specs', () => {
     const { asJSON } = render(
       <ThemeProvider>
         <Component testID="component">Teste</Component>
+      </ThemeProvider>,
+    );
+
+    expect(asJSON().children[0].props.style).toEqual([
+      { borderWidth: 1, borderColor: 'black', borderStyle: 'solid' },
+    ]);
+  });
+
+  it('should render with conditional', () => {
+    const Component = styled.View`
+      border: ${({ borders }) =>
+        borders
+          ? css`
+              ${theme.borders.small}px solid
+            `
+          : 'none'};
+    `;
+
+    const { asJSON, rerender } = render(
+      <ThemeProvider>
+        <Component borders={false} testID="component">
+          Teste
+        </Component>
+      </ThemeProvider>,
+    );
+
+    expect(asJSON().children[0].props.style).toEqual([
+      { borderWidth: 0, borderColor: 'black', borderStyle: 'solid' },
+    ]);
+
+    rerender(
+      <ThemeProvider>
+        <Component borders data-testid="component" />
       </ThemeProvider>,
     );
 

--- a/packages/yoga/src/Theme/helpers/themeReader/web/web.test.jsx
+++ b/packages/yoga/src/Theme/helpers/themeReader/web/web.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { render } from '@testing-library/react';
 
 import ThemeProvider, { theme } from '../../../index';
@@ -16,6 +16,33 @@ describe('themeReader - web specs', () => {
     const { getByTestId } = render(
       <ThemeProvider>
         <Component data-testid="component" />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId('component')).toHaveStyleRule('border', '1px solid');
+  });
+
+  it('should render with conditional', () => {
+    const Component = styled.div`
+      border: ${({ borders }) =>
+        borders
+          ? css`
+              ${theme.borders.small}px solid
+            `
+          : 'none'};
+    `;
+
+    const { getByTestId, rerender } = render(
+      <ThemeProvider>
+        <Component borders={false} data-testid="component" />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId('component')).toHaveStyleRule('border', 'none');
+
+    rerender(
+      <ThemeProvider>
+        <Component borders data-testid="component" />
       </ThemeProvider>,
     );
 


### PR DESCRIPTION
This PR solve two related bugs:

- Fixes #138 
- Fix input helper text when the parent element has a bigger width than Input.

**Bug** example:
![Captura de Tela 2020-06-16 às 10 51 34](https://user-images.githubusercontent.com/13424727/84785268-b1842d80-afc1-11ea-988e-874e4ed87c1d.png)

**Fixed** example (bordered parent with bigger width):
![image](https://user-images.githubusercontent.com/13424727/84785506-f14b1500-afc1-11ea-8009-1183ed31dcb6.png)

