### PR TITLE
Fix: import of styled components

### DIFF
--- a/packages/doc/src/components/CodeBlock/CodeBlock.jsx
+++ b/packages/doc/src/components/CodeBlock/CodeBlock.jsx
@@ -12,9 +12,11 @@ import {
 
 const buildImportString = (code, modules) => {
   const findComponents = /(?:<|{)(\w*)(?=\s*?\/?>*)/gm;
+  const findStyledComponents = /styled\(\w*/gm;
   const sortModules = /(@gympass\/yoga*)/gm;
   const imports = [];
   const foundComponents = code.match(findComponents) || [];
+  const foundStyledComponents = code.match(findStyledComponents) || [];
 
   modules
     .sort(a => (a.path.match(sortModules) ? -1 : 0))
@@ -23,6 +25,11 @@ const buildImportString = (code, modules) => {
         components: [
           ...new Set(
             foundComponents.map(c => c.replace(/<|{/, '')).filter(c => c),
+          ),
+          ...new Set(
+            foundStyledComponents
+              .map(c => c.replace(/styled\(/, ''))
+              .filter(c => c),
           ),
         ]
           .filter(importedComponent =>


### PR DESCRIPTION
# Import styled components

As the code is, the codesandbox generation is not able to capture the elements that are styled-component styled.
The problem was encountered on the [media page](https://gympass.github.io/yoga/components/helpers/media#usage) when logging in when trying to create the codesandbox from the first usage example.

![image](https://user-images.githubusercontent.com/24553367/120543117-501bc100-c3c2-11eb-95bf-c40ac845b95e.png)

In short, it was only necessary to add one more conditional when extracting the components, creating a new regex rule. I hope it will be useful for all the documentation, as it will open up a range of possibilities for customizing components. :)

![image](https://user-images.githubusercontent.com/24553367/120544162-7ee66700-c3c3-11eb-9498-d7a0edb9fb11.png)
