### PR TITLE
Add 'react-scripts' as dependency

### DIFF
--- a/packages/doc/src/components/CodeBlock/ReactLive/sandboxConfig.js
+++ b/packages/doc/src/components/CodeBlock/ReactLive/sandboxConfig.js
@@ -11,6 +11,7 @@ const getPackage = ([imports, component]) =>
           dependencies: {
             react: 'latest',
             'react-dom': 'latest',
+            'react-scripts': 'latest',
             '@gympass/yoga': 'latest',
             'styled-components': 'latest',
           },


### PR DESCRIPTION
It was observed that when a code is generated in CodeSandBox, where there is a `<></> (fragment)` it will give a certain error. Here is the error example:

![image](https://user-images.githubusercontent.com/59899974/120694424-8d468880-c480-11eb-81e9-e2fd52dd10b2.png)

One of the solutions would be to put in each component that uses it `<React.Fragment> or <div>`. As in the example below:

![image](https://user-images.githubusercontent.com/59899974/120694515-b1a26500-c480-11eb-8854-ce0ce607467b.png)

However, it can be solved by adding the dependency 'react-scripts', and that way the `<></> (fragment)` will be recognized in all code generated in CodeSandBox from the Yoga documentation. Example:

![image](https://user-images.githubusercontent.com/59899974/120694856-09d96700-c481-11eb-929d-d725ca90e766.png)