### PR TITLE
docs: update text patterns to medium size

### DIFF
--- a/packages/doc/content/components/components/text/index.mdx
+++ b/packages/doc/content/components/components/text/index.mdx
@@ -23,8 +23,8 @@ possible.
 | `<Text.H4>`      | `<h4>`      | xlarge        | medium          | xlarge          |
 | `<Text.H5>`      | `<h5>`      | large         | medium          | large           |
 | `<Text>`         | `<p>`       | medium        | regular         | medium          |
-| `<Text.Small>`   | `<p>`       | small         | medium          | small           |
-| `<Text.Tiny>`    | `<p>`       | xsmall        | medium          | xsmall          |
+| `<Text.Small>`   | `<p>`       | small         | regular         | small           |
+| `<Text.Tiny>`    | `<p>`       | xsmall        | regular         | xsmall          |
 | `<Text.Light>`   | `<p>`       | medium        | light           | -               |
 | `<Text.Regular>` | `<p>`       | medium        | regular         | -               |
 | `<Text.Medium>`  | `<p>`       | medium        | medium          | -               |

--- a/packages/doc/content/components/components/text/index.mdx
+++ b/packages/doc/content/components/components/text/index.mdx
@@ -25,11 +25,11 @@ possible.
 | `<Text>`         | `<p>`       | medium        | regular         | medium          |
 | `<Text.Small>`   | `<p>`       | small         | medium          | small           |
 | `<Text.Tiny>`    | `<p>`       | xsmall        | medium          | xsmall          |
-| `<Text.Light>`   | `<p>`       | -             | light           | -               |
-| `<Text.Regular>` | `<p>`       | -             | regular         | -               |
-| `<Text.Medium>`  | `<p>`       | -             | medium          | -               |
-| `<Text.Bold>`    | `<p>`       | -             | bold            | -               |
-| `<Text.Black>`   | `<p>`       | -             | black           | -               |
+| `<Text.Light>`   | `<p>`       | medium        | light           | -               |
+| `<Text.Regular>` | `<p>`       | medium        | regular         | -               |
+| `<Text.Medium>`  | `<p>`       | medium        | medium          | -               |
+| `<Text.Bold>`    | `<p>`       | medium        | bold            | -               |
+| `<Text.Black>`   | `<p>`       | medium        | black           | -               |
 
 _You can see the font-size tokens values
 [here](https://gympass.github.io/yoga/guidelines/tokens/font-sizes)._


### PR DESCRIPTION
Change `-` to `medium`

![image](https://user-images.githubusercontent.com/46816386/105863069-3fe87500-5fcf-11eb-8fba-6e5c1b02cb69.png)
