### PR TITLE
feat(card.actions): accept Tag inside Card.Actions

### DIFF
--- a/packages/yoga/src/Card/native/Card/Actions.jsx
+++ b/packages/yoga/src/Card/native/Card/Actions.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { arrayOf, oneOfType } from 'prop-types';
 
 import Button from '../../../Button';
+import Tag from '../../../Tag';
 import { typeOf } from '../../../shared/propTypes';
 
 const Actions = styled.View``;
@@ -13,6 +14,8 @@ Actions.propTypes = {
       typeOf(Button.Text),
       typeOf(Button),
       typeOf(Button.Link),
+      typeOf(Tag),
+      typeOf(Tag.Informative),
     ]),
     arrayOf(
       oneOfType([
@@ -20,6 +23,8 @@ Actions.propTypes = {
         typeOf(Button.Text),
         typeOf(Button),
         typeOf(Button.Link),
+        typeOf(Tag),
+        typeOf(Tag.Informative),
       ]),
     ),
   ]).isRequired,

--- a/packages/yoga/src/Card/web/Card/Actions.jsx
+++ b/packages/yoga/src/Card/web/Card/Actions.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { arrayOf, oneOfType } from 'prop-types';
 
 import Button from '../../../Button';
+import Tag from '../../../Tag';
 import { typeOf } from '../../../shared/propTypes';
 
 const Actions = styled.footer``;
@@ -13,6 +14,8 @@ Actions.propTypes = {
       typeOf(Button.Text),
       typeOf(Button.Outline),
       typeOf(Button.Link),
+      typeOf(Tag),
+      typeOf(Tag.Informative),
     ]),
     arrayOf(
       oneOfType([
@@ -20,6 +23,8 @@ Actions.propTypes = {
         typeOf(Button.Text),
         typeOf(Button.Outline),
         typeOf(Button.Link),
+        typeOf(Tag),
+        typeOf(Tag.Informative),
       ]),
     ),
   ]).isRequired,


### PR DESCRIPTION
We have usages in our application that uses other kind of components besides Button, as shown below
<img src="https://user-images.githubusercontent.com/28108272/112528834-5f0f4300-8d83-11eb-89ac-5aa415b3588f.png" width="520" />

I suggested to add them to our PropTypes to avoid console errors and to be a "first" solution rather than extending/creating this component from scratch in our application just because of this error.