### PR TITLE
fix: fix checkbox width when adding large label text

### DIFF
--- a/packages/yoga/src/Checkbox/web/Checkbox.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.jsx
@@ -21,6 +21,8 @@ const CheckMark = styled.div`
 
   border-style: solid;
 
+  flex-shrink: 0;
+
   ${({
     checked,
     disabled,

--- a/packages/yoga/src/Checkbox/web/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/yoga/src/Checkbox/web/__snapshots__/Checkbox.test.jsx.snap
@@ -23,6 +23,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with checked checkbox 1`] 
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -217,6 +220,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with default checkbox 1`] 
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -364,6 +370,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with disabled and checked 
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -585,6 +594,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with disabled checkbox 1`]
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -757,6 +769,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with error and checked che
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -972,6 +987,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with error checkbox 1`] = 
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -1181,6 +1199,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with inverted 1`] = `
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -1411,6 +1432,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with inverted and checked 
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -1648,6 +1672,9 @@ exports[`<Checkbox /> Snapshots should match snapshot with inverted and checked 
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;
@@ -1910,6 +1937,9 @@ exports[`<Checkbox /> Snapshots should match snapshot without props 1`] = `
 .c6 {
   position: relative;
   border-style: solid;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 24px;
   height: 24px;
   margin-right: 8px;


### PR DESCRIPTION
# :bug: Fix checkbox width when adding large label text

## Motivation
We were using the `<Checkbox />` component, and notice that when we add a large label text the checkbox width is small than defined

## Changes
- Add `flex-shrink: 0` to `CheckMark` element. The idea is to keep the same width on Checkbox input
- Update tests snapshots

## Screenshots
**Before**
![Screenshot from 2021-06-29 11-59-53](https://user-images.githubusercontent.com/8313529/123823031-2f685d80-d8d3-11eb-80fe-7aec21826eb8.png)


**After**
![Screenshot from 2021-06-29 11-59-19](https://user-images.githubusercontent.com/8313529/123823054-34c5a800-d8d3-11eb-9c30-03ecbc1a928b.png)


## Issue
Closes #279 