### PR TITLE
size and light for Text

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,7 @@
     "version": {
       "conventionalCommits": true,
       "createRelease": "github",
-      "message": "chore(release): :tada: :rocket:",
+      "message": "chore(release): :tada: :rocket: [skip ci]",
       "allowBranch": ["master", "alpha", "beta"]
     }
   }

--- a/packages/doc/content/components/components/text/default-native.mdx
+++ b/packages/doc/content/components/components/text/default-native.mdx
@@ -6,6 +6,17 @@
   <Text.H3 variant="tertiary">Live the mission</Text.H3>
   <Text.H4>Live the mission</Text.H4>
   <Text.H5>Live the mission</Text.H5>
+
+  <Text.H1 variant="primary" light>
+    Heading H1
+  </Text.H1>
+  <Text.H2 variant="secondary" light>
+    Heading H2
+  </Text.H2>
+  <Text.H3 variant="tertiary" light>
+    Heading H3
+  </Text.H3>
+
   <Text>Live the mission</Text>
   <Text.Small>Live the mission</Text.Small>
   <Text.Tiny>Live the mission</Text.Tiny>
@@ -14,6 +25,10 @@
   <Text.Medium>Live the mission</Text.Medium>
   <Text.Bold>Live the mission</Text.Bold>
   <Text.Black>Live the mission</Text.Black>
+
+  <Text.Medium size="xsmall">XSmall Text.Medium</Text.Medium>
+  <Text.Medium size="medium">Medium Text.Medium</Text.Medium>
+  <Text.Medium size="xlarge">XLarge Text.Medium</Text.Medium>
 ```
 
 ### Adding Gympass font in your project

--- a/packages/doc/content/components/components/text/default-web.mdx
+++ b/packages/doc/content/components/components/text/default-web.mdx
@@ -13,12 +13,18 @@
   <Text.H3>Live the mission</Text.H3>
   <Text.H4>Live the mission</Text.H4>
   <Text>Live the mission</Text>
+  <br />
   <Text.Small>Live the mission</Text.Small>
   <Text.Tiny>Live the mission</Text.Tiny>
   <Text.Regular>Live the mission</Text.Regular>
   <Text.Medium>Live the mission</Text.Medium>
   <Text.Bold>Live the mission</Text.Bold>
   <Text.Black>Live the mission</Text.Black>
+  <br />
+  <Text.Small size="xsmall">Live the small mission</Text.Small>
+  <Text.Tiny size="medium">Live the medium mission</Text.Tiny>
+  <Text.Regular size="xlarge">Live the xlarge mission</Text.Regular>
+  <Text.Medium size="xxxlarge">Live the xxxlarge mission</Text.Medium>
   <br />
   <Text variant="vibin">Live the mission</Text>
   <Text variant="hope">Live the mission</Text>

--- a/packages/doc/content/components/components/text/index.mdx
+++ b/packages/doc/content/components/components/text/index.mdx
@@ -22,7 +22,7 @@ possible.
 | `<Text.H3>`      | `<h3>`      | xxlarge       | medium          | xxlarge         |
 | `<Text.H4>`      | `<h4>`      | xlarge        | medium          | xlarge          |
 | `<Text.H5>`      | `<h5>`      | large         | medium          | large           |
-| `<Text>`         | `<p>`       | medium        | medium          | medium          |
+| `<Text>`         | `<p>`       | medium        | regular         | medium          |
 | `<Text.Small>`   | `<p>`       | small         | medium          | small           |
 | `<Text.Tiny>`    | `<p>`       | xsmall        | medium          | xsmall          |
 | `<Text.Light>`   | `<p>`       | -             | light           | -               |
@@ -33,6 +33,9 @@ possible.
 
 _You can see the font-size tokens values
 [here](https://gympass.github.io/yoga/guidelines/tokens/font-sizes)._
+
+All Text components have a prop `size` which will set the `fontSize` accordingly 
+with our tokens. Regardless, all pre-established config will be prioritized.
 
 <TabbedView>
   <Tab title="Web">

--- a/packages/labnative/pages/Text.jsx
+++ b/packages/labnative/pages/Text.jsx
@@ -32,6 +32,21 @@ const TextPage = () => (
       <Text.H5>Heading H5</Text.H5>
     </TextWrapper>
     <TextWrapper>
+      <Text.H1 variant="primary" light>
+        Heading H1
+      </Text.H1>
+    </TextWrapper>
+    <TextWrapper>
+      <Text.H2 variant="secondary" light>
+        Heading H2
+      </Text.H2>
+    </TextWrapper>
+    <TextWrapper>
+      <Text.H3 variant="tertiary" light>
+        Heading H3
+      </Text.H3>
+    </TextWrapper>
+    <TextWrapper>
       <Text>Text Paragraph</Text>
     </TextWrapper>
     <TextWrapper>
@@ -51,6 +66,15 @@ const TextPage = () => (
     </TextWrapper>
     <TextWrapper>
       <Text.Black>Text Black</Text.Black>
+    </TextWrapper>
+    <TextWrapper>
+      <Text.Medium size="xsmall">XSmall Text.Medium</Text.Medium>
+    </TextWrapper>
+    <TextWrapper>
+      <Text.Medium size="medium">Medium Text.Medium</Text.Medium>
+    </TextWrapper>
+    <TextWrapper>
+      <Text.Medium size="xlarge">XLarge Text.Medium</Text.Medium>
     </TextWrapper>
   </ScrollView>
 );

--- a/packages/yoga/src/Card/native/GymCard/CheckIn/__snapshots__/CheckIn.test.jsx.snap
+++ b/packages/yoga/src/Card/native/GymCard/CheckIn/__snapshots__/CheckIn.test.jsx.snap
@@ -473,7 +473,9 @@ exports[`<GymCard.CheckIn /> Snapshots should match snapshot with avatar 1`] = `
       >
         <Text
           inverted={false}
+          light={false}
           numberOfLines={2}
+          size="medium"
           style={
             Array [
               Object {
@@ -482,6 +484,9 @@ exports[`<GymCard.CheckIn /> Snapshots should match snapshot with avatar 1`] = `
                 "fontSize": 16,
                 "fontWeight": "400",
                 "lineHeight": 24,
+              },
+              Object {
+                "fontWeight": "400",
                 "marginBottom": 8,
                 "minHeight": 40,
               },
@@ -1057,7 +1062,9 @@ exports[`<GymCard.CheckIn /> Snapshots should match snapshot without avatar 1`] 
       >
         <Text
           inverted={false}
+          light={false}
           numberOfLines={2}
+          size="medium"
           style={
             Array [
               Object {
@@ -1066,6 +1073,9 @@ exports[`<GymCard.CheckIn /> Snapshots should match snapshot without avatar 1`] 
                 "fontSize": 16,
                 "fontWeight": "400",
                 "lineHeight": 24,
+              },
+              Object {
+                "fontWeight": "400",
                 "marginBottom": 8,
                 "minHeight": 40,
               },

--- a/packages/yoga/src/Card/web/EventCard/EventCard.jsx
+++ b/packages/yoga/src/Card/web/EventCard/EventCard.jsx
@@ -4,7 +4,7 @@ import { shape, string } from 'prop-types';
 import { Time } from '@gympass/yoga-icons';
 
 import Card from '../Card';
-import Text from '../../../Text';
+import { TextRenderer, Text } from '../../../Text/web/Text';
 
 const Event = styled(Card)`
   display: flex;
@@ -28,7 +28,7 @@ const EventInfo = styled.div`
     padding: ${event.info.padding.top}px ${event.info.padding.right}px
       ${event.info.padding.bottom}px ${event.info.padding.left}px;
 
-    ${Text}, ${Text.Small} {
+    ${TextRenderer}, ${Text.Small} {
       display: -webkit-inline-box;
       overflow: hidden;
 
@@ -38,7 +38,7 @@ const EventInfo = styled.div`
       text-overflow: -o-ellipsis-lastline;
     }
 
-    ${Text} {
+    ${TextRenderer} {
       height: ${event.info.name.height}px;
       margin-bottom: ${event.info.name.marginBottom}px;
 

--- a/packages/yoga/src/Dropdown/native/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/native/__snapshots__/Dropdown.test.jsx.snap
@@ -40,14 +40,19 @@ exports[`<Dropdown /> Snapshots should match snapshot 1`] = `
       <Text
         disabled={false}
         inverted={false}
+        light={false}
+        size="medium"
         style={
           Array [
             Object {
-              "color": "#9898A6",
+              "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
               "fontWeight": "400",
               "lineHeight": 24,
+            },
+            Object {
+              "color": "#9898A6",
             },
           ]
         }
@@ -170,14 +175,19 @@ exports[`<Dropdown /> Snapshots should match snapshot when disabled 1`] = `
       <Text
         disabled={true}
         inverted={false}
+        light={false}
+        size="medium"
         style={
           Array [
             Object {
-              "color": "#F5F5FA",
+              "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
               "fontWeight": "400",
               "lineHeight": 24,
+            },
+            Object {
+              "color": "#F5F5FA",
             },
           ]
         }
@@ -300,14 +310,19 @@ exports[`<Dropdown /> Snapshots should match snapshot when full 1`] = `
       <Text
         disabled={false}
         inverted={false}
+        light={false}
+        size="medium"
         style={
           Array [
             Object {
-              "color": "#9898A6",
+              "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
               "fontWeight": "400",
               "lineHeight": 24,
+            },
+            Object {
+              "color": "#9898A6",
             },
           ]
         }
@@ -437,6 +452,7 @@ exports[`<Dropdown /> Snapshots should match snapshot when has a selected value 
       <Text
         disabled={true}
         inverted={false}
+        light={false}
         selected={
           Object {
             "label": "Swimming",
@@ -444,6 +460,7 @@ exports[`<Dropdown /> Snapshots should match snapshot when has a selected value 
             "value": "swimming",
           }
         }
+        size="medium"
         style={
           Array [
             Object {
@@ -452,6 +469,9 @@ exports[`<Dropdown /> Snapshots should match snapshot when has a selected value 
               "fontSize": 16,
               "fontWeight": "400",
               "lineHeight": 24,
+            },
+            Object {
+              "color": "#231B22",
             },
           ]
         }

--- a/packages/yoga/src/Slider/web/__snapshots__/Slider.test.jsx.snap
+++ b/packages/yoga/src/Slider/web/__snapshots__/Slider.test.jsx.snap
@@ -485,6 +485,7 @@ exports[`<Slider /> Tooltip should render tooltips 1`] = `
 .c3 {
   margin: 0;
   padding: 0;
+  font-size: 16px;
   font-weight: 700;
   font-family: Rubik;
   color: #231B22;

--- a/packages/yoga/src/Stepper/web/__snapshots__/Stepper.test.jsx.snap
+++ b/packages/yoga/src/Stepper/web/__snapshots__/Stepper.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`<Stepper /> Snapshots should match snapshot with first step active 1`] 
 .c8 {
   margin: 0;
   padding: 0;
+  font-size: 16px;
   font-weight: 700;
   font-family: Rubik;
   color: #231B22;
@@ -173,6 +174,7 @@ exports[`<Stepper /> Snapshots should match snapshot with second step active 1`]
 .c8 {
   margin: 0;
   padding: 0;
+  font-size: 16px;
   font-weight: 700;
   font-family: Rubik;
   color: #231B22;

--- a/packages/yoga/src/Text/native/Text.jsx
+++ b/packages/yoga/src/Text/native/Text.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 import { oneOf, bool } from 'prop-types';
 import textStyle from '../textStyle';
@@ -42,19 +43,53 @@ Bold.displayName = 'Text.Bold';
 const Black = styledText('black');
 Black.displayName = 'Text.Black';
 
-const Text = styledText('p');
+const TextRenderer = styledText('p');
 
+const Text = props => <TextRenderer {...props} />;
 Text.displayName = 'Text';
 
 Text.propTypes = {
   inverted: bool,
-  /** style the text following the theme (primary, secondary, tertiary) */
-  variant: oneOf(['primary', 'secondary', 'tertiary']),
+  /** style the text following the theme */
+  variant: oneOf([
+    'primary',
+    'secondary',
+    'vibin',
+    'hope',
+    'energy',
+    'relax',
+    'peace',
+    'verve',
+    'uplift',
+    'deepPurple',
+    'stamina',
+    'deep',
+    'medium',
+    'light',
+    'clear',
+    'whit',
+  ]),
+  /** set the font-size following the theme */
+  size: oneOf([
+    'xxsmall',
+    'xsmall',
+    'small',
+    'medium',
+    'large',
+    'xlarge',
+    'xxlarge',
+    'xxxlarge',
+    'huge',
+  ]),
+  /** set the font-weight to regular */
+  light: bool,
 };
 
 Text.defaultProps = {
   inverted: false,
   variant: undefined,
+  size: 'medium',
+  light: false,
 };
 
 export {

--- a/packages/yoga/src/Text/native/Text.jsx
+++ b/packages/yoga/src/Text/native/Text.jsx
@@ -67,7 +67,7 @@ Text.propTypes = {
     'medium',
     'light',
     'clear',
-    'whit',
+    'white',
   ]),
   /** set the font-size following the theme */
   size: oneOf([

--- a/packages/yoga/src/Text/native/Text.test.jsx
+++ b/packages/yoga/src/Text/native/Text.test.jsx
@@ -35,6 +35,29 @@ describe('<Text />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with Text light', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Text.H1 light>Live the mission</Text.H1>
+          <Text.H2 light>Live the mission</Text.H2>
+          <Text.H3 light>Live the mission</Text.H3>
+        </ThemeProvider>,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with Text size', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Text.Small size="xsmall">Live the small mission</Text.Small>
+          <Text.Tiny size="medium">Live the medium mission</Text.Tiny>
+          <Text.Regular size="xlarge">Live the xlarge mission</Text.Regular>
+          <Text.Medium size="xxxlarge">Live the xxxlarge mission</Text.Medium>
+        </ThemeProvider>,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with inverted Text', () => {
       const { container } = render(
         <ThemeProvider>

--- a/packages/yoga/src/Text/native/__snapshots__/Text.test.jsx.snap
+++ b/packages/yoga/src/Text/native/__snapshots__/Text.test.jsx.snap
@@ -122,6 +122,7 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
         Object {
           "color": "#231B22",
           "fontFamily": "Rubik",
+          "fontSize": 16,
           "fontWeight": "400",
         },
       ]
@@ -135,6 +136,7 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
         Object {
           "color": "#231B22",
           "fontFamily": "Rubik",
+          "fontSize": 16,
           "fontWeight": "500",
         },
       ]
@@ -148,6 +150,7 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
         Object {
           "color": "#231B22",
           "fontFamily": "Rubik",
+          "fontSize": 16,
           "fontWeight": "700",
         },
       ]
@@ -161,12 +164,149 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
         Object {
           "color": "#231B22",
           "fontFamily": "Rubik",
+          "fontSize": 16,
           "fontWeight": "900",
         },
       ]
     }
   >
     Live the mission
+  </Text>
+</View>
+`;
+
+exports[`<Text /> Snapshots should match snapshot with Text light 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <Text
+    light={true}
+    style={
+      Array [
+        Object {
+          "color": "#231B22",
+          "fontFamily": "Rubik",
+          "fontSize": 48,
+          "fontWeight": "300",
+          "lineHeight": 56,
+        },
+      ]
+    }
+  >
+    Live the mission
+  </Text>
+  <Text
+    light={true}
+    style={
+      Array [
+        Object {
+          "color": "#231B22",
+          "fontFamily": "Rubik",
+          "fontSize": 40,
+          "fontWeight": "300",
+          "lineHeight": 48,
+        },
+      ]
+    }
+  >
+    Live the mission
+  </Text>
+  <Text
+    light={true}
+    style={
+      Array [
+        Object {
+          "color": "#231B22",
+          "fontFamily": "Rubik",
+          "fontSize": 32,
+          "fontWeight": "300",
+          "lineHeight": 40,
+        },
+      ]
+    }
+  >
+    Live the mission
+  </Text>
+</View>
+`;
+
+exports[`<Text /> Snapshots should match snapshot with Text size 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <Text
+    size="xsmall"
+    style={
+      Array [
+        Object {
+          "color": "#231B22",
+          "fontFamily": "Rubik",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 20,
+        },
+      ]
+    }
+  >
+    Live the small mission
+  </Text>
+  <Text
+    size="medium"
+    style={
+      Array [
+        Object {
+          "color": "#231B22",
+          "fontFamily": "Rubik",
+          "fontSize": 12,
+          "fontWeight": "400",
+          "lineHeight": 16,
+        },
+      ]
+    }
+  >
+    Live the medium mission
+  </Text>
+  <Text
+    size="xlarge"
+    style={
+      Array [
+        Object {
+          "color": "#231B22",
+          "fontFamily": "Rubik",
+          "fontSize": 24,
+          "fontWeight": "400",
+        },
+      ]
+    }
+  >
+    Live the xlarge mission
+  </Text>
+  <Text
+    size="xxxlarge"
+    style={
+      Array [
+        Object {
+          "color": "#231B22",
+          "fontFamily": "Rubik",
+          "fontSize": 40,
+          "fontWeight": "500",
+        },
+      ]
+    }
+  >
+    Live the xxxlarge mission
   </Text>
 </View>
 `;

--- a/packages/yoga/src/Text/native/__snapshots__/Text.test.jsx.snap
+++ b/packages/yoga/src/Text/native/__snapshots__/Text.test.jsx.snap
@@ -72,6 +72,8 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
   </Text>
   <Text
     inverted={false}
+    light={false}
+    size="medium"
     style={
       Array [
         Object {
@@ -384,6 +386,8 @@ exports[`<Text /> Snapshots should match snapshot with inverted Text 1`] = `
 >
   <Text
     inverted={true}
+    light={false}
+    size="medium"
     style={
       Array [
         Object {

--- a/packages/yoga/src/Text/textStyle.android.jsx
+++ b/packages/yoga/src/Text/textStyle.android.jsx
@@ -2,12 +2,16 @@ import { css } from 'styled-components';
 
 const textStyle = type => () => css`
   ${({
+    light,
     variant,
     inverted,
+    size = 'medium',
     theme: {
       yoga: {
         baseFont,
-        colors: { [variant]: color = {}, dark, white },
+        fontWeights,
+        fontSizes: { [size]: pSize },
+        colors: { [variant]: color, text, white },
         components: {
           text: {
             [type]: { fontsize, lineHeight, fontWeight },
@@ -16,13 +20,16 @@ const textStyle = type => () => css`
       },
     },
   }) => `
-    ${fontsize ? `font-size: ${fontsize}px` : ''};
+    ${fontsize || pSize ? `font-size: ${fontsize || pSize}px` : ''};
     ${lineHeight ? `line-height: ${lineHeight}px` : ''};
 
     font-family: ${baseFont.family}${
     fontWeight !== 400 ? `-${fontWeight}` : ''
   };
-    color: ${variant ? color[3] : dark};
+
+    ${light ? `font-family: ${baseFont.family}-${fontWeights.light}` : ''};
+
+    color: ${variant ? color : text.primary};
     ${inverted ? `color: ${white};` : ''}
   `}
 `;

--- a/packages/yoga/src/Text/textStyle.android.jsx
+++ b/packages/yoga/src/Text/textStyle.android.jsx
@@ -20,7 +20,7 @@ const textStyle = type => () => css`
       },
     },
   }) => `
-    ${fontsize || pSize ? `font-size: ${fontsize || pSize}px` : ''};
+    font-size: ${fontsize || pSize}px;
     ${lineHeight ? `line-height: ${lineHeight}px` : ''};
 
     font-family: ${baseFont.family}${

--- a/packages/yoga/src/Text/textStyle.jsx
+++ b/packages/yoga/src/Text/textStyle.jsx
@@ -20,7 +20,7 @@ const textStyle = type => () => css`
       },
     },
   }) => `
-    ${fontsize || pSize ? `font-size: ${fontsize || pSize}px` : ''};
+    font-size: ${fontsize || pSize}px;
     ${lineHeight ? `line-height: ${lineHeight}px` : ''};
     ${fontWeight ? `font-weight: ${fontWeight}` : ''};
     ${light ? `font-weight: ${fontWeights.light}` : ''};

--- a/packages/yoga/src/Text/textStyle.jsx
+++ b/packages/yoga/src/Text/textStyle.jsx
@@ -2,11 +2,15 @@ import { css } from 'styled-components';
 
 const textStyle = type => () => css`
   ${({
+    light,
     variant,
     inverted,
+    size = 'medium',
     theme: {
       yoga: {
         baseFont,
+        fontWeights,
+        fontSizes: { [size]: pSize },
         colors: { [variant]: color, text, white },
         components: {
           text: {
@@ -16,9 +20,10 @@ const textStyle = type => () => css`
       },
     },
   }) => `
-    ${fontsize ? `font-size: ${fontsize}px` : ''};
+    ${fontsize || pSize ? `font-size: ${fontsize || pSize}px` : ''};
     ${lineHeight ? `line-height: ${lineHeight}px` : ''};
     ${fontWeight ? `font-weight: ${fontWeight}` : ''};
+    ${light ? `font-weight: ${fontWeights.light}` : ''};
 
     font-family: ${baseFont.family};
     color: ${variant ? color : text.primary};

--- a/packages/yoga/src/Text/web/Text.jsx
+++ b/packages/yoga/src/Text/web/Text.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 import { oneOf, bool } from 'prop-types';
 import textStyle from '../textStyle';
@@ -47,18 +48,53 @@ Bold.displayName = 'Text.Bold';
 const Black = styledText('black');
 Black.displayName = 'Text.Black';
 
-const Text = styledText('p');
+const TextRenderer = styledText('p');
+
+const Text = props => <TextRenderer {...props} />;
 Text.displayName = 'Text';
 
 Text.propTypes = {
   inverted: bool,
-  /** style the text following the theme (primary, secondary, tertiary) */
-  variant: oneOf(['primary', 'secondary', 'tertiary']),
+  /** style the text following the theme */
+  variant: oneOf([
+    'primary',
+    'secondary',
+    'vibin',
+    'hope',
+    'energy',
+    'relax',
+    'peace',
+    'verve',
+    'uplift',
+    'deepPurple',
+    'stamina',
+    'deep',
+    'medium',
+    'light',
+    'clear',
+    'whit',
+  ]),
+  /** set the font-size following the theme */
+  size: oneOf([
+    'xxsmall',
+    'xsmall',
+    'small',
+    'medium',
+    'large',
+    'xlarge',
+    'xxlarge',
+    'xxxlarge',
+    'huge',
+  ]),
+  /** set the font-weight to regular */
+  light: bool,
 };
 
 Text.defaultProps = {
   inverted: false,
   variant: undefined,
+  size: 'medium',
+  light: false,
 };
 
 export {

--- a/packages/yoga/src/Text/web/Text.jsx
+++ b/packages/yoga/src/Text/web/Text.jsx
@@ -98,6 +98,7 @@ Text.defaultProps = {
 };
 
 export {
+  TextRenderer,
   Text,
   H1,
   H2,

--- a/packages/yoga/src/Text/web/Text.jsx
+++ b/packages/yoga/src/Text/web/Text.jsx
@@ -72,7 +72,7 @@ Text.propTypes = {
     'medium',
     'light',
     'clear',
-    'whit',
+    'white',
   ]),
   /** set the font-size following the theme */
   size: oneOf([

--- a/packages/yoga/src/Text/web/Text.test.jsx
+++ b/packages/yoga/src/Text/web/Text.test.jsx
@@ -36,6 +36,29 @@ describe('<Text />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with Text light', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Text.H1 light>Live the mission</Text.H1>
+          <Text.H2 light>Live the mission</Text.H2>
+          <Text.H3 light>Live the mission</Text.H3>
+        </ThemeProvider>,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with Text size', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Text.Small size="xsmall">Live the small mission</Text.Small>
+          <Text.Tiny size="medium">Live the medium mission</Text.Tiny>
+          <Text.Regular size="xlarge">Live the xlarge mission</Text.Regular>
+          <Text.Medium size="xxxlarge">Live the xxxlarge mission</Text.Medium>
+        </ThemeProvider>,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with inverted Text', () => {
       const { container } = render(
         <ThemeProvider>

--- a/packages/yoga/src/Text/web/__snapshots__/Text.test.jsx.snap
+++ b/packages/yoga/src/Text/web/__snapshots__/Text.test.jsx.snap
@@ -74,6 +74,7 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
 .c8 {
   margin: 0;
   padding: 0;
+  font-size: 16px;
   font-weight: 400;
   font-family: Rubik;
   color: #231B22;
@@ -82,6 +83,7 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
 .c9 {
   margin: 0;
   padding: 0;
+  font-size: 16px;
   font-weight: 500;
   font-family: Rubik;
   color: #231B22;
@@ -90,6 +92,7 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
 .c10 {
   margin: 0;
   padding: 0;
+  font-size: 16px;
   font-weight: 700;
   font-family: Rubik;
   color: #231B22;
@@ -98,6 +101,7 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
 .c11 {
   margin: 0;
   padding: 0;
+  font-size: 16px;
   font-weight: 900;
   font-family: Rubik;
   color: #231B22;
@@ -173,6 +177,122 @@ exports[`<Text /> Snapshots should match snapshot with Text 1`] = `
     class="c11"
   >
     Live the mission
+  </p>
+</div>
+`;
+
+exports[`<Text /> Snapshots should match snapshot with Text light 1`] = `
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-size: 48px;
+  line-height: 56px;
+  font-weight: 500;
+  font-weight: 300;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c1 {
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
+  line-height: 48px;
+  font-weight: 500;
+  font-weight: 300;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c2 {
+  margin: 0;
+  padding: 0;
+  font-size: 32px;
+  line-height: 40px;
+  font-weight: 500;
+  font-weight: 300;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+<div>
+  <h1
+    class="c0"
+  >
+    Live the mission
+  </h1>
+  <h2
+    class="c1"
+  >
+    Live the mission
+  </h2>
+  <h3
+    class="c2"
+  >
+    Live the mission
+  </h3>
+</div>
+`;
+
+exports[`<Text /> Snapshots should match snapshot with Text size 1`] = `
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c1 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c2 {
+  margin: 0;
+  padding: 0;
+  font-size: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
+  font-weight: 500;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+<div>
+  <p
+    class="c0"
+  >
+    Live the small mission
+  </p>
+  <p
+    class="c1"
+  >
+    Live the medium mission
+  </p>
+  <p
+    class="c2"
+  >
+    Live the xlarge mission
+  </p>
+  <p
+    class="c3"
+  >
+    Live the xxxlarge mission
   </p>
 </div>
 `;


### PR DESCRIPTION
This PR:

 - Fix missing prop table on Text component
![image](https://user-images.githubusercontent.com/6536985/105487098-57052b00-5c8e-11eb-88c0-fce438ee2812.png)

 - Add `size` prop to Text component, setting the font-size rule accordingly to our theme. It must have a value of one of  `xxsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`, `xxlarge`, `xxxlarge`, or `huge`.

- Add `light` prop to Text component, setting its weight to regular.
