### PR TITLE
Fix width and height usage in Icon component

### DIFF
--- a/packages/yoga/src/Icon/Icon.jsx
+++ b/packages/yoga/src/Icon/Icon.jsx
@@ -12,8 +12,8 @@ const Icon = ({
   ...props
 }) => (
   <Component
-    width={theme.yoga.spacing[width] || width}
-    height={theme.yoga.spacing[height] || height}
+    {...(width && { width: theme.yoga.spacing[width] || width })}
+    {...(height && { height: theme.yoga.spacing[height] || height })}
     {...(fill && { fill: theme.yoga.colors[fill] || fill })}
     {...(stroke && { stroke: theme.yoga.colors[stroke] || stroke })}
     {...props}


### PR DESCRIPTION
This fixes a strange behaviour happening in SVG where it disappears and awkward stuff happens when one of its dimensions is undefined by passing them conditionally.