### PR TITLE
Fix CodeSandbox and Expo snack examples

### DIFF
--- a/packages/doc/src/components/CodeBlock/CodeBlock.jsx
+++ b/packages/doc/src/components/CodeBlock/CodeBlock.jsx
@@ -57,7 +57,7 @@ const peerDependencies = [
   { path: 'react-is' },
 ];
 
-const CodeBlock = ({ children: sampleCode, center, state, type, theme }) => {
+const CodeBlock = ({ children: sampleCode, center, state, type }) => {
   const code = sampleCode.trim();
 
   const imports = type === 'highlight' ? [] : buildImportString(code, packages);
@@ -72,7 +72,6 @@ const CodeBlock = ({ children: sampleCode, center, state, type, theme }) => {
     dependencies,
     imports,
     state,
-    theme,
   };
 
   const CodeBlockComponent = {

--- a/packages/doc/src/components/CodeBlock/ReactLive/CodeSandboxButton.jsx
+++ b/packages/doc/src/components/CodeBlock/ReactLive/CodeSandboxButton.jsx
@@ -6,9 +6,9 @@ import { URL, setOptions } from './sandboxConfig';
 
 const CodeSandboxButton = () => {
   const [loading, setLoading] = useState(false);
-  const { imports, code, theme } = useContext(CodeBlockContext);
+  const { imports, code } = useContext(CodeBlockContext);
 
-  const sandbox = [imports, code, theme];
+  const sandbox = [imports, code];
 
   const createSandbox = () => {
     setLoading(true);

--- a/packages/doc/src/components/CodeBlock/ReactLive/sandboxConfig.js
+++ b/packages/doc/src/components/CodeBlock/ReactLive/sandboxConfig.js
@@ -3,7 +3,7 @@ import { web } from '../shared/templates';
 const HTML = '<div id="root"></div>';
 const URL = 'https://codesandbox.io/api/v1/sandboxes/define?json=1';
 
-const getPackage = ([imports, component, theme]) =>
+const getPackage = ([imports, component]) =>
   JSON.stringify({
     files: {
       'package.json': {
@@ -17,7 +17,7 @@ const getPackage = ([imports, component, theme]) =>
         },
       },
       'index.js': {
-        content: web(imports, component, theme),
+        content: web(imports, component),
       },
       'index.html': {
         content: HTML,

--- a/packages/doc/src/components/CodeBlock/SnackEmbed/SnackEmbed.jsx
+++ b/packages/doc/src/components/CodeBlock/SnackEmbed/SnackEmbed.jsx
@@ -30,9 +30,7 @@ const addProperties = (properties, to, prefix = '') => {
 };
 
 const SnackEmbed = ({ id, ...props }) => {
-  const { imports, code, dependencies, state, theme } = useContext(
-    CodeBlockContext,
-  );
+  const { imports, code, dependencies, state } = useContext(CodeBlockContext);
 
   const sanitizedCode = encodeURI(code);
 
@@ -46,7 +44,7 @@ const SnackEmbed = ({ id, ...props }) => {
             ['react', 'react-native'],
             false,
           )}\n\n${sanitizedCode}`
-        : native(imports, sanitizedCode, theme),
+        : native(imports, sanitizedCode),
       dependencies: dependencies.join(','),
     },
     {},

--- a/packages/doc/src/components/CodeBlock/shared/templates/native.js
+++ b/packages/doc/src/components/CodeBlock/shared/templates/native.js
@@ -1,6 +1,6 @@
 import { injectImport } from '..';
 
-const native = (imports, code, theme) => `import React from 'react';
+const native = (imports, code) => `import React from 'react';
 import styled from 'styled-components';
 ${injectImport(
   imports,
@@ -9,7 +9,7 @@ ${injectImport(
 )}
 
 const App = () => (
-  <ThemeProvider ${theme ? `theme='${theme}'` : ''}>
+  <ThemeProvider>
     <View style={styles.container}>
       ${code}
     </View>

--- a/packages/doc/src/components/CodeBlock/shared/templates/web.js
+++ b/packages/doc/src/components/CodeBlock/shared/templates/web.js
@@ -1,6 +1,6 @@
 import { injectImport, getCodeFragments } from '..';
 
-const web = (imports, code, theme) => {
+const web = (imports, code) => {
   const isState = code.search('render') !== -1;
 
   const buildCode = component => `import React, { useState, useEffect } from 'react';
@@ -28,7 +28,7 @@ const App = () => {
   ${codeBetweenRenderAndReturn.trim()}
 
   return (
-    <ThemeProvider${theme ? `theme='${theme}'` : ''}>
+    <ThemeProvider>
       <FontLoader />
       ${componentCode}
     </ThemeProvider>
@@ -37,7 +37,7 @@ const App = () => {
   }
 
   return buildCode(`const App = () => (
-  <ThemeProvider${theme ? `theme='${theme}'` : ''}>
+  <ThemeProvider>
     <FontLoader />
     ${code}
   </ThemeProvider>

--- a/packages/doc/src/components/Documentation/Documentation.jsx
+++ b/packages/doc/src/components/Documentation/Documentation.jsx
@@ -28,7 +28,7 @@ import {
   Ul,
 } from '../MDXElements/MDXElements';
 
-const customComponents = (prefix, theme) => ({
+const customComponents = prefix => ({
   h1: props => <ComponentTitle {...props} prefix={prefix} />,
   h2: props => <SubHeading2 {...props} />,
   h3: props => <SubHeading3 {...props} />,
@@ -36,7 +36,7 @@ const customComponents = (prefix, theme) => ({
   p: props => <Paragraph {...props} />,
   ul: props => <Ul {...props} />,
   pre: 'div',
-  code: props => <CodeBlock theme={theme} {...props} />,
+  code: props => <CodeBlock {...props} />,
   inlineCode: InlineCode,
   TabbedView: props => <TabbedView {...props} />,
   Tab: props => <Tab {...props} />,
@@ -63,10 +63,10 @@ const Wrapper = styled.div`
   }
 `;
 
-const Documentation = ({ mdx, prefix, theme }) => (
+const Documentation = ({ mdx, prefix }) => (
   <Wrapper>
     <div style={{ width: '100%' }}>
-      <MDXProvider components={customComponents(prefix, theme)}>
+      <MDXProvider components={customComponents(prefix)}>
         <MDXRenderer>{mdx}</MDXRenderer>
       </MDXProvider>
     </div>

--- a/packages/doc/src/components/Layout/Layout.jsx
+++ b/packages/doc/src/components/Layout/Layout.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { arrayOf, object, shape, bool } from 'prop-types';
 import styled from 'styled-components';
 import Helmet from 'react-helmet';
-import { ThemeProvider, yogaTheme } from '@gympass/yoga';
+import { ThemeProvider } from '@gympass/yoga';
 import { hexToRgb } from '@gympass/yoga-common';
 import { Link } from 'gatsby';
 
@@ -162,7 +162,7 @@ const Layout = ({
             items={nav}
             prefix={prefix}
           />
-          <Documentation mdx={body} prefix={prefix} theme={yogaTheme} />
+          <Documentation mdx={body} prefix={prefix} />
 
           <Footer>
             Made with{' '}


### PR DESCRIPTION
Our _codesandbox_ and _expo_ examples are showing a strange and wrong `theme` value inside the example code.

Since our major deploy from 6.0.0 version it's not necessary to pass the `theme` prop on `<ThemeProvider />` from our examples. This PR is removing it.

Example from expo snacks:
|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/13424727/114223322-0d9bb200-9946-11eb-9a8d-76b4fc03dfe4.png)|![image](https://user-images.githubusercontent.com/13424727/114223455-3cb22380-9946-11eb-8375-c294c21d7432.png)|
