### PR TITLE
Remove topic 'media.min' at media

### DIFF
--- a/packages/doc/content/components/helpers/media.mdx
+++ b/packages/doc/content/components/helpers/media.mdx
@@ -35,10 +35,6 @@ const MyResponsiveButton = styled.button`
   ${media[breakpoint]``}
   // generates: @media (min-width: breakpoint)
   // Ex.: media.md`` or media['xxs']``
-​
-  ${media.min(breakpoint)``}
-  // generates: @media (min-width: breakpoint)
-  // Ex.: media.min('md')``
 
   ${media.max(breakpoint)``}
   // generates: @media (max-width: breakpoint)
@@ -50,7 +46,6 @@ const MyResponsiveButton = styled.button`
 ​
   // We can also use .not (Like jest expect matchers)
   ${media.not[breakpoint]``}
-  ${media.not.min(breakpoint)``}
   // generates: @media not all and (min-width: breakpoint)
   // Ex.: media.not.md`` or media.not['xxs']``
 


### PR DESCRIPTION
The 'media.min' is present in the documentation, but it is redundant since the topic above has the same function. In addition, using this media in the code will give error for not recognizing the 'min'.

![image](https://user-images.githubusercontent.com/59899974/119870233-81dee480-bef7-11eb-942f-85fd88741f74.png)

The correct way to use it would be, per example:

```
${media.md``}
```
or
```
${media.not['md']``}
```