### PR TITLE
Removing the fixed height on PlanCard List

### DIFF
--- a/packages/yoga/src/Card/Card.theme.js
+++ b/packages/yoga/src/Card/Card.theme.js
@@ -64,7 +64,6 @@ const Card = ({
       },
     },
     list: {
-      height: 92,
       margin: {
         top: spacing.small,
       },

--- a/packages/yoga/src/Card/native/EventCard/__snapshots__/EventCard.test.jsx.snap
+++ b/packages/yoga/src/Card/native/EventCard/__snapshots__/EventCard.test.jsx.snap
@@ -478,7 +478,6 @@ exports[`<EventCard /> Snapshots should match snapshot of small EventCard active
                           "top": 12,
                         },
                       },
-                      "height": 92,
                       "item": Object {
                         "font": Object {
                           "color": "#231B22",
@@ -1858,7 +1857,6 @@ exports[`<EventCard /> Snapshots should match snapshot of small EventCard with d
                           "top": 12,
                         },
                       },
-                      "height": 92,
                       "item": Object {
                         "font": Object {
                           "color": "#231B22",
@@ -3234,7 +3232,6 @@ exports[`<EventCard /> Snapshots should match snapshot of small EventCard with e
                           "top": 12,
                         },
                       },
-                      "height": 92,
                       "item": Object {
                         "font": Object {
                           "color": "#231B22",
@@ -4614,7 +4611,6 @@ exports[`<EventCard /> Snapshots should match snapshot of small EventCard with e
                           "top": 12,
                         },
                       },
-                      "height": 92,
                       "item": Object {
                         "font": Object {
                           "color": "#231B22",
@@ -5994,7 +5990,6 @@ exports[`<EventCard /> Snapshots should match snapshot with full EventCard 1`] =
                           "top": 12,
                         },
                       },
-                      "height": 92,
                       "item": Object {
                         "font": Object {
                           "color": "#231B22",

--- a/packages/yoga/src/Card/native/PlanCard/List.jsx
+++ b/packages/yoga/src/Card/native/PlanCard/List.jsx
@@ -9,7 +9,6 @@ import theme from '../../../Theme/helpers/themeReader';
 const { plan } = theme.components.card;
 
 const List = styled.View`
-  min-height: ${plan.list.height}px;
   margin-top: ${plan.list.margin.top}px;
 `;
 

--- a/packages/yoga/src/Card/native/PlanCard/__snapshots__/PlanCard.test.jsx.snap
+++ b/packages/yoga/src/Card/native/PlanCard/__snapshots__/PlanCard.test.jsx.snap
@@ -281,7 +281,6 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
             Array [
               Object {
                 "marginTop": 16,
-                "minHeight": 92,
               },
             ]
           }

--- a/packages/yoga/src/Card/web/PlanCard/List.jsx
+++ b/packages/yoga/src/Card/web/PlanCard/List.jsx
@@ -14,7 +14,6 @@ const truncateStyle = css`
 `;
 
 const List = styled.ul`
-  height: ${plan.list.height}px;
   margin: ${plan.list.margin.top}px 0 0;
   padding: 0;
 

--- a/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
+++ b/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
@@ -234,7 +234,6 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
 }
 
 .c11 {
-  height: 92px;
   margin: 16px 0 0;
   padding: 0;
   list-style: none;


### PR DESCRIPTION
## Description 📄
the planCard does not have a dynamic height and currently when used more than 3 ListItems the
listItems overlap the contents below them, so it was necessary to remove the fixed height aiming to
solve this bug.

## More info
for more details you can look at issue #281 