### PR TITLE
Fix README/CONTRIBUTING, add Contributing section to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ commit some change, please use:
 $ yarn commit
 ```
 
+We usually follow the `{{feat|fix|doc|ci}}/{{what-am-i-doing}}` for branch names.
+
 ## New Component
 
 At Yoga, a Component isn't just one file. It has its own docs, tests, exports,
@@ -64,7 +66,7 @@ packages
 
 ### Theme
 
-Currently we have 3 predefined themes `Corporate`, `EndUser` and `Gyms`, all
+Currently, we have 3 predefined themes `Corporate`, `EndUser` and `Gyms`, all
 of them follows the `BaseTheme` object.
 
 Every component has its own `theme` file. You can find it in its own folder.
@@ -75,7 +77,7 @@ margins, to the component theme file.
 ### Web
 
 We use our doc environment to build our components. To develop your component,
-you can just type
+you can just type.
 
 ```
 $ yarn dev:web
@@ -93,7 +95,7 @@ native version of our components.
 
 #### iOS (Mac only)
 
-For the iOS development, type and the simulator will open automacally.
+For the iOS development, type, and the simulator will open automagically.
 
 ```
 $ yarn dev:native:ios
@@ -120,7 +122,7 @@ can run:
 $ yarn test /path/to/your/component
 ```
 
-Or you can run it by platform:
+Or you can run it by a platform:
 
 ```
 $ yarn test:web /path/to/your/component
@@ -144,7 +146,7 @@ $ yarn test:web
 
 If you want to add a documentation that isn't of a component, like
 [this one](https://gympass.github.io/yoga/guidelines/product-content), you can
-create an `.md` file under `./docs/content/guidelines` and it will be automacally added.
+create an `.md` file under `./docs/content/guidelines` and it will be automagically added.
 
 ## New Icon
 
@@ -153,7 +155,7 @@ Just add the `.svg` file under `packages/icons/src/svg` and modify the
 
 ## Git Hooks
 
-There is two hooks inside Yoga repo:
+We have two hooks inside Yoga repo:
 
 1. `pre-commit`: run eslint on all repo
 2. `pre-push`: run `yarn test`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="packages/doc/src/images/lotus.png" />
 </p>
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 ![Github Actions](https://github.com/gympass/yoga/workflows/Yoga%20-%20Gympass%20Design%20System/badge.svg)
 
 Design system at Gympass, our main intent is to support our projects.
@@ -28,6 +28,20 @@ Here's an overview of our packages:
 | [`@gympass/yoga-common`](/packages/common)   | [![npm version](https://badgen.net/npm/v/@gympass/yoga-common)](https://www.npmjs.com/package/@gympass/yoga-common)   | [![Bundle size](https://badgen.net/bundlephobia/minzip/@gympass/yoga-common)](https://bundlephobia.com/result?p=@gympass/yoga-common)   |
 | [`@gympass/yoga-icons`](/packages/icons)     | [![npm version](https://badgen.net/npm/v/@gympass/yoga-icons)](https://www.npmjs.com/package/@gympass/yoga-icons)     | [![Bundle size](https://badgen.net/bundlephobia/minzip/@gympass/yoga-icons)](https://bundlephobia.com/result?p=@gympass/yoga-icons)     |
 | [`@gympass/yoga-helpers`](/packages/helpers) | [![npm version](https://badgen.net/npm/v/@gympass/yoga-helpers)](https://www.npmjs.com/package/@gympass/yoga-helpers) | [![Bundle size](https://badgen.net/bundlephobia/minzip/@gympass/yoga-helpers)](https://bundlephobia.com/result?p=@gympass/yoga-helpers) |
+
+## Contributing
+
+This repository should _and_ will grow, its contents will be used for many people in our current and future
+projects. As such, we follow some practices to keep a common architecture in our changes.
+
+### [Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md)
+
+We adopted the _Citizen Code of Condute_, which is widely used in many projects and communities such the [Rust comunity](https://www.rust-lang.org/policies/code-of-conduct).
+Please read the [full text](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md) so that you can understand what actions will and will not be tolerated.
+
+### [Contributing Guide](CONTRIBUTING.md)
+
+Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Yoga.
 
 ## Contributors ✨
 


### PR DESCRIPTION
**What this does**
- Fix some typos in both `README.md` and `CONTRIBUTING.md`
- Add *contributing* section to `README` (see #206);
- Add as a proposal, the [citizen code of conduct];(https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md), already widely used to this new section;
- Fix `README` "anchoring" to contributors section.