### PR TITLE
Add 's' at the end of importing the library

### DIFF
--- a/packages/doc/content/components/helpers/media.mdx
+++ b/packages/doc/content/components/helpers/media.mdx
@@ -29,7 +29,7 @@ npm install @gympass/yoga-helpers
 
 ```javascript type=highlight
 import styled from 'styled-components';
-import { media } from '@gympass/yoga-helper';
+import { media } from '@gympass/yoga-helpers';
 ​
 const MyResponsiveButton = styled.button`
   ${media[breakpoint]``}
@@ -70,7 +70,7 @@ component
 
 ```javascript type=highlight
 import styled from 'styled-components';
-import { media } from '@gympass/yoga-helper';
+import { media } from '@gympass/yoga-helpers';
 
 const HideMe = styled.div`
   ${media.hide.xxs}


### PR DESCRIPTION
The documentation does not have the letter 's' at the end, so importing the library(`@gympass/yoga-helper`) will not work.
That way, you must add the 's' at the end of the import for the library(`@gympass/yoga-helpers`) to work.