### PR TITLE
Fix svg issues on our build process

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,14 +1,16 @@
 # Yoga Icons
 
-<img src="./src/svg/star.svg" alt="Star" width="12" height="12" />
-<img src="./src/svg/building.svg" alt="building" width="12" height="12" />
-<img src="./src/svg/clock.svg" alt="clock" width="12" height="12" />
-<img src="./src/svg/triangle_alert.svg" alt="triangle_alert" width="12" height="12" />
-<img src="./src/svg/close.svg" alt="triangle_alert" width="12" height="12" />
-<img src="./src/svg/visibility.svg" alt="triangle_alert" width="12" height="12" />
-<img src="./src/svg/visibility_off.svg" alt="triangle_alert" width="12" height="12" />
-<img src="./src/svg/arrow_down.svg" alt="arrow_down" width="12" height="12" />
-<img src="./src/svg/youtube.svg" alt="youtube" width="12" height="12" />
+<p style="float: left;">
+  <img src="./src/svg/star.svg" alt="Star" title="Star" width="12"  />
+  <img src="./src/svg/building.svg" alt="building" title="building" width="12"  />
+  <img src="./src/svg/clock.svg" alt="clock" title="clock" width="12"  />
+  <img src="./src/svg/triangle_alert.svg" alt="triangle_alert" title="triangle_alert" width="12"  />
+  <img src="./src/svg/close.svg" alt="triangle_alert" title="triangle_alert" width="12"  />
+  <img src="./src/svg/visibility.svg" alt="triangle_alert" title="triangle_alert" width="12"  />
+  <img src="./src/svg/visibility_off.svg" alt="triangle_alert" title="triangle_alert" width="12"  />
+  <img src="./src/svg/arrow_down.svg" alt="arrow_down" title="arrow_down" width="12"  />
+  <img src="./src/svg/youtube.svg" alt="youtube" title="youtube" width="12"  />
+</p>
 
 ## Instalation
 

--- a/packages/icons/babel.config.js
+++ b/packages/icons/babel.config.js
@@ -3,7 +3,7 @@ module.exports = {
     web: {
       presets: [['@babel/preset-env'], '@babel/preset-react'],
       ignore: ['**/*.native.js'],
-      plugins: ['inline-react-svg'],
+      plugins: [['inline-react-svg', { svgo: false }]],
     },
 
     esm: {
@@ -12,7 +12,7 @@ module.exports = {
         '@babel/preset-react',
       ],
       ignore: ['**/*.native.js'],
-      plugins: ['inline-react-svg'],
+      plugins: [['inline-react-svg', { svgo: false }]],
     },
 
     native: {


### PR DESCRIPTION
This PR removes svgo from our web (cjs and esm) build steps. The issue with that was shown in our CI, [here](https://github.com/Gympass/yoga/runs/796226626?check_suite_focus=true#step:8:34).

Since we add only optimized `svgs` inside icons package, we do not need to svgo config inside babel too.

