### PR TITLE
Add SVGR to yoga-icons build steps

### DIFF
--- a/packages/icons/babel.config.js
+++ b/packages/icons/babel.config.js
@@ -1,18 +1,27 @@
 module.exports = {
+  plugins: [
+    [
+      'transform-rename-import',
+      { original: '^(.+?)\\.svg$', replacement: '$1.js' },
+    ],
+  ],
   env: {
     web: {
-      presets: [['@babel/preset-env'], '@babel/preset-react'],
+      presets: [
+        ['@babel/preset-env'],
+        '@babel/preset-react',
+        '@dr.pogodin/babel-preset-svgr',
+      ],
       ignore: ['**/*.native.js'],
-      plugins: [['inline-react-svg', { svgo: false }]],
     },
 
     esm: {
       presets: [
         ['@babel/preset-env', { modules: false }],
         '@babel/preset-react',
+        '@dr.pogodin/babel-preset-svgr',
       ],
       ignore: ['**/*.native.js'],
-      plugins: [['inline-react-svg', { svgo: false }]],
     },
 
     native: {
@@ -21,7 +30,7 @@ module.exports = {
       plugins: [
         [
           'transform-rename-import',
-          { original: '^(.+?)\\.svg$', replacement: '$1.js' },
+          { original: '^(.+?)\\.svg$', replacement: '$1.native.js' },
         ],
       ],
     },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,16 +21,15 @@
   "scripts": {
     "prebuild": "rm -rf ./dist",
     "build": "yarn build:native && yarn build:web && yarn build:esm",
-    "build:web": "NODE_ENV=web babel ./src --out-dir dist/cjs",
-    "build:esm": "NODE_ENV=esm babel ./src --out-dir dist/esm",
+    "build:web": "NODE_ENV=web babel ./src --out-dir dist/cjs --extensions '.svg,.js'",
+    "build:esm": "NODE_ENV=esm babel ./src --out-dir dist/esm --extensions '.svg,.js'",
     "prebuild:native": "yarn build:native:svg",
     "build:native": "NODE_ENV=native babel ./src --out-dir dist/cjs",
-    "build:native:svg": "NODE_ENV=svg babel ./src --out-dir dist/cjs --extensions '.svg'",
+    "build:native:svg": "NODE_ENV=svg babel ./src --out-dir dist/cjs --extensions '.svg' --out-file-extension .native.js",
     "prepublishOnly": "node ../../scripts/prepublish.js --rn"
   },
   "devDependencies": {
     "@dr.pogodin/babel-preset-svgr": "^1.0.3",
-    "babel-plugin-inline-react-svg": "^1.1.0",
     "babel-plugin-transform-rename-import": "^2.3.0"
   },
   "peerDependencies": {

--- a/packages/yoga/package.json
+++ b/packages/yoga/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@testing-library/react": "^9.1.4",
     "@testing-library/react-native": "^4.1.0",
+    "babel-plugin-inline-react-svg": "^1.1.1",
     "styled-components": "^4.4.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4314,7 +4314,7 @@ babel-plugin-import-glob@^2.0.0:
     identifierfy "^1.1.0"
     minimatch-capture "^1.1.0"
 
-babel-plugin-inline-react-svg@^1.1.0:
+babel-plugin-inline-react-svg@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-1.1.1.tgz#3fce30c5653a6c032c21ccc2b3e0141cd494b1d8"
   integrity sha512-KCCzSKJUigDXd/dxJDE6uNyVTYE46FiTt8Md3vpYHtbADeTjOLJq5LkmaVpISplxKCK25VZU8sha2Km6uIEFJA==


### PR DESCRIPTION
This PR adds @dr.pogodin/babel-preset-svgr to handle SVG files during the build process of yoga-icons package.