### PR TITLE
Revisiting `fontWeight` on Android

### DIFF
--- a/packages/labnative/pages/Box.jsx
+++ b/packages/labnative/pages/Box.jsx
@@ -15,7 +15,9 @@ const BoxPage = () => (
       elevation="small"
       bgColor="white"
     >
-      <Text>Making</Text>
+      <Box as={Text} fw="bold">
+        Making
+      </Box>
       <Text>wellbeing</Text>
       <Text>universal</Text>
     </Box>

--- a/packages/system/src/fontWeight.android.js
+++ b/packages/system/src/fontWeight.android.js
@@ -1,0 +1,26 @@
+import { getFontWeight, generator } from './theme';
+
+export const fontWeight = props =>
+  generator({
+    props,
+    prop: ['fontWeight', 'fw'],
+    cssProperty: 'font-family',
+    getter: getFontWeight,
+    transform: value => {
+      if (!value) {
+        return undefined;
+      }
+
+      const {
+        theme: {
+          yoga: { baseFont },
+        },
+      } = props;
+
+      if (Number(value) === 400) {
+        return baseFont.family;
+      }
+
+      return `${baseFont.family}-${value}`;
+    },
+  });

--- a/packages/system/src/fontWeight.js
+++ b/packages/system/src/fontWeight.js
@@ -1,0 +1,10 @@
+import { getFontWeight, generator } from './theme';
+
+export const fontWeight = props =>
+  generator({
+    props,
+    prop: ['fontWeight', 'fw'],
+    cssProperty: 'font-weight',
+    getter: getFontWeight,
+    transform: value => value && value.toString(),
+  });

--- a/packages/system/src/typography.js
+++ b/packages/system/src/typography.js
@@ -1,12 +1,13 @@
 import { toPx } from './unit';
 import {
   getFontSize,
-  getFontWeight,
   getColor,
   getLineHeight,
   generator,
   compose,
 } from './theme';
+
+import { fontWeight } from './fontWeight';
 
 const color = props =>
   generator({
@@ -23,15 +24,6 @@ const fontSize = props =>
     cssProperty: 'font-size',
     getter: getFontSize,
     transform: toPx,
-  });
-
-const fontWeight = props =>
-  generator({
-    props,
-    prop: ['fontWeight', 'fw'],
-    cssProperty: 'font-weight',
-    getter: getFontWeight,
-    transform: value => value && value.toString(),
   });
 
 const lineHeight = props =>

--- a/packages/system/src/typography.test.js
+++ b/packages/system/src/typography.test.js
@@ -173,7 +173,7 @@ describe('Web and iOS', () => {
 describe('Android', () => {
   describe('typography', () => {
     describe('fontWeight', () => {
-      it('should return the correspondent fontFamily', () => {
+      it('Should return the correspondent fontFamily', () => {
         const expectedFontFamily = css({
           fontFamily: `${baseFont.family}-${fontWeights.medium}`,
         });

--- a/packages/system/src/typography.test.js
+++ b/packages/system/src/typography.test.js
@@ -7,6 +7,8 @@ import {
   typography,
 } from './typography';
 
+import { fontWeight as fontWeightAndroid } from './fontWeight.android';
+
 const fontSizes = [10, 20, 40];
 [fontSizes.small, fontSizes.medium, fontSizes.large] = fontSizes;
 
@@ -15,6 +17,11 @@ const lineHeights = [12, 16, 20];
 
 const fontWeights = [300, 500, 900];
 [fontWeights.light, fontWeights.medium, fontWeights.bold] = fontWeights;
+
+const baseFont = {
+  family: 'Rubik',
+  weight: [...fontWeights, ...fontWeights.map(weight => `${weight}i`)],
+};
 
 const colors = {
   vibin: '#D8385E',
@@ -29,127 +36,177 @@ const theme = {
     fontSizes,
     lineHeights,
     fontWeights,
+    baseFont,
   },
 };
 
-describe('typography', () => {
+describe('Web and iOS', () => {
   describe('typography', () => {
-    it('Should return values for typography prop', () => {
-      const expectedTypography = css({
-        color: colors.vibin,
-        fontSize: fontSizes.medium,
-        fontWeight: fontWeights.bold,
-        lineHeight: `${lineHeights.medium}px`,
+    describe('typography', () => {
+      it('Should return values for typography prop', () => {
+        const expectedTypography = css({
+          color: colors.vibin,
+          fontSize: fontSizes.medium,
+          fontWeight: fontWeights.bold,
+          lineHeight: `${lineHeights.medium}px`,
+        });
+
+        const font = typography({
+          theme,
+          color: 'vibin',
+          fs: fontSizes.medium,
+          fw: fontWeights.bold,
+          lh: lineHeights.medium,
+        });
+
+        expect(font).toStrictEqual(expectedTypography);
       });
 
-      const font = typography({
-        theme,
-        color: 'vibin',
-        fs: fontSizes.medium,
-        fw: fontWeights.bold,
-        lh: lineHeights.medium,
+      it('Should return the value if there is no theme match', () => {
+        const expectedNoTheme = css({ color: 'tomato' });
+
+        const font = typography({ theme, color: 'tomato' });
+        expect(font).toStrictEqual(expectedNoTheme);
+      });
+    });
+
+    describe('fontSize', () => {
+      it('Should return values for fontSize prop', () => {
+        const expectedFontSize = css({ fontSize: fontSizes.medium });
+
+        const fs1 = fontSize({ theme, fs: 'medium' });
+        const fs2 = fontSize({ theme, fontSize: 'medium' });
+
+        expect(fs1).toStrictEqual(fs2);
+
+        const fontSizesOptions = [fs1, fs2];
+        fontSizesOptions.map(c => expect(c).toStrictEqual(expectedFontSize));
       });
 
-      expect(font).toStrictEqual(expectedTypography);
+      it('Should return the value if there is no theme match', () => {
+        const expectedNoTheme = css({ fontSize: 72 });
+
+        const fs = fontSize({ theme, fs: 72 });
+        expect(fs).toStrictEqual(expectedNoTheme);
+      });
     });
 
-    it('Should return the value if there is no theme match', () => {
-      const expectedNoTheme = css({ color: 'tomato' });
+    describe('fontWeight', () => {
+      it('Should return values for fontWeight prop', () => {
+        const expectedFontWeight = css({ fontWeight: fontWeights.medium });
 
-      const font = typography({ theme, color: 'tomato' });
-      expect(font).toStrictEqual(expectedNoTheme);
+        const fw1 = fontWeight({ theme, fw: 'medium' });
+        const fw2 = fontWeight({ theme, fontWeight: 'medium' });
+
+        expect(fw1).toStrictEqual(fw2);
+
+        const fontWeightsOptions = [fw1, fw2];
+        fontWeightsOptions.map(c =>
+          expect(c).toStrictEqual(expectedFontWeight),
+        );
+      });
+
+      it('Should return the value if there is no theme match', () => {
+        const expectedNoTheme = css({ fontWeight: 600 });
+
+        const fw = fontWeight({ theme, fw: 600 });
+        expect(fw).toStrictEqual(expectedNoTheme);
+      });
+    });
+
+    describe('lineHeight', () => {
+      it('Should return values for lineHeight prop', () => {
+        const expectedLineHeight = css({
+          lineHeight: `${lineHeights.medium}px`,
+        });
+
+        const lh1 = lineHeight({ theme, lh: 'medium' });
+        const lh2 = lineHeight({ theme, lineHeight: 'medium' });
+
+        expect(lh1).toStrictEqual(lh2);
+
+        const lineHeightsOptions = [lh1, lh2];
+        lineHeightsOptions.map(c =>
+          expect(c).toStrictEqual(expectedLineHeight),
+        );
+      });
+
+      it('Should return the value if there is no theme match', () => {
+        const expectedNoTheme = css({ lineHeight: '5px' });
+
+        const lh = lineHeight({ theme, lh: 5 });
+        expect(lh).toStrictEqual(expectedNoTheme);
+      });
+    });
+
+    describe('color', () => {
+      it('Should return values for color prop', () => {
+        const expectedColor = css({ color: colors.vibin });
+
+        const c1 = color({ theme, c: 'vibin' });
+        const c2 = color({ theme, color: 'vibin' });
+
+        expect(c1).toStrictEqual(c2);
+
+        const colorOptions = [c1, c2];
+        colorOptions.map(c => expect(c).toStrictEqual(expectedColor));
+      });
+
+      it('Should return the color based on its path', () => {
+        const expectedNoTheme = css({ color: colors.text.primary });
+
+        const c = color({ theme, color: 'text.primary' });
+
+        expect(c).toStrictEqual(expectedNoTheme);
+      });
+
+      it('Should return the value if there is no theme match', () => {
+        const expectedNoTheme = css({ color: 'tomato' });
+
+        const c = color({ theme, color: 'tomato' });
+        expect(c).toStrictEqual(expectedNoTheme);
+      });
     });
   });
+});
 
-  describe('fontSize', () => {
-    it('Should return values for fontSize prop', () => {
-      const expectedFontSize = css({ fontSize: fontSizes.medium });
+describe('Android', () => {
+  describe('typography', () => {
+    describe('fontWeight', () => {
+      it('should return the correspondent fontFamily', () => {
+        const expectedFontFamily = css({
+          fontFamily: `${baseFont.family}-${fontWeights.medium}`,
+        });
 
-      const fs1 = fontSize({ theme, fs: 'medium' });
-      const fs2 = fontSize({ theme, fontSize: 'medium' });
+        const fw1 = fontWeightAndroid({ theme, fw: 'medium' });
 
-      expect(fs1).toStrictEqual(fs2);
+        expect(fw1).toStrictEqual(expectedFontFamily);
+      });
 
-      const fontSizesOptions = [fs1, fs2];
-      fontSizesOptions.map(c => expect(c).toStrictEqual(expectedFontSize));
-    });
+      it('Should return values for fontWeight prop', () => {
+        const expectedFontFamily = css({
+          fontFamily: `${baseFont.family}-${fontWeights.medium}`,
+        });
 
-    it('Should return the value if there is no theme match', () => {
-      const expectedNoTheme = css({ fontSize: 72 });
+        const fw1 = fontWeightAndroid({ theme, fw: 'medium' });
+        const fw2 = fontWeightAndroid({ theme, fontWeight: 'medium' });
 
-      const fs = fontSize({ theme, fs: 72 });
-      expect(fs).toStrictEqual(expectedNoTheme);
-    });
-  });
+        expect(fw1).toStrictEqual(fw2);
 
-  describe('fontWeight', () => {
-    it('Should return values for fontWeight prop', () => {
-      const expectedFontWeight = css({ fontWeight: fontWeights.medium });
+        const fontWeightsOptions = [fw1, fw2];
+        fontWeightsOptions.map(c =>
+          expect(c).toStrictEqual(expectedFontFamily),
+        );
+      });
 
-      const fw1 = fontWeight({ theme, fw: 'medium' });
-      const fw2 = fontWeight({ theme, fontWeight: 'medium' });
+      it('Should return the value if there is no theme match', () => {
+        const expectedNoTheme = css({
+          fontFamily: `${baseFont.family}-200`,
+        });
 
-      expect(fw1).toStrictEqual(fw2);
-
-      const fontWeightsOptions = [fw1, fw2];
-      fontWeightsOptions.map(c => expect(c).toStrictEqual(expectedFontWeight));
-    });
-
-    it('Should return the value if there is no theme match', () => {
-      const expectedNoTheme = css({ fontWeight: 600 });
-
-      const fw = fontWeight({ theme, fw: 600 });
-      expect(fw).toStrictEqual(expectedNoTheme);
-    });
-  });
-
-  describe('lineHeight', () => {
-    it('Should return values for lineHeight prop', () => {
-      const expectedLineHeight = css({ lineHeight: `${lineHeights.medium}px` });
-
-      const lh1 = lineHeight({ theme, lh: 'medium' });
-      const lh2 = lineHeight({ theme, lineHeight: 'medium' });
-
-      expect(lh1).toStrictEqual(lh2);
-
-      const lineHeightsOptions = [lh1, lh2];
-      lineHeightsOptions.map(c => expect(c).toStrictEqual(expectedLineHeight));
-    });
-
-    it('Should return the value if there is no theme match', () => {
-      const expectedNoTheme = css({ lineHeight: '5px' });
-
-      const lh = lineHeight({ theme, lh: 5 });
-      expect(lh).toStrictEqual(expectedNoTheme);
-    });
-  });
-
-  describe('color', () => {
-    it('Should return values for color prop', () => {
-      const expectedColor = css({ color: colors.vibin });
-
-      const c1 = color({ theme, c: 'vibin' });
-      const c2 = color({ theme, color: 'vibin' });
-
-      expect(c1).toStrictEqual(c2);
-
-      const colorOptions = [c1, c2];
-      colorOptions.map(c => expect(c).toStrictEqual(expectedColor));
-    });
-
-    it('Should return the color based on its path', () => {
-      const expectedNoTheme = css({ color: colors.text.primary });
-
-      const c = color({ theme, color: 'text.primary' });
-
-      expect(c).toStrictEqual(expectedNoTheme);
-    });
-
-    it('Should return the value if there is no theme match', () => {
-      const expectedNoTheme = css({ color: 'tomato' });
-
-      const c = color({ theme, color: 'tomato' });
-      expect(c).toStrictEqual(expectedNoTheme);
+        const fw = fontWeightAndroid({ theme, fw: 200 });
+        expect(fw).toStrictEqual(expectedNoTheme);
+      });
     });
   });
 });


### PR DESCRIPTION
Changing the `font-weight` in Android using react native is [a known hacky](https://github.com/facebook/react-native/issues/26193). 

It is not just changing it to `300`, `400`, `700`, or even to `bold`, `normal`, etc. 
You need to change the `font-family` to reflect what you want.

So, who needs to know about it? 
Our system knows now.

<table>
<thead>
<tr>
<th>RN Code</th>
<th>Android</th>
</tr>
</thead>
<tbody>
<tr>
<td>

```jsx
<Box
  b="small"
  p="small"
  borderRadius="small"
  borderColor="feedback.success.dark"
  display="flex"
  flexDirection="column"
  alignItems="center"
  elevation="small"
  bgColor="white"
>
  <Box as={Text} fw="bold">
    Making
  </Box>
  <Text>wellbeing</Text>
  <Text>universal</Text>
</Box>
  ```

</td>
<td>

<img src="https://user-images.githubusercontent.com/6536985/132037723-cc667dfc-1976-4b72-b03e-844a1a0b8343.png" alt="Android screenshot showing a Text component with font-weight bold" width="300" />

</td>
</tr>
</tbody>
</table>

PS: sorry for not having the system on Text component yet.