### PR TITLE
Fix Input helper text color when affected by an error

### DIFF
--- a/packages/yoga/src/Input/web/Helper.jsx
+++ b/packages/yoga/src/Input/web/Helper.jsx
@@ -32,11 +32,11 @@ const Info = styled(Text.Small)`
       },
     },
   }) => `
-    color: ${input.helper.color};
+    color: currentColor;
     font-size: ${input.helper.font.size}px;
     
     ${right ? 'margin-left: auto;' : ''}
-  `}
+    `}
 `;
 
 const Helper = ({ disabled, error, helper, maxLength, length }) => (

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -459,7 +459,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
   font-weight: 400;
   font-family: Rubik;
   color: #41414A;
-  color: #9898A6;
+  color: currentColor;
   font-size: 12px;
 }
 
@@ -847,7 +847,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
   font-weight: 400;
   font-family: Rubik;
   color: #41414A;
-  color: #9898A6;
+  color: currentColor;
   font-size: 12px;
 }
 
@@ -859,7 +859,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
   font-weight: 400;
   font-family: Rubik;
   color: #41414A;
-  color: #9898A6;
+  color: currentColor;
   font-size: 12px;
   margin-left: auto;
 }


### PR DESCRIPTION
The Input error text was being rendered by the `Info` component that was overriding the error text color from `Wrapper`, so I added the error condition on `Info` too to avoid the conflict

Fix #193