### PR TITLE
Update jest configuration to fix coverage table

### DIFF
--- a/jest/config/config.js
+++ b/jest/config/config.js
@@ -1,3 +1,17 @@
 module.exports = {
-  projects: ['<rootDir>/native.js', '<rootDir>/helpers.js', '<rootDir>/web.js'],
+  projects: [
+    '<rootDir>/jest/config/native.js',
+    '<rootDir>/jest/config/helpers.js',
+    '<rootDir>/jest/config/web.js',
+  ],
+  collectCoverageFrom: [
+    '<rootDir>/packages/**/*.{js,jsx}',
+    '!<rootDir>/packages/**/index.{js,native.js}',
+    '!<rootDir>/packages/**/*.test.{js,jsx}',
+    '!<rootDir>/packages/**/babel.config.js',
+    '!<rootDir>/**/node_modules/**',
+    '!<rootDir>/packages/labnative/**',
+    '!<rootDir>/packages/doc/**',
+  ],
+  rootDir: '../../',
 };

--- a/jest/config/helpers.js
+++ b/jest/config/helpers.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testMatch: ['<rootDir>/../../packages/helpers/**/*.test.js'],
+  testMatch: ['<rootDir>/packages/helpers/**/*.test.js'],
   displayName: 'helpers',
-  roots: ['<rootDir>/../../'],
+  rootDir: '../../',
 };

--- a/jest/config/native.js
+++ b/jest/config/native.js
@@ -1,21 +1,21 @@
 module.exports = {
-  roots: ['<rootDir>/../../'],
-  testMatch: ['<rootDir>/../../packages/**/native/**/*.test.jsx'],
+  testMatch: ['<rootDir>/packages/**/native/**/*.test.jsx'],
   transform: { '^.+\\.jsx?$': 'babel-jest' },
   displayName: 'native',
   preset: '@testing-library/react-native',
-  setupFilesAfterEnv: ['../setup/native.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest/setup/native.js'],
   moduleDirectories: [
-    '<rootDir>/../../node_modules',
-    '<rootDir>/../../packages/labnative/node_modules',
+    '<rootDir>/node_modules',
+    '<rootDir>/packages/labnative/node_modules',
   ],
   moduleNameMapper: {
     'styled-components': require.resolve(
       'styled-components/native/dist/styled-components.native.cjs',
     ),
-    '\\.svg$': '<rootDir>/../mock/svg.native.js',
+    '\\.svg$': '<rootDir>/jest/mock/svg.native.js',
   },
   transformIgnorePatterns: [
     '/node_modules/(?!@ptomasroos/react-native-multi-slider|react-native).+\\.js$',
   ],
+  rootDir: '../../',
 };

--- a/jest/config/web.js
+++ b/jest/config/web.js
@@ -1,12 +1,12 @@
 module.exports = {
   testMatch: [
-    '<rootDir>/../../packages/**/web/**/*.test.js',
-    '<rootDir>/../../packages/**/web/**/*.test.jsx',
+    '<rootDir>/packages/**/web/**/*.test.js',
+    '<rootDir>/packages/**/web/**/*.test.jsx',
   ],
-  setupFilesAfterEnv: ['../setup/web.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest/setup/web.js'],
   displayName: 'web',
   moduleNameMapper: {
-    '\\.svg$': '<rootDir>/../mock/svg.js',
+    '\\.svg$': '<rootDir>/jest/mock/svg.js',
   },
-  roots: ['<rootDir>/../../'],
+  rootDir: '../../',
 };


### PR DESCRIPTION
This PR changes the jest configuration files to bring back the coverage report.

|Before|After|
|------|------|
|![image](https://user-images.githubusercontent.com/13424727/116463884-a33da980-a841-11eb-91f5-9cf9dd2d749b.png)|![image](https://user-images.githubusercontent.com/13424727/116463937-b2245c00-a841-11eb-8fb0-06e9b6b6c124.png)| 

As we can see on the print-screen, we have `93.49%` of code coverage