### PR TITLE
fix(Avatar): add required Avatar styling in web version

### DIFF
--- a/packages/yoga/src/Avatar/web/Avatar.jsx
+++ b/packages/yoga/src/Avatar/web/Avatar.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import styled from 'styled-components';
 import { BuildingFilled } from '@gympass/yoga-icons';
 import { string, func, checkPropTypes } from 'prop-types';
 
 import Box from '../../Box';
 import Icon from '../../Icon';
+
+const Image = styled.img`
+  max-width: 100%;
+`;
 
 /**
  * The Avatar component is used to display the image.
@@ -30,7 +35,7 @@ const Avatar = ({
     {...otherProps}
   >
     {src ? (
-      <img src={src} alt={alt} />
+      <Image src={src} alt={alt} />
     ) : (
       <Icon as={icon} width="50%" height="50%" fill={fill} stroke={stroke} />
     )}

--- a/packages/yoga/src/Avatar/web/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/yoga/src/Avatar/web/__snapshots__/Avatar.test.jsx.snap
@@ -102,6 +102,10 @@ exports[`<Avatar /> should match snapshot in circle avatar with src and alt prop
   overflow: hidden;
 }
 
+.c1 {
+  max-width: 100%;
+}
+
 <div>
   <div
     class="c0"
@@ -113,6 +117,7 @@ exports[`<Avatar /> should match snapshot in circle avatar with src and alt prop
   >
     <img
       alt="Gympass brand logo"
+      class="c1"
       src="https://github.com/Gympass.png"
     />
   </div>
@@ -221,6 +226,10 @@ exports[`<Avatar /> should match snapshot in default avatar with src and alt pro
   overflow: hidden;
 }
 
+.c1 {
+  max-width: 100%;
+}
+
 <div>
   <div
     class="c0"
@@ -232,6 +241,7 @@ exports[`<Avatar /> should match snapshot in default avatar with src and alt pro
   >
     <img
       alt="Gympass brand logo"
+      class="c1"
       src="https://github.com/Gympass.png"
     />
   </div>


### PR DESCRIPTION
The added style already exists in Gatsby CSS Reset from the documentation. In a normal use of the library outside of the yoga project, the stylization ceases to exist.

- **Without the max-width the image goes from the avatar's safe area:**

![image](https://user-images.githubusercontent.com/31045534/132895345-b245a701-7416-4f04-9b48-626c8150f6e9.png)

-  **CSS Reset inside Yoga project:**

![image](https://user-images.githubusercontent.com/31045534/132894884-af0a315d-f132-4d51-ac8f-0d49769a8149.png)

- **After modification:**

![image](https://user-images.githubusercontent.com/31045534/132895167-6317a83a-6f8c-406d-99e3-a6ef87cd09fc.png)

