### PR TITLE
Fix "codesandbox" code generation

### DIFF
--- a/packages/doc/src/components/CodeBlock/CodeBlock.jsx
+++ b/packages/doc/src/components/CodeBlock/CodeBlock.jsx
@@ -9,7 +9,7 @@ const CodeBlock = ({ children: sampleCode, center, state, type, theme }) => {
   const code = sampleCode.trim();
 
   const buildImportString = modules => {
-    const findComponents = /(?:<)(\w*)(?=\s*?\/?>*)/gm;
+    const findComponents = /(?:<|{)(\w*)(?=\s*?\/?>*)/gm;
     const sortModules = /(@gympass\/yoga*)/gm;
     const imports = [];
     const foundComponents = code.match(findComponents) || [];
@@ -20,7 +20,7 @@ const CodeBlock = ({ children: sampleCode, center, state, type, theme }) => {
         const moduleComponents = {
           components: [
             ...new Set(
-              foundComponents.map(c => c.replace('<', '')).filter(c => c),
+              foundComponents.map(c => c.replace(/<|{/, '')).filter(c => c),
             ),
           ]
             .filter(importedComponent =>

--- a/packages/doc/src/components/CodeBlock/SnackEmbed/SnackEmbed.jsx
+++ b/packages/doc/src/components/CodeBlock/SnackEmbed/SnackEmbed.jsx
@@ -4,7 +4,7 @@ import { string, bool } from 'prop-types';
 
 import CodeBlockContext from '../CodeBlockContext';
 import { native } from '../shared/templates';
-import injectImport from '../shared/functions';
+import { injectImport } from '../shared/functions';
 
 const Snack = styled.div`
   overflow: hidden;

--- a/packages/doc/src/components/CodeBlock/shared/functions.js
+++ b/packages/doc/src/components/CodeBlock/shared/functions.js
@@ -29,7 +29,7 @@ const injectImport = (imports, componentList, paths, destruct) => {
   return injectedString;
 };
 
-const getStateTypeCode = code => {
+const getCodeFragments = code => {
   const [codeThatIsntComponent] = code.match(/([.*\s*\S*]*)return/gi) || [];
   const codeBetweenRenderAndReturn = codeThatIsntComponent
     ? codeThatIsntComponent.replace(/\s*render.*/, '').replace(/\s*return/, '')
@@ -50,4 +50,4 @@ const getStateTypeCode = code => {
   };
 };
 
-export { getStateTypeCode, injectImport };
+export { getCodeFragments, injectImport };

--- a/packages/doc/src/components/CodeBlock/shared/functions.js
+++ b/packages/doc/src/components/CodeBlock/shared/functions.js
@@ -29,4 +29,25 @@ const injectImport = (imports, componentList, paths, destruct) => {
   return injectedString;
 };
 
-export default injectImport;
+const getStateTypeCode = code => {
+  const [codeThatIsntComponent] = code.match(/([.*\s*\S*]*)return/gi) || [];
+  const codeBetweenRenderAndReturn = codeThatIsntComponent
+    ? codeThatIsntComponent.replace(/\s*render.*/, '').replace(/\s*return/, '')
+    : '';
+  const [styledComponents] = code.match(/const\s*.*styled[.*\s*\S*]*`;/) || [];
+
+  const withoutStyledComponents = codeBetweenRenderAndReturn.replace(
+    styledComponents,
+    '',
+  );
+
+  const [componentCode] = code.match(/<\s*?[.*\s*\S*]*>/) || [];
+
+  return {
+    styledComponents,
+    codeBetweenRenderAndReturn: withoutStyledComponents,
+    componentCode,
+  };
+};
+
+export { getStateTypeCode, injectImport };

--- a/packages/doc/src/components/CodeBlock/shared/index.js
+++ b/packages/doc/src/components/CodeBlock/shared/index.js
@@ -1,3 +1,3 @@
-import { injectImport, getStateTypeCode } from './functions';
+import { injectImport, getCodeFragments } from './functions';
 
-export { injectImport, getStateTypeCode };
+export { injectImport, getCodeFragments };

--- a/packages/doc/src/components/CodeBlock/shared/index.js
+++ b/packages/doc/src/components/CodeBlock/shared/index.js
@@ -1,3 +1,3 @@
-import injectImport from './functions';
+import { injectImport, getStateTypeCode } from './functions';
 
-export default injectImport;
+export { injectImport, getStateTypeCode };

--- a/packages/doc/src/components/CodeBlock/shared/templates/native.js
+++ b/packages/doc/src/components/CodeBlock/shared/templates/native.js
@@ -1,4 +1,4 @@
-import injectImport from '..';
+import { injectImport } from '..';
 
 const native = (imports, code, theme) => `import React from 'react';
 import styled from 'styled-components';

--- a/packages/doc/src/components/CodeBlock/shared/templates/web.js
+++ b/packages/doc/src/components/CodeBlock/shared/templates/web.js
@@ -1,4 +1,4 @@
-import { injectImport, getStateTypeCode } from '..';
+import { injectImport, getCodeFragments } from '..';
 
 const web = (imports, code, theme) => {
   const isState = code.search('render') !== -1;
@@ -21,7 +21,7 @@ ReactDOM.render(
       styledComponents,
       codeBetweenRenderAndReturn,
       componentCode,
-    } = getStateTypeCode(code);
+    } = getCodeFragments(code);
 
     return buildCode(`${styledComponents || ''}
 const App = () => {

--- a/packages/doc/src/components/CodeBlock/shared/templates/web.js
+++ b/packages/doc/src/components/CodeBlock/shared/templates/web.js
@@ -1,16 +1,47 @@
-import injectImport from '..';
+import { injectImport, getStateTypeCode } from '..';
 
-const web = (imports, code, theme) => `import React from 'react';
+const web = (imports, code, theme) => {
+  const isState = code.search('render') !== -1;
+
+  const buildCode = component => `import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
-${injectImport(imports, ['ThemeProvider'], ['@gympass/yoga'])}
+import styled from 'styled-components';
+${injectImport(imports, ['ThemeProvider, FontLoader'], ['@gympass/yoga'])}
 
-const App = () => <ThemeProvider ${theme ? `theme='${theme}'` : ''}>
-${code}
-</ThemeProvider>
+${component}
 
 ReactDOM.render(
   <App />,
   document.getElementById('root')
-);`;
+);
+`;
+
+  if (isState) {
+    const {
+      styledComponents,
+      codeBetweenRenderAndReturn,
+      componentCode,
+    } = getStateTypeCode(code);
+
+    return buildCode(`${styledComponents || ''}
+const App = () => {
+  ${codeBetweenRenderAndReturn}
+
+  return (
+    <ThemeProvider${theme ? `theme='${theme}'` : ''}>
+      <FontLoader />
+      ${componentCode}
+    </ThemeProvider>
+  );
+};`);
+  }
+
+  return buildCode(`const App = () => (
+  <ThemeProvider${theme ? `theme='${theme}'` : ''}>
+    <FontLoader />
+    ${code}
+  </ThemeProvider>
+);`);
+};
 
 export default web;

--- a/packages/doc/src/components/CodeBlock/shared/templates/web.js
+++ b/packages/doc/src/components/CodeBlock/shared/templates/web.js
@@ -25,7 +25,7 @@ ReactDOM.render(
 
     return buildCode(`${styledComponents || ''}
 const App = () => {
-  ${codeBetweenRenderAndReturn}
+  ${codeBetweenRenderAndReturn.trim()}
 
   return (
     <ThemeProvider${theme ? `theme='${theme}'` : ''}>

--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 100%;
   height: 52px;
   padding-left: 12px;
@@ -283,6 +284,7 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;
@@ -501,6 +503,7 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 100%;
   height: 52px;
   padding-left: 12px;
@@ -845,6 +848,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;

--- a/packages/yoga/src/Input/web/Fieldset.jsx
+++ b/packages/yoga/src/Input/web/Fieldset.jsx
@@ -5,6 +5,8 @@ const Fieldset = styled.fieldset`
   margin: 0;
   padding: 0;
 
+  box-sizing: border-box;
+
   ${({
     error,
     disabled,

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;
@@ -262,6 +263,7 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;
@@ -467,6 +469,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;
@@ -656,6 +659,7 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 100%;
   height: 52px;
   padding-left: 12px;
@@ -868,6 +872,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;
@@ -1064,6 +1069,7 @@ exports[`<Input /> Snapshots should match with label 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;
@@ -304,6 +305,7 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;
@@ -534,6 +536,7 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 100%;
   height: 52px;
   padding-left: 12px;

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -44,6 +44,7 @@ exports[`<TextArea /> should match snapshot 1`] = `
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
   width: 320px;
   height: 52px;
   padding-left: 12px;


### PR DESCRIPTION
This PR fixes a problem with the codesandbox examples when it has a stateful example.

Ex:

Yoga doc was like this:
```jsx
render(() => {
  const [value, setValue] = useState('');

  return (
    <AutoComplete
      value={value}
      onChange={value => setValue(value)}
      onSelect={selected => setValue(selected)}
      onClean={cleaned => setValue(cleaned)}
      options={[
        'Madrid',
        'Milan',
        'São Paulo',
        'New York',
        'Paris',
        'Buenos Aires',
        'Amsterdam',
        'Los Angeles',
        'Hollywood',
      ]}
    />
  );
});
```

The codesandbox code was like this (Syntax Error):

```jsx
import React from 'react';
import ReactDOM from 'react-dom';
import { AutoComplete, ThemeProvider } from '@gympass/yoga';

const App = () => <ThemeProvider >
render(() => {
  const [value, setValue] = useState('');

  return (
    <AutoComplete
      value={value}
      onChange={value => setValue(value)}
      onSelect={selected => setValue(selected)}
      onClean={cleaned => setValue(cleaned)}
      options={[
        'Madrid',
        'Milan',
        'São Paulo',
        'New York',
        'Paris',
        'Buenos Aires',
        'Amsterdam',
        'Los Angeles',
        'Hollywood',
      ]}
    />
  );
});
</ThemeProvider>

ReactDOM.render(
  <App />,
  document.getElementById('root')
);
```

The fixed version of codesandbox example generates a code like this:

```jsx
import React, { useState, useEffect } from 'react';
import ReactDOM from 'react-dom';
import styled from 'styled-components';
import { AutoComplete, FontLoader, ThemeProvider } from '@gympass/yoga';


const App = () => {
  
  const [value, setValue] = useState('');

  return (
    <ThemeProvider>
      <FontLoader />
      <AutoComplete
      value={value}
      onChange={value => setValue(value)}
      onSelect={selected => setValue(selected)}
      onClean={cleaned => setValue(cleaned)}
      options={[
        'Madrid',
        'Milan',
        'São Paulo',
        'New York',
        'Paris',
        'Buenos Aires',
        'Amsterdam',
        'Los Angeles',
        'Hollywood',
      ]}
    />
    </ThemeProvider>
  );
};

ReactDOM.render(
  <App />,
  document.getElementById('root')
);
```