### PR TITLE
Add overflow prop to system

### DIFF
--- a/packages/doc/content/system/system/overflow.mdx
+++ b/packages/doc/content/system/system/overflow.mdx
@@ -1,0 +1,77 @@
+---
+title: 'Overflow'
+metaTitle: 'System - Overflow'
+metaDescription: '@gympass/yoga-system overflow'
+---
+
+## overflow
+
+```javascript state
+const Square = styled.p`
+  width: 200px;
+  height: 50px;
+
+  ${overflow}
+`;
+
+render(() => {
+  return (
+  <Square of="scroll">
+     This is a description to show the example of using the overflow property 
+     with the scroll value     
+  </Square>
+  );
+});
+```
+
+_For React Native users, we strongly recommend the usage of shorthands due to
+[some](https://github.com/facebook/react-native/issues/12469) &nbsp;
+[conflicts](https://github.com/styled-components/styled-components/issues/403)
+&nbsp; [you could face](https://github.com/hyrwork/react-native-row/issues/6)_
+
+The `overflows` module has all the listed above
+
+<table>
+  <thead>
+    <tr>
+      <th>Module</th>
+      <th>Prop</th>
+      <th>CSS Property</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <inlineCode>overflow</inlineCode>
+      </td>
+      <td>
+        <inlineCode>overflow</inlineCode>, <inlineCode>of</inlineCode>
+      </td>
+      <td>
+        <inlineCode>overflow</inlineCode>
+      </td>
+    </tr>
+     <tr>
+      <td>
+        <inlineCode>overflowY</inlineCode>
+      </td>
+      <td>
+        <inlineCode>overflowY</inlineCode>, <inlineCode>oy</inlineCode>
+      </td>
+      <td>
+        <inlineCode>overflow-y</inlineCode>
+      </td>
+    </tr>
+     <tr>
+      <td>
+        <inlineCode>overflowX</inlineCode>
+      </td>
+      <td>
+        <inlineCode>overflowX</inlineCode>, <inlineCode>ox</inlineCode>
+      </td>
+      <td>
+        <inlineCode>overflow-x</inlineCode>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/packages/doc/content/system/system/overflow.mdx
+++ b/packages/doc/content/system/system/overflow.mdx
@@ -14,14 +14,10 @@ const Square = styled.p`
   ${overflow}
 `;
 
-render(() => {
-  return (
-  <Square of="scroll">
+render(() => <Square of="scroll">
      This is a description to show the example of using the overflow property 
      with the scroll value     
-  </Square>
-  );
-});
+  </Square>);
 ```
 
 _For React Native users, we strongly recommend the usage of shorthands due to

--- a/packages/system/src/index.js
+++ b/packages/system/src/index.js
@@ -6,3 +6,4 @@ export * from './layout';
 export * from './spacing';
 export * from './system';
 export * from './typography';
+export * from './overflow';

--- a/packages/system/src/overflow.js
+++ b/packages/system/src/overflow.js
@@ -1,0 +1,30 @@
+import { compose, generator } from './theme';
+
+const overflow = props =>
+  generator({
+    props,
+    prop: ['overflow', 'of'],
+    cssProperty: 'overflow',
+  });
+
+const overflowX = props =>
+  generator({
+    props,
+    prop: ['overflowX', 'ox'],
+    cssProperty: 'overflow-x',
+  });
+
+const overflowY = props =>
+  generator({
+    props,
+    prop: ['overflowY', 'oy'],
+    cssProperty: 'overflow-y',
+  });
+
+const overflows = compose(
+  overflow,
+  overflowX,
+  overflowY,
+);
+
+export { overflows, overflow, overflowX, overflowY };

--- a/packages/system/src/overflow.test.js
+++ b/packages/system/src/overflow.test.js
@@ -24,7 +24,7 @@ describe('overflow', () => {
 
   describe('overflow', () => {
     it('Should return values for overflow prop', () => {
-      const expectedDisplay = css({ overflow: 'scroll' });
+      const expectedOverflow = css({ overflow: 'scroll' });
 
       const ofProp = overflow({ of: 'scroll' });
       const overflowProp = overflow({ overflow: 'scroll' });
@@ -33,13 +33,13 @@ describe('overflow', () => {
 
       const ofOptions = [ofProp, overflowProp];
 
-      ofOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+      ofOptions.map(c => expect(c).toStrictEqual(expectedOverflow));
     });
   });
 
   describe('overflowX', () => {
     it('Should return values for overflow-x prop', () => {
-      const expectedDisplay = css({ overflowX: 'auto' });
+      const expectedOverflow = css({ overflowX: 'auto' });
 
       const oxProp = overflowX({ ox: 'auto' });
       const overflowXProp = overflowX({ overflowX: 'auto' });
@@ -48,13 +48,13 @@ describe('overflow', () => {
 
       const oxOptions = [oxProp, overflowXProp];
 
-      oxOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+      oxOptions.map(c => expect(c).toStrictEqual(expectedOverflow));
     });
   });
 
   describe('overflowY', () => {
     it('Should return values for overflow-y prop', () => {
-      const expectedDisplay = css({ overflowY: 'auto' });
+      const expectedOverflow = css({ overflowY: 'auto' });
 
       const oyProp = overflowY({ oy: 'auto' });
       const overflowYProp = overflowY({ overflowY: 'auto' });
@@ -63,7 +63,7 @@ describe('overflow', () => {
 
       const oyOptions = [oyProp, overflowYProp];
 
-      oyOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+      oyOptions.map(c => expect(c).toStrictEqual(expectedOverflow));
     });
   });
 });

--- a/packages/system/src/overflow.test.js
+++ b/packages/system/src/overflow.test.js
@@ -1,0 +1,52 @@
+import { css } from 'styled-components';
+import { overflow, overflowX, overflowY, overflows } from './overflow';
+
+describe('overflow', () => {
+  describe('overflows', () => {
+    it('Should return values for all overflow props', () => {
+      const expectedDisplay = css({ overflowX: 'scroll', overflowY: 'scroll' });
+
+      const ofProp = overflows({ ox: 'scroll', oy: 'scroll' });
+      const overflowsProp = overflows({
+        overflowX: 'scroll',
+        overflowY: 'scroll',
+      });
+      expect(ofProp).toStrictEqual(overflowsProp);
+      const bgOptions = [ofProp, overflowsProp];
+      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+    });
+  });
+  describe('overflow', () => {
+    it('Should return values for overflow prop', () => {
+      const expectedDisplay = css({ overflow: 'scroll' });
+
+      const ofProp = overflow({ of: 'scroll' });
+      const overflowProp = overflow({ overflow: 'scroll' });
+      expect(ofProp).toStrictEqual(overflowProp);
+      const bgOptions = [ofProp, overflowProp];
+      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+    });
+  });
+  describe('overflowX', () => {
+    it('Should return values for overflow-x prop', () => {
+      const expectedDisplay = css({ overflowX: 'auto' });
+
+      const oxProp = overflowX({ ox: 'auto' });
+      const overflowXProp = overflowX({ overflowX: 'auto' });
+      expect(oxProp).toStrictEqual(overflowXProp);
+      const bgOptions = [oxProp, overflowXProp];
+      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+    });
+  });
+  describe('overflowY', () => {
+    it('Should return values for overflow-y prop', () => {
+      const expectedDisplay = css({ overflowY: 'auto' });
+
+      const oyProp = overflowY({ oy: 'auto' });
+      const overflowYProp = overflowY({ overflowY: 'auto' });
+      expect(oyProp).toStrictEqual(overflowYProp);
+      const bgOptions = [oyProp, overflowYProp];
+      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+    });
+  });
+});

--- a/packages/system/src/overflow.test.js
+++ b/packages/system/src/overflow.test.js
@@ -4,49 +4,66 @@ import { overflow, overflowX, overflowY, overflows } from './overflow';
 describe('overflow', () => {
   describe('overflows', () => {
     it('Should return values for all overflow props', () => {
-      const expectedDisplay = css({ overflowX: 'scroll', overflowY: 'scroll' });
-
+      const expectedOverflow = css({
+        overflowX: 'scroll',
+        overflowY: 'scroll',
+      });
       const ofProp = overflows({ ox: 'scroll', oy: 'scroll' });
       const overflowsProp = overflows({
         overflowX: 'scroll',
         overflowY: 'scroll',
       });
+
       expect(ofProp).toStrictEqual(overflowsProp);
-      const bgOptions = [ofProp, overflowsProp];
-      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+
+      const ofOptions = [ofProp, overflowsProp];
+
+      ofOptions.map(c => expect(c).toStrictEqual(expectedOverflow));
     });
   });
+
   describe('overflow', () => {
     it('Should return values for overflow prop', () => {
       const expectedDisplay = css({ overflow: 'scroll' });
 
       const ofProp = overflow({ of: 'scroll' });
       const overflowProp = overflow({ overflow: 'scroll' });
+
       expect(ofProp).toStrictEqual(overflowProp);
-      const bgOptions = [ofProp, overflowProp];
-      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+
+      const ofOptions = [ofProp, overflowProp];
+
+      ofOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
     });
   });
+
   describe('overflowX', () => {
     it('Should return values for overflow-x prop', () => {
       const expectedDisplay = css({ overflowX: 'auto' });
 
       const oxProp = overflowX({ ox: 'auto' });
       const overflowXProp = overflowX({ overflowX: 'auto' });
+
       expect(oxProp).toStrictEqual(overflowXProp);
-      const bgOptions = [oxProp, overflowXProp];
-      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+
+      const oxOptions = [oxProp, overflowXProp];
+
+      oxOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
     });
   });
+
   describe('overflowY', () => {
     it('Should return values for overflow-y prop', () => {
       const expectedDisplay = css({ overflowY: 'auto' });
 
       const oyProp = overflowY({ oy: 'auto' });
       const overflowYProp = overflowY({ overflowY: 'auto' });
+
       expect(oyProp).toStrictEqual(overflowYProp);
-      const bgOptions = [oyProp, overflowYProp];
-      bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
+
+      const oyOptions = [oyProp, overflowYProp];
+
+      oyOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
     });
   });
 });

--- a/packages/system/src/system.js
+++ b/packages/system/src/system.js
@@ -5,6 +5,7 @@ import { spacing } from './spacing';
 import { typography } from './typography';
 import { display, positions } from './layout';
 import { flexes } from './flex';
+import { overflows } from './overflow';
 import { compose } from './theme';
 
 const system = compose(
@@ -16,6 +17,7 @@ const system = compose(
   display,
   positions,
   flexes,
+  overflows,
 );
 
 export { system };


### PR DESCRIPTION
# ✨ Add overflow prop to system

![image](https://user-images.githubusercontent.com/46993493/128224011-9670f3e2-28a9-479b-b975-b1e20c688983.png)

## Motivation

Keeping the work in `@gympass/system`, we're adding the follow new module:

- `overflows` (having all bellow)
- `overflow` `of`
- `overflowX` `ox`
- `overflowY` `oy`

Those updates will be reflected into our Box component as it makes use of the `system` module

### Checklist

- [x] Unit tests