### PR TITLE
Stop persisting default github config and fix lerna command

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Configure CI Git User
         run: |
           git remote set-url origin https://${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/scripts/publish
+++ b/scripts/publish
@@ -7,10 +7,10 @@ set -e
 
 if [[ $BRANCH == "master" ]];
 then
-  yarn lerna publish major --conventional-graduate --yes
+  yarn lerna publish --yes
 elif [[ $BRANCH == "alpha" || $BRANCH == "beta" ]];
 then
-  yarn lerna publish --conventional-prerelease --yes --preid $BRANCH --dist-tag $BRANCH 
+  yarn lerna publish --conventional-prerelease --yes --preid $BRANCH --dist-tag $BRANCH
 else
   echo "Nothing to publish on branch $BRANCH..."
 fi


### PR DESCRIPTION
We already using a GITHUB_TOKEN with required permissions to config actions, but, for some reason, after updating to action/checkout@v2 lerna was facing some permissions issues (not able to push to master branch).

So, looking to a lerna issue in it's repository I've found [this solution](https://github.com/lerna/lerna/issues/1957#issuecomment-702396095).

Also, changed the lerna command that are always forcing a new major version.