### PR TITLE
Add Result to YogaNativeComponents modules

### DIFF
--- a/packages/doc/src/components/CodeBlock/CodeBlock.jsx
+++ b/packages/doc/src/components/CodeBlock/CodeBlock.jsx
@@ -11,7 +11,7 @@ import {
 } from './shared/modules';
 
 const buildImportString = (code, modules) => {
-  const findComponents = /(?:<|{)(\w*)(?=\s*?\/?>*)/gm;
+  const findComponents = /(?:<|: |{)(\w*)(?=\s*?\/?>*)/gm;
   const findStyledComponents = /styled\(\w*/gm;
   const sortModules = /(@gympass\/yoga*)/gm;
   const imports = [];
@@ -24,7 +24,7 @@ const buildImportString = (code, modules) => {
       const moduleComponents = {
         components: [
           ...new Set(
-            foundComponents.map(c => c.replace(/<|{/, '')).filter(c => c),
+            foundComponents.map(c => c.replace(/<|: |{/, '')).filter(c => c),
           ),
           ...new Set(
             foundStyledComponents

--- a/packages/doc/src/components/CodeBlock/shared/modules/modules.js
+++ b/packages/doc/src/components/CodeBlock/shared/modules/modules.js
@@ -2,7 +2,11 @@ import * as YogaComponents from '@gympass/yoga';
 import * as YogaIcons from '@gympass/yoga-icons';
 import * as YogaHelpers from '@gympass/yoga-helpers';
 
-const YogaNativeComponents = { GymCard: undefined };
+const YogaNativeComponents = {
+  GymCard: undefined,
+  Result: undefined,
+  Avatar: undefined,
+};
 Object.assign(YogaComponents, YogaNativeComponents);
 
 const NativeComponents = {


### PR DESCRIPTION
## Add Result to YogaNativeComponents modules

#### Description 📄
Adding Result and Avatar Components to yogaNativeComponents modules and changing the findComponent regex so that the imports of the components work correctly and it is possible to view the component in the expo emulator