### PR TITLE
Add `react` as a peer dependency to `@gympass/yoga`

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -33,7 +33,8 @@
     "babel-plugin-transform-rename-import": "^2.3.0"
   },
   "peerDependencies": {
-    "react-native-svg": ">=9.13.3"
+    "react-native-svg": ">=9.13.3",
+    "react": ">=16"
   },
   "bugs": {
     "url": "https://github.com/Gympass/yoga/issues"

--- a/packages/yoga/package.json
+++ b/packages/yoga/package.json
@@ -53,6 +53,7 @@
     "styled-components": "^4.4.0"
   },
   "peerDependencies": {
-    "styled-components": "^4.4.0"
+    "styled-components": "^4.4.0",
+    "react": ">=16"
   }
 }


### PR DESCRIPTION
I checked our documentation and we are using the version `^16.9.0`, which's where the `>=16` comes from.