### PR TITLE
fix(checkbox-switch): explicitly convert checked to number

### DIFF
--- a/packages/yoga/src/Checkbox/native/Switch.jsx
+++ b/packages/yoga/src/Checkbox/native/Switch.jsx
@@ -100,7 +100,7 @@ const CheckboxSwitch = ({
     },
   },
 }) => {
-  const [thumbPosition] = useState(new Animated.Value(checked));
+  const [thumbPosition] = useState(new Animated.Value(Number(checked)));
   const thumbTo =
     checkboxswitch.track.width -
     checkboxswitch.thumb.width -


### PR DESCRIPTION
**Description**
- This explicitly converts `checked` to a Number inside mobile version of `Checkbox.Switch`, to prevent these usages inside our application:
```jsx
// screens/Amenities/Item.js

<Checkbox.Switch
  testID="checkBox"
  id={item.id}
  checked={Number(checked)}
  onChange={onChange}
/>
```