### PR TITLE
docs(native-font): add documentation for native font in getting started

### DIFF
--- a/packages/doc/content/components/components/text/default-native.mdx
+++ b/packages/doc/content/components/components/text/default-native.mdx
@@ -16,51 +16,6 @@
   <Text.Black>Live the mission</Text.Black>
 ```
 
-### Adding Gympass font in your project
-
-Both iOS and Android come with their own set of platform fonts but all Yoga
-components needs its own font family based on
-[font design token](https://gympass.github.io/yoga/guidelines/tokens/fonts).
-
-#### React Native > 0.60
-
-Edit or create the file `react-native.config.js` in your project's root to be as
-follows:
-
-```javascript type=highlight
-module.exports = {
-  project: {
-    ios: {},
-    android: {},
-  },
-  assets: ['./node_modules/@gympass/yoga/fonts'],
-};
-```
-
-and run the command bellow:
-
-```javascript type=highlight
-react-native link
-```
-
-#### React Native < 0.60
-
-Add the following lines in your `package.json`:
-
-```javascript type=highlight
-"rnpm": {
-  "assets": [
-    "./node_modules/@gympass/yoga/fonts"
-  ]
-}
-```
-
-and run the command bellow:
-
-```javascript type=highlight
-react-native link
-```
-
 ### Props
 
 <PropsTable component="Text" platform="native" />

--- a/packages/doc/content/components/getting-started/default-native.mdx
+++ b/packages/doc/content/components/getting-started/default-native.mdx
@@ -1,15 +1,3 @@
-### Installing
-
-In order to install our design-system just run:
-
-```bash type=highlight
-yarn add @gympass/yoga
-
-// or
-
-npm install @gympass/yoga
-```
-
 ### Adding Gympass font in your project
 
 Both iOS and Android come with their own set of platform fonts but all Yoga
@@ -53,18 +41,4 @@ and run the command bellow:
 
 ```javascript type=highlight
 react-native link
-```
-
-### Usage
-
-An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
-
-```javascript type=highlight
-import { ThemeProvider, Button } from '@gympass/yoga';
-
-const App = () => (
-  <ThemeProvider>
-    <Button>Find an activity</Button>
-  </ThemeProvider>
-);
 ```

--- a/packages/doc/content/components/getting-started/default-native.mdx
+++ b/packages/doc/content/components/getting-started/default-native.mdx
@@ -1,0 +1,70 @@
+### Installing
+
+In order to install our design-system just run:
+
+```bash type=highlight
+yarn add @gympass/yoga
+
+// or
+
+npm install @gympass/yoga
+```
+
+### Adding Gympass font in your project
+
+Both iOS and Android come with their own set of platform fonts but all Yoga
+components needs its own font family based on
+[font design token](https://gympass.github.io/yoga/guidelines/tokens/fonts).
+
+#### React Native > 0.60
+
+Edit or create the file `react-native.config.js` in your project's root to be as
+follows:
+
+```javascript type=highlight
+module.exports = {
+  project: {
+    ios: {},
+    android: {},
+  },
+  assets: ['./node_modules/@gympass/yoga/fonts'],
+};
+```
+
+and run the command bellow:
+
+```javascript type=highlight
+react-native link
+```
+
+#### React Native < 0.60
+
+Add the following lines in your `package.json`:
+
+```javascript type=highlight
+"rnpm": {
+  "assets": [
+    "./node_modules/@gympass/yoga/fonts"
+  ]
+}
+```
+
+and run the command bellow:
+
+```javascript type=highlight
+react-native link
+```
+
+### Usage
+
+An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
+
+```javascript type=highlight
+import { ThemeProvider, Button } from '@gympass/yoga';
+
+const App = () => (
+  <ThemeProvider>
+    <Button>Find an activity</Button>
+  </ThemeProvider>
+);
+```

--- a/packages/doc/content/components/getting-started/default-web.mdx
+++ b/packages/doc/content/components/getting-started/default-web.mdx
@@ -1,28 +1,14 @@
 ### Adding Gympass font in your project
 
+Make sure to import and use `FontLoader` inside `ThemeProvider`.
+
 ```javascript type=highlight
-import React from 'react';
-import GoogleFontLoader from 'react-google-font-loader';
-import { withTheme } from 'styled-components';
+import { ThemeProvider, Button, FontLoader } from '@gympass/yoga';
 
-const FontLoader = ({
-  theme: {
-    yoga: {
-      baseFont: { family, weight },
-    },
-  },
-}) => (
-  <>
-    {typeof window !== 'undefined' ? (
-      <GoogleFontLoader fonts={[{ font: family, weights: weight }]} />
-    ) : (
-      <link
-        rel="stylesheet"
-        href={`https://fonts.googleapis.com/css?family=${family}:${weight.join()}`}
-      />
-    )}
-  </>
+const App = () => (
+  <ThemeProvider>
+    <FontLoader />
+    <Button>Find an activity</Button>
+  </ThemeProvider>
 );
-
-export default withTheme(FontLoader);
 ```

--- a/packages/doc/content/components/getting-started/default-web.mdx
+++ b/packages/doc/content/components/getting-started/default-web.mdx
@@ -1,25 +1,28 @@
-### Installing
-
-In order to install our design-system just run:
-
-```bash type=highlight
-yarn add @gympass/yoga
-
-// or
-
-npm install @gympass/yoga
-```
-
-### Usage
-
-An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
+### Adding Gympass font in your project
 
 ```javascript type=highlight
-import { ThemeProvider, Button } from '@gympass/yoga';
+import React from 'react';
+import GoogleFontLoader from 'react-google-font-loader';
+import { withTheme } from 'styled-components';
 
-const App = () => (
-  <ThemeProvider>
-    <Button>Find an activity</Button>
-  </ThemeProvider>
+const FontLoader = ({
+  theme: {
+    yoga: {
+      baseFont: { family, weight },
+    },
+  },
+}) => (
+  <>
+    {typeof window !== 'undefined' ? (
+      <GoogleFontLoader fonts={[{ font: family, weights: weight }]} />
+    ) : (
+      <link
+        rel="stylesheet"
+        href={`https://fonts.googleapis.com/css?family=${family}:${weight.join()}`}
+      />
+    )}
+  </>
 );
+
+export default withTheme(FontLoader);
 ```

--- a/packages/doc/content/components/getting-started/default-web.mdx
+++ b/packages/doc/content/components/getting-started/default-web.mdx
@@ -1,0 +1,25 @@
+### Installing
+
+In order to install our design-system just run:
+
+```bash type=highlight
+yarn add @gympass/yoga
+
+// or
+
+npm install @gympass/yoga
+```
+
+### Usage
+
+An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
+
+```javascript type=highlight
+import { ThemeProvider, Button } from '@gympass/yoga';
+
+const App = () => (
+  <ThemeProvider>
+    <Button>Find an activity</Button>
+  </ThemeProvider>
+);
+```

--- a/packages/doc/content/components/getting-started/index.mdx
+++ b/packages/doc/content/components/getting-started/index.mdx
@@ -36,3 +36,47 @@ const App = () => (
   </ThemeProvider>
 );
 ```
+### Adding Gympass font in your project
+
+Both iOS and Android come with their own set of platform fonts but all Yoga
+components needs its own font family based on
+[font design token](https://gympass.github.io/yoga/guidelines/tokens/fonts).
+
+#### React Native > 0.60
+
+Edit or create the file `react-native.config.js` in your project's root to be as
+follows:
+
+```javascript type=highlight
+module.exports = {
+  project: {
+    ios: {},
+    android: {},
+  },
+  assets: ['./node_modules/@gympass/yoga/fonts'],
+};
+```
+
+and run the command bellow:
+
+```javascript type=highlight
+react-native link
+```
+
+#### React Native < 0.60
+
+Add the following lines in your `package.json`:
+
+```javascript type=highlight
+"rnpm": {
+  "assets": [
+    "./node_modules/@gympass/yoga/fonts"
+  ]
+}
+```
+
+and run the command bellow:
+
+```javascript type=highlight
+react-native link
+```

--- a/packages/doc/content/components/getting-started/index.mdx
+++ b/packages/doc/content/components/getting-started/index.mdx
@@ -14,6 +14,32 @@ Gympass design-system's follows design guidelines specification, we developed a 
 
 An important note is that the **styled-components** is a peerDependency [see why](https://styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library), if you dont have styled-components installed you'll [need to install](https://styled-components.com/docs/basics#installation).
 
+### Installing
+
+In order to install our design-system just run:
+
+```bash type=highlight
+yarn add @gympass/yoga
+
+// or
+
+npm install @gympass/yoga
+```
+
+### Usage
+
+An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
+
+```javascript type=highlight
+import { ThemeProvider, Button } from '@gympass/yoga';
+
+const App = () => (
+  <ThemeProvider>
+    <Button>Find an activity</Button>
+  </ThemeProvider>
+);
+```
+
 <TabbedView>
   <Tab title="Web">
     <GettingStartedWeb />

--- a/packages/doc/content/components/getting-started/index.mdx
+++ b/packages/doc/content/components/getting-started/index.mdx
@@ -5,78 +5,21 @@ metaDescription: 'This is the Getting started'
 order: 0
 ---
 
+import GettingStartedWeb from './default-web.mdx';
+import GettingStartedNative from './default-native.mdx';
+
 ## Getting Started
 
 Gympass design-system's follows design guidelines specification, we developed a React and React Native UI library that contains a set of high quality components that defines our interfaces.
 
 An important note is that the **styled-components** is a peerDependency [see why](https://styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library), if you dont have styled-components installed you'll [need to install](https://styled-components.com/docs/basics#installation).
 
-### Installing
+<TabbedView>
+  <Tab title="Web">
+    <GettingStartedWeb />
+  </Tab>
 
-In order to install our design-system just run:
-
-```bash type=highlight
-yarn add @gympass/yoga
-
-// or
-
-npm install @gympass/yoga
-```
-
-### Usage
-
-An important point in using it is that your whole application must be wrapped in our `ThemeProvider` component:
-
-```javascript type=highlight
-import { ThemeProvider, Button } from '@gympass/yoga';
-
-const App = () => (
-  <ThemeProvider>
-    <Button>Find an activity</Button>
-  </ThemeProvider>
-);
-```
-### Adding Gympass font in your project
-
-Both iOS and Android come with their own set of platform fonts but all Yoga
-components needs its own font family based on
-[font design token](https://gympass.github.io/yoga/guidelines/tokens/fonts).
-
-#### React Native > 0.60
-
-Edit or create the file `react-native.config.js` in your project's root to be as
-follows:
-
-```javascript type=highlight
-module.exports = {
-  project: {
-    ios: {},
-    android: {},
-  },
-  assets: ['./node_modules/@gympass/yoga/fonts'],
-};
-```
-
-and run the command bellow:
-
-```javascript type=highlight
-react-native link
-```
-
-#### React Native < 0.60
-
-Add the following lines in your `package.json`:
-
-```javascript type=highlight
-"rnpm": {
-  "assets": [
-    "./node_modules/@gympass/yoga/fonts"
-  ]
-}
-```
-
-and run the command bellow:
-
-```javascript type=highlight
-react-native link
-```
+  <Tab title="Native">
+    <GettingStartedNative />
+  </Tab>
+</TabbedView>


### PR DESCRIPTION
Hi guys, how are you? :rocket:

It is a pleasure to contribute to this incredible project. I found an item about the documentation where I went through difficulty.

The native font import documentation was in the `Text` component. The components are listed in alphabetical order, so the `Text` component becomes one of the last items, making it difficult to access font import documentation.