### PR TITLE
Add 's' at the end of import yoga-helpers

### DIFF
--- a/packages/doc/content/components/helpers/media.mdx
+++ b/packages/doc/content/components/helpers/media.mdx
@@ -29,7 +29,7 @@ npm install @gympass/yoga-helpers
 
 ```javascript type=highlight
 import styled from 'styled-components';
-import { media } from '@gympass/yoga-helper';
+import { media } from '@gympass/yoga-helpers';
 ​
 const MyResponsiveButton = styled.button`
   ${media[breakpoint]``}
@@ -70,7 +70,7 @@ component
 
 ```javascript type=highlight
 import styled from 'styled-components';
-import { media } from '@gympass/yoga-helper';
+import { media } from '@gympass/yoga-helpers';
 
 const HideMe = styled.div`
   ${media.hide.xxs}


### PR DESCRIPTION
The documentation does not have the letter 's' at the end, so importing the library(`@gympass/yoga-helper`) will not work.
That way, you must add the 's' at the end of the import for the library(`@gympass/yoga-helpers`) to work.

### Before
![image](https://user-images.githubusercontent.com/32910717/119861340-a8981d80-beed-11eb-830e-8e06589471b9.png)

### After
![image](https://user-images.githubusercontent.com/32910717/119861520-ded59d00-beed-11eb-8fb6-aff9d8d8d43b.png)
