### PR TITLE
Fix AutoComplete onClean/onSelect event

### DIFF
--- a/packages/doc/content/components/components/autocomplete/index.mdx
+++ b/packages/doc/content/components/components/autocomplete/index.mdx
@@ -13,8 +13,6 @@ import { Link } from 'gatsby';
 It accepts unlimited number of suggstions, but it filters and only display the six
 most matched options.
 
-You can use `onSelect` prop to handle when user select a suggested option.
-
 It inherit all the [Input](/components/input/default) props.
 
 ## Usage

--- a/packages/doc/content/components/components/autocomplete/index.mdx
+++ b/packages/doc/content/components/components/autocomplete/index.mdx
@@ -15,7 +15,7 @@ most matched options.
 
 You can use `onSelect` prop to handle when user select a suggested option.
 
-It inherit all the <Link to="/components/input/default">Input</Link> props.
+It inherit all the [Input](/components/input/default) props.
 
 ## Usage
 
@@ -27,8 +27,8 @@ render(() => {
     <AutoComplete
       value={value}
       onChange={value => setValue(value)}
-      onSelect={selected => setValue(selected)}
-      onClean={cleaned => setValue(cleaned)}
+      onSelect={selected => console.log(selected)}
+      onClean={cleaned => console.log('cleaned', cleaned)}
       options={[
         'Madrid',
         'Milan',

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -159,14 +159,19 @@ const AutoComplete = ({
     <Downshift
       selectedItem={userValue}
       onStateChange={changes => {
-        if (Object.prototype.hasOwnProperty.call(changes, 'selectedItem')) {
-          setUserValue(changes.selectedItem);
-          onSelect(changes.selectedItem);
+        const { selectedItem, inputValue } = changes;
+        if (
+          Object.prototype.hasOwnProperty.call(changes, 'selectedItem') &&
+          selectedItem
+        ) {
+          setUserValue(selectedItem);
+          onSelect(selectedItem);
+          onChange(selectedItem);
         } else if (
           Object.prototype.hasOwnProperty.call(changes, 'inputValue')
         ) {
-          setUserValue(changes.inputValue);
-          onChange(changes.inputValue);
+          setUserValue(inputValue);
+          onChange(inputValue);
         }
       }}
     >

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -260,8 +260,11 @@ AutoComplete.propTypes = {
   full: bool,
   options: arrayOf(string),
   style: shape({}),
+  /** callback to know when a user selects a suggestion */
   onSelect: func,
+  /** called when user type or clean the field and when selects a suggestion */
   onChange: func,
+  /** a callback to know when the user cleaned the field */
   onClean: func,
   value: string,
 };

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -160,10 +160,7 @@ const AutoComplete = ({
       selectedItem={userValue}
       onStateChange={changes => {
         const { selectedItem, inputValue } = changes;
-        if (
-          Object.prototype.hasOwnProperty.call(changes, 'selectedItem') &&
-          selectedItem
-        ) {
+        if (selectedItem) {
           setUserValue(selectedItem);
           onSelect(selectedItem);
           onChange(selectedItem);

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
@@ -83,6 +83,8 @@ describe('<AutoComplete />', () => {
   describe('Event listeners', () => {
     it('should call onChangeMock', () => {
       const onChangeMock = jest.fn();
+      const onCleanMock = jest.fn();
+      const onSelectMock = jest.fn();
 
       const { getByDisplayValue } = render(
         <ThemeProvider>
@@ -97,10 +99,14 @@ describe('<AutoComplete />', () => {
       fireEvent.change(getByDisplayValue('New'), { target: { value: 'a' } });
 
       expect(onChangeMock).toHaveBeenCalled();
+      expect(onSelectMock).not.toHaveBeenCalled();
+      expect(onCleanMock).not.toHaveBeenCalled();
     });
 
     it('should call onCleanMock', () => {
       const onCleanMock = jest.fn();
+      const onSelectMock = jest.fn();
+      const onChangeMock = jest.fn();
 
       const { getByDisplayValue, getByRole } = render(
         <ThemeProvider>
@@ -108,6 +114,8 @@ describe('<AutoComplete />', () => {
             value="New"
             options={['New York']}
             onClean={onCleanMock}
+            onSelect={onSelectMock}
+            onChange={onChangeMock}
           />
         </ThemeProvider>,
       );
@@ -116,6 +124,33 @@ describe('<AutoComplete />', () => {
       fireEvent.click(getByRole('button'));
 
       expect(onCleanMock).toHaveBeenCalledWith('');
+      expect(onSelectMock).not.toHaveBeenCalled();
+      expect(onChangeMock).toHaveBeenCalled();
+    });
+
+    it('should call onSelectMock', () => {
+      const onSelectMock = jest.fn();
+      const onCleanMock = jest.fn();
+      const onChangeMock = jest.fn();
+
+      const { getByDisplayValue, getByRole } = render(
+        <ThemeProvider>
+          <AutoComplete
+            value="New"
+            options={['New York']}
+            onSelect={onSelectMock}
+            onClean={onCleanMock}
+            onChange={onChangeMock}
+          />
+        </ThemeProvider>,
+      );
+
+      fireEvent.focus(getByDisplayValue('New'));
+      fireEvent.click(getByRole('option'));
+
+      expect(onSelectMock).toHaveBeenCalledWith('New York');
+      expect(onCleanMock).not.toHaveBeenCalled();
+      expect(onChangeMock).toHaveBeenCalled();
     });
   });
 });

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
@@ -98,7 +98,7 @@ describe('<AutoComplete />', () => {
 
       fireEvent.change(getByDisplayValue('New'), { target: { value: 'a' } });
 
-      expect(onChangeMock).toHaveBeenCalled();
+      expect(onChangeMock).toHaveBeenCalledWith('a');
       expect(onSelectMock).not.toHaveBeenCalled();
       expect(onCleanMock).not.toHaveBeenCalled();
     });
@@ -125,7 +125,7 @@ describe('<AutoComplete />', () => {
 
       expect(onCleanMock).toHaveBeenCalledWith('');
       expect(onSelectMock).not.toHaveBeenCalled();
-      expect(onChangeMock).toHaveBeenCalled();
+      expect(onChangeMock).toHaveBeenCalledWith('');
     });
 
     it('should call onSelectMock', () => {
@@ -149,8 +149,8 @@ describe('<AutoComplete />', () => {
       fireEvent.click(getByRole('option'));
 
       expect(onSelectMock).toHaveBeenCalledWith('New York');
+      expect(onChangeMock).toHaveBeenCalledWith('New York');
       expect(onCleanMock).not.toHaveBeenCalled();
-      expect(onChangeMock).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This PR fixes the issue that "onSelect" event was being called when the user clicks on the "Clear (X)" button.

|Before|After|
|------|-----|
|![autocomplete-before](https://user-images.githubusercontent.com/13424727/117195283-7fd3ab00-adbb-11eb-9abb-b90a176062e0.gif)|![autocomplete-after](https://user-images.githubusercontent.com/13424727/117195325-88c47c80-adbb-11eb-8473-d47759ad7f32.gif)|