### PR TITLE
feat(chips): change native style to match the web

### DIFF
--- a/packages/yoga/src/Chips/native/Chips.jsx
+++ b/packages/yoga/src/Chips/native/Chips.jsx
@@ -42,7 +42,7 @@ const Wrapper = styled.View`
     selected
       ? css`
           background-color: ${theme.colors.yoga};
-          border-color: ${theme.colors.primary};
+          border-color: transparent;
         `
       : ''}
 `;
@@ -91,7 +91,7 @@ const Chips = ({
           />
         )}
         <StyledChips
-          as={selected ? Text.Bold : Text}
+          as={selected ? Text.Medium : Text}
           selected={selected}
           numberOfLines={1}
         >

--- a/packages/yoga/src/Chips/native/__snapshots__/Chips.test.jsx.snap
+++ b/packages/yoga/src/Chips/native/__snapshots__/Chips.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -167,7 +167,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -217,7 +217,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -244,7 +244,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -555,7 +555,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -582,7 +582,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -639,7 +639,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -666,7 +666,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -723,7 +723,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -750,7 +750,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -780,7 +780,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -807,7 +807,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -844,7 +844,7 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -871,7 +871,7 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -962,7 +962,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -989,7 +989,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",
@@ -1013,7 +1013,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
           Object {
             "alignItems": "center",
             "backgroundColor": "#FFEEF2",
-            "borderColor": "#D8385E",
+            "borderColor": "transparent",
             "borderRadius": 8,
             "borderStyle": "solid",
             "borderWidth": 1,
@@ -1040,7 +1040,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
               "color": "#231B22",
               "fontFamily": "Rubik",
               "fontSize": 16,
-              "fontWeight": "700",
+              "fontWeight": "500",
             },
             Object {
               "color": "#D8385E",


### PR DESCRIPTION
Change the values used in `border-color` and `font-weight` when the `Chips` component is selected. 

| Before | After |
| ------ | ----- |
|    <img width="300px" src="https://user-images.githubusercontent.com/7108030/128411436-50183ebf-f552-4264-aff7-a458ed48ad9b.png" />    |     <img width="300px" src="https://user-images.githubusercontent.com/7108030/128411401-652546f9-3ac3-4d85-9b91-e8f5b8133feb.png" />  |



