### PR TITLE
Add `padding-line-between-statements` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,17 @@ module.exports = {
     'import/no-extraneous-dependencies': 0,
     'no-plusplus': 0,
     'no-restricted-globals': 0,
+    'padding-line-between-statements': [
+      2,
+      { blankLine: 'always', prev: ['const', 'var', 'let'], next: '*' },
+      {
+        blankLine: 'any',
+        prev: ['const', 'var', 'let'],
+        next: ['const', 'var', 'let'],
+      },
+      { blankLine: 'always', prev: 'directive', next: '*' },
+      { blankLine: 'any', prev: 'directive', next: 'directive' },
+    ],
   },
   globals: {
     window: true,

--- a/packages/doc/gatsby-node.js
+++ b/packages/doc/gatsby-node.js
@@ -3,6 +3,7 @@ const startCase = require('lodash.startcase');
 
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions;
+
   return new Promise((resolve, reject) => {
     resolve(
       graphql(

--- a/packages/doc/src/components/CodeBlock/SnackEmbed/SnackEmbed.jsx
+++ b/packages/doc/src/components/CodeBlock/SnackEmbed/SnackEmbed.jsx
@@ -54,6 +54,7 @@ const SnackEmbed = ({ id, ...props }) => {
   useEffect(() => {
     if (typeof window !== 'undefined' && !window.ExpoSnack) {
       const script = document.createElement('script');
+
       script.addEventListener('load', () => window.ExpoSnack.initialize());
 
       addProperties(

--- a/packages/doc/src/components/CodeBlock/shared/modules/modules.js
+++ b/packages/doc/src/components/CodeBlock/shared/modules/modules.js
@@ -6,6 +6,7 @@ const YogaNativeComponents = {
   GymCard: undefined,
   Result: undefined,
 };
+
 Object.assign(YogaComponents, YogaNativeComponents);
 
 const NativeComponents = {

--- a/packages/doc/src/components/Navigation/tree.js
+++ b/packages/doc/src/components/Navigation/tree.js
@@ -35,6 +35,7 @@ const createTree = items => {
       order,
       collapsed,
     });
+
     allRoutes = merge(routeObj, allRoutes);
   });
 

--- a/packages/doc/src/components/Summary/Summary.jsx
+++ b/packages/doc/src/components/Summary/Summary.jsx
@@ -96,6 +96,7 @@ AnchorList.propTypes = {
 
 const Summary = () => {
   const [anchors, setAnchors] = useState([]);
+
   useEffect(
     () => {
       if (hasWindow) {

--- a/packages/doc/src/components/Tokens/Colors.jsx
+++ b/packages/doc/src/components/Tokens/Colors.jsx
@@ -33,6 +33,7 @@ const Color = styled.div`
 const SubColors = ({ token }) => {
   const valueType = typeof token.value === 'string';
   const values = valueType ? [token.value] : token.value;
+
   return values.map((subcolor, index) => (
     <Color key={subcolor} color={subcolor}>
       <Tag light>{valueType ? token.alias : `${token.alias}[${index}]`}</Tag>

--- a/packages/doc/src/components/Tokens/withToken.jsx
+++ b/packages/doc/src/components/Tokens/withToken.jsx
@@ -9,6 +9,7 @@ const getKeys = (tokensModule, values) => {
     const keys = tokens.filter(([, v]) => v === value);
     const key = keys.length > 1 ? keys[1][0] : keys[0][0];
     const isAlias = key !== index.toString();
+
     return { type: isAlias ? 'alias' : 'position', position: index, key };
   });
 };

--- a/packages/helpers/src/media.js
+++ b/packages/helpers/src/media.js
@@ -31,6 +31,7 @@ const getRange = (width, range) => {
     const msg = `Make sure you've entered the right breakpoints. 
   Your input: ${Array.isArray(width) ? width.join(', ') : width}
   Available breakpoints: ${availableBreakpoints.join(', ')}`;
+
     throw new Error(msg);
   }
 };

--- a/packages/labnative/pages/Switch.jsx
+++ b/packages/labnative/pages/Switch.jsx
@@ -13,6 +13,7 @@ const SwitchWrapper = styled.View`
 
 const SwitchPage = () => {
   const [checked, setChecked] = useState(true);
+
   return (
     <View
       style={{

--- a/packages/system/src/border.test.js
+++ b/packages/system/src/border.test.js
@@ -23,9 +23,11 @@ import {
 } from './border';
 
 const borders = [0, 1, 2];
+
 [borders.zero, borders.small, borders.medium] = borders;
 
 const radii = [0, 4, 8, 9999];
+
 [radii.sharp, radii.semiRounded, radii.rounded, radii.circle] = radii;
 
 const colors = {
@@ -49,16 +51,20 @@ describe('borders', () => {
 
       const zero1 = border({ theme, b: 'zero' });
       const zero2 = border({ theme, border: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const small1 = border({ theme, b: 'small' });
       const small2 = border({ theme, border: 'small' });
+
       expect(small1).toStrictEqual(small2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const smallOptions = [small1, small2];
+
       smallOptions.map(s => expect(s).toStrictEqual(expectedSmallStyle));
     });
 
@@ -66,6 +72,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ border: '10px solid' });
 
       const b = border({ theme, border: '10px solid' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -77,16 +84,20 @@ describe('borders', () => {
 
       const zero1 = borderTop({ theme, bt: 'zero' });
       const zero2 = borderTop({ theme, borderTop: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const small1 = borderTop({ theme, bt: 'small' });
       const small2 = borderTop({ theme, borderTop: 'small' });
+
       expect(small1).toStrictEqual(small2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const smallOptions = [small1, small2];
+
       smallOptions.map(s => expect(s).toStrictEqual(expectedSmallStyle));
     });
 
@@ -94,6 +105,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderTop: '10px solid' });
 
       const b = borderTop({ theme, borderTop: '10px solid' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -107,16 +119,20 @@ describe('borders', () => {
 
       const zero1 = borderRight({ theme, br: 'zero' });
       const zero2 = borderRight({ theme, borderRight: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const small1 = borderRight({ theme, br: 'small' });
       const small2 = borderRight({ theme, borderRight: 'small' });
+
       expect(small1).toStrictEqual(small2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const smallOptions = [small1, small2];
+
       smallOptions.map(s => expect(s).toStrictEqual(expectedSmallStyle));
     });
 
@@ -124,6 +140,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderRight: '10px solid' });
 
       const b = borderRight({ theme, borderRight: '10px solid' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -137,16 +154,20 @@ describe('borders', () => {
 
       const zero1 = borderBottom({ theme, bb: 'zero' });
       const zero2 = borderBottom({ theme, borderBottom: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const small1 = borderBottom({ theme, bb: 'small' });
       const small2 = borderBottom({ theme, borderBottom: 'small' });
+
       expect(small1).toStrictEqual(small2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const smallOptions = [small1, small2];
+
       smallOptions.map(s => expect(s).toStrictEqual(expectedSmallStyle));
     });
 
@@ -154,6 +175,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderBottom: '10px solid' });
 
       const b = borderBottom({ theme, borderBottom: '10px solid' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -167,16 +189,20 @@ describe('borders', () => {
 
       const zero1 = borderLeft({ theme, bl: 'zero' });
       const zero2 = borderLeft({ theme, borderLeft: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const small1 = borderLeft({ theme, bl: 'small' });
       const small2 = borderLeft({ theme, borderLeft: 'small' });
+
       expect(small1).toStrictEqual(small2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const smallOptions = [small1, small2];
+
       smallOptions.map(s => expect(s).toStrictEqual(expectedSmallStyle));
     });
 
@@ -184,6 +210,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderLeft: '10px solid' });
 
       const b = borderLeft({ theme, borderLeft: '10px solid' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -197,16 +224,20 @@ describe('borders', () => {
 
       const vibin1 = borderColor({ theme, bc: 'vibin' });
       const vibin2 = borderColor({ theme, borderColor: 'vibin' });
+
       expect(vibin1).toStrictEqual(vibin2);
 
       const hope1 = borderColor({ theme, bc: 'hope' });
       const hope2 = borderColor({ theme, borderColor: 'hope' });
+
       expect(hope1).toStrictEqual(hope2);
 
       const vibinOptions = [vibin1, vibin2];
+
       vibinOptions.map(z => expect(z).toStrictEqual(vibinStyle));
 
       const hopeOptions = [hope1, hope2];
+
       hopeOptions.map(s => expect(s).toStrictEqual(hopeStyle));
     });
 
@@ -214,6 +245,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderColor: 'red' });
 
       const b = borderColor({ theme, borderColor: 'red' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -227,16 +259,20 @@ describe('borders', () => {
 
       const vibin1 = borderTopColor({ theme, btc: 'vibin' });
       const vibin2 = borderTopColor({ theme, borderTopColor: 'vibin' });
+
       expect(vibin1).toStrictEqual(vibin2);
 
       const hope1 = borderTopColor({ theme, btc: 'hope' });
       const hope2 = borderTopColor({ theme, borderTopColor: 'hope' });
+
       expect(hope1).toStrictEqual(hope2);
 
       const vibinOptions = [vibin1, vibin2];
+
       vibinOptions.map(z => expect(z).toStrictEqual(vibinStyle));
 
       const hopeOptions = [hope1, hope2];
+
       hopeOptions.map(s => expect(s).toStrictEqual(hopeStyle));
     });
 
@@ -244,6 +280,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderTopColor: 'red' });
 
       const b = borderTopColor({ theme, borderTopColor: 'red' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -257,16 +294,20 @@ describe('borders', () => {
 
       const vibin1 = borderRightColor({ theme, brc: 'vibin' });
       const vibin2 = borderRightColor({ theme, borderRightColor: 'vibin' });
+
       expect(vibin1).toStrictEqual(vibin2);
 
       const hope1 = borderRightColor({ theme, brc: 'hope' });
       const hope2 = borderRightColor({ theme, borderRightColor: 'hope' });
+
       expect(hope1).toStrictEqual(hope2);
 
       const vibinOptions = [vibin1, vibin2];
+
       vibinOptions.map(z => expect(z).toStrictEqual(vibinStyle));
 
       const hopeOptions = [hope1, hope2];
+
       hopeOptions.map(s => expect(s).toStrictEqual(hopeStyle));
     });
 
@@ -274,6 +315,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderRightColor: 'red' });
 
       const b = borderRightColor({ theme, borderRightColor: 'red' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -287,16 +329,20 @@ describe('borders', () => {
 
       const vibin1 = borderBottomColor({ theme, bbc: 'vibin' });
       const vibin2 = borderBottomColor({ theme, borderBottomColor: 'vibin' });
+
       expect(vibin1).toStrictEqual(vibin2);
 
       const hope1 = borderBottomColor({ theme, bbc: 'hope' });
       const hope2 = borderBottomColor({ theme, borderBottomColor: 'hope' });
+
       expect(hope1).toStrictEqual(hope2);
 
       const vibinOptions = [vibin1, vibin2];
+
       vibinOptions.map(z => expect(z).toStrictEqual(vibinStyle));
 
       const hopeOptions = [hope1, hope2];
+
       hopeOptions.map(s => expect(s).toStrictEqual(hopeStyle));
     });
 
@@ -304,6 +350,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderBottomColor: 'red' });
 
       const b = borderBottomColor({ theme, borderBottomColor: 'red' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -317,16 +364,20 @@ describe('borders', () => {
 
       const vibin1 = borderLeftColor({ theme, blc: 'vibin' });
       const vibin2 = borderLeftColor({ theme, borderLeftColor: 'vibin' });
+
       expect(vibin1).toStrictEqual(vibin2);
 
       const hope1 = borderLeftColor({ theme, blc: 'hope' });
       const hope2 = borderLeftColor({ theme, borderLeftColor: 'hope' });
+
       expect(hope1).toStrictEqual(hope2);
 
       const vibinOptions = [vibin1, vibin2];
+
       vibinOptions.map(z => expect(z).toStrictEqual(vibinStyle));
 
       const hopeOptions = [hope1, hope2];
+
       hopeOptions.map(s => expect(s).toStrictEqual(hopeStyle));
     });
 
@@ -334,6 +385,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderLeftColor: 'red' });
 
       const b = borderLeftColor({ theme, borderLeftColor: 'red' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -347,16 +399,20 @@ describe('borders', () => {
 
       const zero1 = borderWidth({ theme, bw: 'zero' });
       const zero2 = borderWidth({ theme, borderWidth: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const medium1 = borderWidth({ theme, bw: 'medium' });
       const medium2 = borderWidth({ theme, borderWidth: 'medium' });
+
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(s => expect(s).toStrictEqual(expectedMediumStyle));
     });
 
@@ -364,6 +420,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderWidth: '30%' });
 
       const b = borderWidth({ theme, borderWidth: '30%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -377,16 +434,20 @@ describe('borders', () => {
 
       const zero1 = borderTopWidth({ theme, btw: 'zero' });
       const zero2 = borderTopWidth({ theme, borderTopWidth: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const medium1 = borderTopWidth({ theme, btw: 'medium' });
       const medium2 = borderTopWidth({ theme, borderTopWidth: 'medium' });
+
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(s => expect(s).toStrictEqual(expectedMediumStyle));
     });
 
@@ -394,6 +455,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderTopWidth: '30%' });
 
       const b = borderTopWidth({ theme, borderTopWidth: '30%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -407,16 +469,20 @@ describe('borders', () => {
 
       const zero1 = borderRightWidth({ theme, brw: 'zero' });
       const zero2 = borderRightWidth({ theme, borderRightWidth: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const medium1 = borderRightWidth({ theme, brw: 'medium' });
       const medium2 = borderRightWidth({ theme, borderRightWidth: 'medium' });
+
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(s => expect(s).toStrictEqual(expectedMediumStyle));
     });
 
@@ -424,6 +490,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderRightWidth: '30%' });
 
       const b = borderRightWidth({ theme, borderRightWidth: '30%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -437,16 +504,20 @@ describe('borders', () => {
 
       const zero1 = borderBottomWidth({ theme, bbw: 'zero' });
       const zero2 = borderBottomWidth({ theme, borderBottomWidth: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const medium1 = borderBottomWidth({ theme, bbw: 'medium' });
       const medium2 = borderBottomWidth({ theme, borderBottomWidth: 'medium' });
+
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(s => expect(s).toStrictEqual(expectedMediumStyle));
     });
 
@@ -454,6 +525,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderBottomWidth: '30%' });
 
       const b = borderBottomWidth({ theme, borderBottomWidth: '30%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -467,16 +539,20 @@ describe('borders', () => {
 
       const zero1 = borderLeftWidth({ theme, blw: 'zero' });
       const zero2 = borderLeftWidth({ theme, borderLeftWidth: 'zero' });
+
       expect(zero1).toStrictEqual(zero2);
 
       const medium1 = borderLeftWidth({ theme, blw: 'medium' });
       const medium2 = borderLeftWidth({ theme, borderLeftWidth: 'medium' });
+
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroStyle));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(s => expect(s).toStrictEqual(expectedMediumStyle));
     });
 
@@ -484,6 +560,7 @@ describe('borders', () => {
       const expectedNoTheme = css({ borderLeftWidth: '30%' });
 
       const b = borderLeftWidth({ theme, borderLeftWidth: '30%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -497,16 +574,20 @@ describe('radius', () => {
 
       const sharp1 = borderRadius({ theme, bRadius: 'sharp' });
       const sharp2 = borderRadius({ theme, borderRadius: 'sharp' });
+
       expect(sharp1).toStrictEqual(sharp2);
 
       const rounded1 = borderRadius({ theme, bRadius: 'rounded' });
       const rounded2 = borderRadius({ theme, borderRadius: 'rounded' });
+
       expect(rounded1).toStrictEqual(rounded2);
 
       const sharpOptions = [sharp1, sharp2];
+
       sharpOptions.map(s => expect(s).toStrictEqual(expectedSharpStyle));
 
       const roundedOptions = [rounded1, rounded2];
+
       roundedOptions.map(r => expect(r).toStrictEqual(expectedRoundedStyle));
     });
 
@@ -514,6 +595,7 @@ describe('radius', () => {
       const expectedNoTheme = css({ borderRadius: '50%' });
 
       const b = borderRadius({ theme, borderRadius: '50%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -528,6 +610,7 @@ describe('radius', () => {
         theme,
         borderTopLeftRadius: 'sharp',
       });
+
       expect(sharp1).toStrictEqual(sharp2);
 
       const rounded1 = borderTopLeftRadius({ theme, btlr: 'rounded' });
@@ -535,12 +618,15 @@ describe('radius', () => {
         theme,
         borderTopLeftRadius: 'rounded',
       });
+
       expect(rounded1).toStrictEqual(rounded2);
 
       const sharpOptions = [sharp1, sharp2];
+
       sharpOptions.map(s => expect(s).toStrictEqual(expectedSharpStyle));
 
       const roundedOptions = [rounded1, rounded2];
+
       roundedOptions.map(r => expect(r).toStrictEqual(expectedRoundedStyle));
     });
 
@@ -548,6 +634,7 @@ describe('radius', () => {
       const expectedNoTheme = css({ borderTopLeftRadius: '50%' });
 
       const b = borderTopLeftRadius({ theme, borderTopLeftRadius: '50%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -562,6 +649,7 @@ describe('radius', () => {
         theme,
         borderTopRightRadius: 'sharp',
       });
+
       expect(sharp1).toStrictEqual(sharp2);
 
       const rounded1 = borderTopRightRadius({ theme, btrr: 'rounded' });
@@ -569,12 +657,15 @@ describe('radius', () => {
         theme,
         borderTopRightRadius: 'rounded',
       });
+
       expect(rounded1).toStrictEqual(rounded2);
 
       const sharpOptions = [sharp1, sharp2];
+
       sharpOptions.map(s => expect(s).toStrictEqual(expectedSharpStyle));
 
       const roundedOptions = [rounded1, rounded2];
+
       roundedOptions.map(r => expect(r).toStrictEqual(expectedRoundedStyle));
     });
 
@@ -582,6 +673,7 @@ describe('radius', () => {
       const expectedNoTheme = css({ borderTopRightRadius: '50%' });
 
       const b = borderTopRightRadius({ theme, borderTopRightRadius: '50%' });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -598,6 +690,7 @@ describe('radius', () => {
         theme,
         borderBottomLeftRadius: 'sharp',
       });
+
       expect(sharp1).toStrictEqual(sharp2);
 
       const rounded1 = borderBottomLeftRadius({ theme, bblr: 'rounded' });
@@ -605,12 +698,15 @@ describe('radius', () => {
         theme,
         borderBottomLeftRadius: 'rounded',
       });
+
       expect(rounded1).toStrictEqual(rounded2);
 
       const sharpOptions = [sharp1, sharp2];
+
       sharpOptions.map(s => expect(s).toStrictEqual(expectedSharpStyle));
 
       const roundedOptions = [rounded1, rounded2];
+
       roundedOptions.map(r => expect(r).toStrictEqual(expectedRoundedStyle));
     });
 
@@ -621,6 +717,7 @@ describe('radius', () => {
         theme,
         borderBottomLeftRadius: '50%',
       });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });
@@ -637,6 +734,7 @@ describe('radius', () => {
         theme,
         borderBottomRightRadius: 'sharp',
       });
+
       expect(sharp1).toStrictEqual(sharp2);
 
       const rounded1 = borderBottomRightRadius({ theme, bbrr: 'rounded' });
@@ -644,12 +742,15 @@ describe('radius', () => {
         theme,
         borderBottomRightRadius: 'rounded',
       });
+
       expect(rounded1).toStrictEqual(rounded2);
 
       const sharpOptions = [sharp1, sharp2];
+
       sharpOptions.map(s => expect(s).toStrictEqual(expectedSharpStyle));
 
       const roundedOptions = [rounded1, rounded2];
+
       roundedOptions.map(r => expect(r).toStrictEqual(expectedRoundedStyle));
     });
 
@@ -660,6 +761,7 @@ describe('radius', () => {
         theme,
         borderBottomRightRadius: '50%',
       });
+
       expect(b).toStrictEqual(expectedNoTheme);
     });
   });

--- a/packages/system/src/color.test.js
+++ b/packages/system/src/color.test.js
@@ -30,6 +30,7 @@ describe('backgroundColor', () => {
     expect(bgColor).toStrictEqual(backGroundColor);
 
     const bgOptions = [bg, bgColor, backGroundColor];
+
     bgOptions.map(c => expect(c).toStrictEqual(expectedColor));
   });
 
@@ -48,6 +49,7 @@ describe('backgroundColor', () => {
     const expectedNoTheme = css({ backgroundColor: 'tomato' });
 
     const bg = backgroundColor({ theme, backgroundColor: 'tomato' });
+
     expect(bg).toStrictEqual(expectedNoTheme);
   });
 });

--- a/packages/system/src/elevation.test.js
+++ b/packages/system/src/elevation.test.js
@@ -9,6 +9,7 @@ describe('Web and iOS', () => {
       : 'none';
 
   const elevations = [0, 1, 2].map(shadow);
+
   [elevations.zero, elevations.small, elevations.medium] = elevations;
 
   const theme = {
@@ -37,9 +38,11 @@ describe('Web and iOS', () => {
       expect(small2).toStrictEqual(small3);
 
       const zeroOptions = [zero1, zero2, zero3];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroElevation));
 
       const smallOptions = [small1, small2, small3];
+
       smallOptions.map(s => expect(s).toStrictEqual(expectedSmallElevation));
     });
 
@@ -47,6 +50,7 @@ describe('Web and iOS', () => {
       const expectedNoTheme = css({ boxShadow: '0 2px 2px black' });
 
       const bs = elevation({ theme, boxShadow: '0 2px 2px black' });
+
       expect(bs).toStrictEqual(expectedNoTheme);
     });
   });
@@ -54,6 +58,7 @@ describe('Web and iOS', () => {
 
 describe('Android', () => {
   const elevations = ['0', '1', '2'];
+
   [elevations.zero, elevations.small, elevations.medium] = elevations;
 
   const theme = {
@@ -82,9 +87,11 @@ describe('Android', () => {
       expect(small2).toStrictEqual(small3);
 
       const zeroOptions = [zero1, zero2, zero3];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroElevation));
 
       const smallOptions = [small1, small2, small3];
+
       smallOptions.map(s => expect(s).toStrictEqual(expectedSmallElevation));
     });
 
@@ -92,6 +99,7 @@ describe('Android', () => {
       const expectedNoTheme = css({ elevation: '20' });
 
       const ae = androidElevation({ theme, boxShadow: '20' });
+
       expect(ae).toStrictEqual(expectedNoTheme);
     });
   });

--- a/packages/system/src/layout.test.js
+++ b/packages/system/src/layout.test.js
@@ -10,6 +10,7 @@ import {
 } from './layout';
 
 const spacings = [0, 4, 8, 12];
+
 [spacings.zero, spacings.small, spacings.medium, spacings.large] = spacings;
 
 const theme = {
@@ -29,6 +30,7 @@ describe('layout', () => {
       expect(b).toStrictEqual(block);
 
       const bgOptions = [b, block];
+
       bgOptions.map(c => expect(c).toStrictEqual(expectedDisplay));
     });
   });
@@ -56,6 +58,7 @@ describe('layout', () => {
         const expectedPosition = css({ position: 'absolute' });
 
         const p = position({ position: 'absolute' });
+
         expect(p).toStrictEqual(expectedPosition);
       });
     });
@@ -83,6 +86,7 @@ describe('layout', () => {
         });
 
         const t = top({ theme, top: '50%' });
+
         expect(t).toStrictEqual(expectedNoTheme);
       });
     });
@@ -110,6 +114,7 @@ describe('layout', () => {
         });
 
         const r = right({ theme, right: '50%' });
+
         expect(r).toStrictEqual(expectedNoTheme);
       });
     });
@@ -137,6 +142,7 @@ describe('layout', () => {
         });
 
         const b = bottom({ theme, bottom: '50%' });
+
         expect(b).toStrictEqual(expectedNoTheme);
       });
     });
@@ -164,6 +170,7 @@ describe('layout', () => {
         });
 
         const l = left({ theme, left: '50%' });
+
         expect(l).toStrictEqual(expectedNoTheme);
       });
     });

--- a/packages/system/src/spacing.test.js
+++ b/packages/system/src/spacing.test.js
@@ -22,6 +22,7 @@ import {
 } from './spacing';
 
 const spacings = [0, 4, 8, 12];
+
 [spacings.zero, spacings.small, spacings.medium, spacings.large] = spacings;
 
 const theme = {
@@ -53,9 +54,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(s => expect(s).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -66,6 +69,7 @@ describe('spacings', () => {
       });
 
       const s = spacing({ theme, p: 20, m: 20 });
+
       expect(s).toStrictEqual(expectedNoTheme);
     });
   });
@@ -90,9 +94,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -102,6 +108,7 @@ describe('spacings', () => {
       });
 
       const m = margin({ theme, m: 20 });
+
       expect(m).toStrictEqual(expectedNoTheme);
     });
   });
@@ -126,9 +133,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -138,6 +147,7 @@ describe('spacings', () => {
       });
 
       const mt = marginTop({ theme, mt: 20 });
+
       expect(mt).toStrictEqual(expectedNoTheme);
     });
   });
@@ -162,9 +172,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -174,6 +186,7 @@ describe('spacings', () => {
       });
 
       const mr = marginRight({ theme, mr: 20 });
+
       expect(mr).toStrictEqual(expectedNoTheme);
     });
   });
@@ -198,9 +211,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -210,6 +225,7 @@ describe('spacings', () => {
       });
 
       const mb = marginBottom({ theme, mb: 20 });
+
       expect(mb).toStrictEqual(expectedNoTheme);
     });
   });
@@ -234,9 +250,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -246,6 +264,7 @@ describe('spacings', () => {
       });
 
       const ml = marginLeft({ theme, ml: 20 });
+
       expect(ml).toStrictEqual(expectedNoTheme);
     });
   });
@@ -276,9 +295,11 @@ describe('spacings', () => {
       expect(medium2).toStrictEqual(medium3);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -289,6 +310,7 @@ describe('spacings', () => {
       });
 
       const mh = marginHorizontal({ theme, mh: 20 });
+
       expect(mh).toStrictEqual(expectedNoTheme);
     });
   });
@@ -319,9 +341,11 @@ describe('spacings', () => {
       expect(medium2).toStrictEqual(medium3);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -332,6 +356,7 @@ describe('spacings', () => {
       });
 
       const mv = marginVertical({ theme, mv: 20 });
+
       expect(mv).toStrictEqual(expectedNoTheme);
     });
   });
@@ -375,9 +400,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -387,6 +414,7 @@ describe('spacings', () => {
       });
 
       const p = padding({ theme, p: 20 });
+
       expect(p).toStrictEqual(expectedNoTheme);
     });
   });
@@ -411,9 +439,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -423,6 +453,7 @@ describe('spacings', () => {
       });
 
       const pt = paddingTop({ theme, pt: 20 });
+
       expect(pt).toStrictEqual(expectedNoTheme);
     });
   });
@@ -447,9 +478,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -459,6 +492,7 @@ describe('spacings', () => {
       });
 
       const pr = paddingRight({ theme, pr: 20 });
+
       expect(pr).toStrictEqual(expectedNoTheme);
     });
   });
@@ -483,9 +517,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -495,6 +531,7 @@ describe('spacings', () => {
       });
 
       const pb = paddingBottom({ theme, pb: 20 });
+
       expect(pb).toStrictEqual(expectedNoTheme);
     });
   });
@@ -519,9 +556,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -531,6 +570,7 @@ describe('spacings', () => {
       });
 
       const pl = paddingLeft({ theme, pl: 20 });
+
       expect(pl).toStrictEqual(expectedNoTheme);
     });
   });
@@ -561,9 +601,11 @@ describe('spacings', () => {
       expect(medium2).toStrictEqual(medium3);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -574,6 +616,7 @@ describe('spacings', () => {
       });
 
       const ph = paddingHorizontal({ theme, ph: 20 });
+
       expect(ph).toStrictEqual(expectedNoTheme);
     });
   });
@@ -604,9 +647,11 @@ describe('spacings', () => {
       expect(medium2).toStrictEqual(medium3);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -617,6 +662,7 @@ describe('spacings', () => {
       });
 
       const pv = paddingVertical({ theme, pv: 20 });
+
       expect(pv).toStrictEqual(expectedNoTheme);
     });
   });
@@ -660,9 +706,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -672,6 +720,7 @@ describe('spacings', () => {
       });
 
       const pv = width({ theme, w: 20 });
+
       expect(pv).toStrictEqual(expectedNoTheme);
     });
   });
@@ -696,9 +745,11 @@ describe('spacings', () => {
       expect(medium1).toStrictEqual(medium2);
 
       const zeroOptions = [zero1, zero2];
+
       zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
 
       const mediumOptions = [medium1, medium2];
+
       mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
     });
 
@@ -708,6 +759,7 @@ describe('spacings', () => {
       });
 
       const pv = height({ theme, h: 20 });
+
       expect(pv).toStrictEqual(expectedNoTheme);
     });
   });

--- a/packages/system/src/typography.test.js
+++ b/packages/system/src/typography.test.js
@@ -10,12 +10,15 @@ import {
 import { fontWeight as fontWeightAndroid } from './fontWeight.android';
 
 const fontSizes = [10, 20, 40];
+
 [fontSizes.small, fontSizes.medium, fontSizes.large] = fontSizes;
 
 const lineHeights = [12, 16, 20];
+
 [lineHeights.small, lineHeights.medium, lineHeights.large] = lineHeights;
 
 const fontWeights = [300, 500, 900];
+
 [fontWeights.light, fontWeights.medium, fontWeights.bold] = fontWeights;
 
 const baseFont = {
@@ -66,6 +69,7 @@ describe('Web and iOS', () => {
         const expectedNoTheme = css({ color: 'tomato' });
 
         const font = typography({ theme, color: 'tomato' });
+
         expect(font).toStrictEqual(expectedNoTheme);
       });
     });
@@ -80,6 +84,7 @@ describe('Web and iOS', () => {
         expect(fs1).toStrictEqual(fs2);
 
         const fontSizesOptions = [fs1, fs2];
+
         fontSizesOptions.map(c => expect(c).toStrictEqual(expectedFontSize));
       });
 
@@ -87,6 +92,7 @@ describe('Web and iOS', () => {
         const expectedNoTheme = css({ fontSize: 72 });
 
         const fs = fontSize({ theme, fs: 72 });
+
         expect(fs).toStrictEqual(expectedNoTheme);
       });
     });
@@ -101,6 +107,7 @@ describe('Web and iOS', () => {
         expect(fw1).toStrictEqual(fw2);
 
         const fontWeightsOptions = [fw1, fw2];
+
         fontWeightsOptions.map(c =>
           expect(c).toStrictEqual(expectedFontWeight),
         );
@@ -110,6 +117,7 @@ describe('Web and iOS', () => {
         const expectedNoTheme = css({ fontWeight: 600 });
 
         const fw = fontWeight({ theme, fw: 600 });
+
         expect(fw).toStrictEqual(expectedNoTheme);
       });
     });
@@ -126,6 +134,7 @@ describe('Web and iOS', () => {
         expect(lh1).toStrictEqual(lh2);
 
         const lineHeightsOptions = [lh1, lh2];
+
         lineHeightsOptions.map(c =>
           expect(c).toStrictEqual(expectedLineHeight),
         );
@@ -135,6 +144,7 @@ describe('Web and iOS', () => {
         const expectedNoTheme = css({ lineHeight: '5px' });
 
         const lh = lineHeight({ theme, lh: 5 });
+
         expect(lh).toStrictEqual(expectedNoTheme);
       });
     });
@@ -149,6 +159,7 @@ describe('Web and iOS', () => {
         expect(c1).toStrictEqual(c2);
 
         const colorOptions = [c1, c2];
+
         colorOptions.map(c => expect(c).toStrictEqual(expectedColor));
       });
 
@@ -164,6 +175,7 @@ describe('Web and iOS', () => {
         const expectedNoTheme = css({ color: 'tomato' });
 
         const c = color({ theme, color: 'tomato' });
+
         expect(c).toStrictEqual(expectedNoTheme);
       });
     });
@@ -194,6 +206,7 @@ describe('Android', () => {
         expect(fw1).toStrictEqual(fw2);
 
         const fontWeightsOptions = [fw1, fw2];
+
         fontWeightsOptions.map(c =>
           expect(c).toStrictEqual(expectedFontFamily),
         );
@@ -205,6 +218,7 @@ describe('Android', () => {
         });
 
         const fw = fontWeightAndroid({ theme, fw: 200 });
+
         expect(fw).toStrictEqual(expectedNoTheme);
       });
     });

--- a/packages/tokens/src/global/borders.js
+++ b/packages/tokens/src/global/borders.js
@@ -20,6 +20,7 @@
  * @default
  */
 const border = [0, 1, 2];
+
 [border.zero, border.small, border.medium] = border;
 
 export default border;

--- a/packages/tokens/src/global/fonts.js
+++ b/packages/tokens/src/global/fonts.js
@@ -25,6 +25,7 @@ const fonts = [
     weight: [...weights, ...weights.map(weight => `${weight}i`)],
   },
 ];
+
 [fonts.rubik] = fonts;
 
 export default fonts;

--- a/packages/tokens/src/global/radii.js
+++ b/packages/tokens/src/global/radii.js
@@ -22,6 +22,7 @@
  * @default
  */
 const radii = [0, 4, 8, 16, 9999];
+
 [radii.sharp, radii.xsmall, radii.small, radii.regular, radii.circle] = radii;
 
 export default radii;

--- a/packages/tokens/src/global/spacing.js
+++ b/packages/tokens/src/global/spacing.js
@@ -29,6 +29,7 @@
  * @default
  */
 const spacing = [0, 4, 8, 12, 16, 20, 24, 32, 40, 56, 72, 80];
+
 [
   spacing.zero,
   spacing.xxxsmall,

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -160,6 +160,7 @@ const AutoComplete = ({
       selectedItem={userValue}
       onStateChange={changes => {
         const { selectedItem, inputValue } = changes;
+
         if (selectedItem) {
           setUserValue(selectedItem);
           onSelect(selectedItem);

--- a/packages/yoga/src/Button/native/Button.test.jsx
+++ b/packages/yoga/src/Button/native/Button.test.jsx
@@ -15,6 +15,7 @@ describe('<Button />', () => {
               <Button />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -24,6 +25,7 @@ describe('<Button />', () => {
               <Button.Text />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -33,6 +35,7 @@ describe('<Button />', () => {
               <Button.Link />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -42,6 +45,7 @@ describe('<Button />', () => {
               <Button icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -51,6 +55,7 @@ describe('<Button />', () => {
               <Button.Text icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -62,6 +67,7 @@ describe('<Button />', () => {
               <Button inverted />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -71,6 +77,7 @@ describe('<Button />', () => {
               <Button.Text inverted />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -80,6 +87,7 @@ describe('<Button />', () => {
               <Button inverted icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -89,6 +97,7 @@ describe('<Button />', () => {
               <Button.Text inverted icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -100,6 +109,7 @@ describe('<Button />', () => {
               <Button small />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -109,6 +119,7 @@ describe('<Button />', () => {
               <Button.Text small />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -118,6 +129,7 @@ describe('<Button />', () => {
               <Button small icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -127,6 +139,7 @@ describe('<Button />', () => {
               <Button.Text small icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -138,6 +151,7 @@ describe('<Button />', () => {
               <Button full />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -147,6 +161,7 @@ describe('<Button />', () => {
               <Button.Text full />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -156,6 +171,7 @@ describe('<Button />', () => {
               <Button full icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -165,6 +181,7 @@ describe('<Button />', () => {
               <Button.Text full icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -178,6 +195,7 @@ describe('<Button />', () => {
               <Button secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -187,6 +205,7 @@ describe('<Button />', () => {
               <Button.Text secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -196,6 +215,7 @@ describe('<Button />', () => {
               <Button.Link secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -205,6 +225,7 @@ describe('<Button />', () => {
               <Button icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -214,6 +235,7 @@ describe('<Button />', () => {
               <Button.Text icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -225,6 +247,7 @@ describe('<Button />', () => {
               <Button inverted secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -234,6 +257,7 @@ describe('<Button />', () => {
               <Button.Text inverted secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -243,6 +267,7 @@ describe('<Button />', () => {
               <Button inverted icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -252,6 +277,7 @@ describe('<Button />', () => {
               <Button.Text inverted icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -263,6 +289,7 @@ describe('<Button />', () => {
               <Button small secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -272,6 +299,7 @@ describe('<Button />', () => {
               <Button.Text small secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -281,6 +309,7 @@ describe('<Button />', () => {
               <Button small icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -290,6 +319,7 @@ describe('<Button />', () => {
               <Button.Text small icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -301,6 +331,7 @@ describe('<Button />', () => {
               <Button full secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -310,6 +341,7 @@ describe('<Button />', () => {
               <Button.Text full secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -319,6 +351,7 @@ describe('<Button />', () => {
               <Button full icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -328,6 +361,7 @@ describe('<Button />', () => {
               <Button.Text full icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });
@@ -341,6 +375,7 @@ describe('<Button />', () => {
               <Button disabled />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -350,6 +385,7 @@ describe('<Button />', () => {
               <Button.Text disabled />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -359,6 +395,7 @@ describe('<Button />', () => {
               <Button.Link disabled />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -368,6 +405,7 @@ describe('<Button />', () => {
               <Button disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
 
@@ -377,6 +415,7 @@ describe('<Button />', () => {
               <Button.Text disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(toJSON(container)).toMatchSnapshot();
         });
       });

--- a/packages/yoga/src/Button/web/Button.test.jsx
+++ b/packages/yoga/src/Button/web/Button.test.jsx
@@ -15,6 +15,7 @@ describe('<Button />', () => {
               <Button />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -24,6 +25,7 @@ describe('<Button />', () => {
               <Button icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -33,6 +35,7 @@ describe('<Button />', () => {
               <Button.Outline />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -42,6 +45,7 @@ describe('<Button />', () => {
               <Button.Outline icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -51,6 +55,7 @@ describe('<Button />', () => {
               <Button.Text />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -60,6 +65,7 @@ describe('<Button />', () => {
               <Button.Text icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -69,6 +75,7 @@ describe('<Button />', () => {
               <Button.Link />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -80,6 +87,7 @@ describe('<Button />', () => {
               <Button inverted />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -89,6 +97,7 @@ describe('<Button />', () => {
               <Button inverted icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -98,6 +107,7 @@ describe('<Button />', () => {
               <Button.Outline inverted />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -107,6 +117,7 @@ describe('<Button />', () => {
               <Button.Outline inverted icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -116,6 +127,7 @@ describe('<Button />', () => {
               <Button.Text inverted />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -125,6 +137,7 @@ describe('<Button />', () => {
               <Button.Text inverted icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -136,6 +149,7 @@ describe('<Button />', () => {
               <Button small />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -145,6 +159,7 @@ describe('<Button />', () => {
               <Button.Outline small />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -154,6 +169,7 @@ describe('<Button />', () => {
               <Button.Text small />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -163,6 +179,7 @@ describe('<Button />', () => {
               <Button small icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -172,6 +189,7 @@ describe('<Button />', () => {
               <Button.Outline icon={Booking} small />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -181,6 +199,7 @@ describe('<Button />', () => {
               <Button.Text icon={Booking} small />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -192,6 +211,7 @@ describe('<Button />', () => {
               <Button full />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -201,6 +221,7 @@ describe('<Button />', () => {
               <Button.Outline full />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -210,6 +231,7 @@ describe('<Button />', () => {
               <Button.Text full />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -219,6 +241,7 @@ describe('<Button />', () => {
               <Button full icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -228,6 +251,7 @@ describe('<Button />', () => {
               <Button.Outline full icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -237,6 +261,7 @@ describe('<Button />', () => {
               <Button.Text full icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -248,6 +273,7 @@ describe('<Button />', () => {
               <Button disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -257,6 +283,7 @@ describe('<Button />', () => {
               <Button.Outline disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -266,6 +293,7 @@ describe('<Button />', () => {
               <Button.Text disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -275,6 +303,7 @@ describe('<Button />', () => {
               <Button.Link disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -284,6 +313,7 @@ describe('<Button />', () => {
               <Button disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -293,6 +323,7 @@ describe('<Button />', () => {
               <Button.Outline disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -302,6 +333,7 @@ describe('<Button />', () => {
               <Button.Text disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -315,6 +347,7 @@ describe('<Button />', () => {
               <Button secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -324,6 +357,7 @@ describe('<Button />', () => {
               <Button secondary icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -333,6 +367,7 @@ describe('<Button />', () => {
               <Button.Outline secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -342,6 +377,7 @@ describe('<Button />', () => {
               <Button.Outline icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -351,6 +387,7 @@ describe('<Button />', () => {
               <Button.Text secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -360,6 +397,7 @@ describe('<Button />', () => {
               <Button.Text secondary icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -369,6 +407,7 @@ describe('<Button />', () => {
               <Button.Link secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -380,6 +419,7 @@ describe('<Button />', () => {
               <Button inverted secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -389,6 +429,7 @@ describe('<Button />', () => {
               <Button inverted icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -398,6 +439,7 @@ describe('<Button />', () => {
               <Button.Outline inverted secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -407,6 +449,7 @@ describe('<Button />', () => {
               <Button.Outline inverted icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -416,6 +459,7 @@ describe('<Button />', () => {
               <Button.Text inverted secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -425,6 +469,7 @@ describe('<Button />', () => {
               <Button.Text inverted icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -436,6 +481,7 @@ describe('<Button />', () => {
               <Button small secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -445,6 +491,7 @@ describe('<Button />', () => {
               <Button.Outline small secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -454,6 +501,7 @@ describe('<Button />', () => {
               <Button.Text small secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -463,6 +511,7 @@ describe('<Button />', () => {
               <Button small icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -472,6 +521,7 @@ describe('<Button />', () => {
               <Button.Outline icon={Booking} small secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -481,6 +531,7 @@ describe('<Button />', () => {
               <Button.Text icon={Booking} small secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -492,6 +543,7 @@ describe('<Button />', () => {
               <Button full secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -501,6 +553,7 @@ describe('<Button />', () => {
               <Button.Outline full secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -510,6 +563,7 @@ describe('<Button />', () => {
               <Button.Text full secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -519,6 +573,7 @@ describe('<Button />', () => {
               <Button full icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -528,6 +583,7 @@ describe('<Button />', () => {
               <Button.Outline full icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -537,6 +593,7 @@ describe('<Button />', () => {
               <Button.Text full icon={Booking} secondary />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });
@@ -550,6 +607,7 @@ describe('<Button />', () => {
               <Button disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -559,6 +617,7 @@ describe('<Button />', () => {
               <Button.Outline disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -568,6 +627,7 @@ describe('<Button />', () => {
               <Button.Text disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -577,6 +637,7 @@ describe('<Button />', () => {
               <Button.Link disabled />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -586,6 +647,7 @@ describe('<Button />', () => {
               <Button disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -595,6 +657,7 @@ describe('<Button />', () => {
               <Button.Outline disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
 
@@ -604,6 +667,7 @@ describe('<Button />', () => {
               <Button.Text disabled icon={Booking} />
             </ThemeProvider>,
           );
+
           expect(container).toMatchSnapshot();
         });
       });

--- a/packages/yoga/src/Card/native/Card/Card.test.jsx
+++ b/packages/yoga/src/Card/native/Card/Card.test.jsx
@@ -22,6 +22,7 @@ describe('<Card />', () => {
           </Card>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Card/native/EventCard/EventCard.test.jsx
+++ b/packages/yoga/src/Card/native/EventCard/EventCard.test.jsx
@@ -24,6 +24,7 @@ describe('<EventCard />', () => {
           <EventCard {...defaultProps} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
     it('should match snapshot of small EventCard with event indicator disabled', () => {
@@ -32,6 +33,7 @@ describe('<EventCard />', () => {
           <EventCard {...defaultProps} event={false} small onPress={() => {}} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
     it('should match snapshot of small EventCard with event indicator enabled', () => {
@@ -40,6 +42,7 @@ describe('<EventCard />', () => {
           <EventCard {...defaultProps} small onPress={() => {}} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
     it('should match snapshot of small EventCard active', () => {
@@ -48,6 +51,7 @@ describe('<EventCard />', () => {
           <EventCard {...defaultProps} small active onPress={() => {}} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
     it('should match snapshot of small EventCard with day of week and without indicator', () => {
@@ -56,6 +60,7 @@ describe('<EventCard />', () => {
           <EventCard {...defaultProps} small />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Card/native/GymCard/CheckIn/CheckIn.test.jsx
+++ b/packages/yoga/src/Card/native/GymCard/CheckIn/CheckIn.test.jsx
@@ -23,6 +23,7 @@ describe('<GymCard.CheckIn />', () => {
           />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -41,6 +42,7 @@ describe('<GymCard.CheckIn />', () => {
           />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Card/native/PlanCard/PlanCard.test.jsx
+++ b/packages/yoga/src/Card/native/PlanCard/PlanCard.test.jsx
@@ -52,6 +52,7 @@ describe('<PlanCard />', () => {
   describe('Events', () => {
     it('should call onPress when ListItem has a button', () => {
       const { getByText } = renderPlan();
+
       fireEvent.press(getByText('button'));
 
       expect(buttonOnPressMock).toHaveBeenCalled();
@@ -61,6 +62,7 @@ describe('<PlanCard />', () => {
   describe('Snapshots', () => {
     it('should match snapshot with default PlanCard', () => {
       const { container: planCard } = renderPlan();
+
       expect(planCard).toMatchSnapshot();
     });
 

--- a/packages/yoga/src/Card/web/Card/Card.test.jsx
+++ b/packages/yoga/src/Card/web/Card/Card.test.jsx
@@ -17,6 +17,7 @@ describe('<Card />', () => {
           </Card>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Card/web/EventCard/EventCard.test.jsx
+++ b/packages/yoga/src/Card/web/EventCard/EventCard.test.jsx
@@ -23,6 +23,7 @@ describe('<Card />', () => {
           <EventCard event={event} date={date} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Card/web/PlanCard/PlanCard.test.jsx
+++ b/packages/yoga/src/Card/web/PlanCard/PlanCard.test.jsx
@@ -49,9 +49,11 @@ describe('<PlanCard />', () => {
         </PlanCard>
       </ThemeProvider>,
     );
+
   describe('Events', () => {
     it('should call onClick when ListItem has a button', () => {
       const { getByText } = renderPlan();
+
       fireEvent.click(getByText('button'));
 
       expect(buttonOnClickMock).toHaveBeenCalled();
@@ -61,6 +63,7 @@ describe('<PlanCard />', () => {
   describe('Snapshots', () => {
     it('should match snapshot with default PlanCard', () => {
       const { container: planCard } = renderPlan();
+
       expect(planCard).toMatchSnapshot();
     });
 

--- a/packages/yoga/src/Checkbox/native/Checkbox.jsx
+++ b/packages/yoga/src/Checkbox/native/Checkbox.jsx
@@ -176,6 +176,7 @@ const Checkbox = ({
   ...rest
 }) => {
   const [pressed, setPressed] = useState(false);
+
   return (
     <View>
       <TouchableWithoutFeedback

--- a/packages/yoga/src/Checkbox/native/Checkbox.test.jsx
+++ b/packages/yoga/src/Checkbox/native/Checkbox.test.jsx
@@ -17,6 +17,7 @@ describe('<Checkbox />', () => {
           <Checkbox />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -26,6 +27,7 @@ describe('<Checkbox />', () => {
           <Checkbox />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -35,6 +37,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -44,6 +47,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} disabled />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -53,6 +57,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} checked />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -62,6 +67,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} disabled checked />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -71,6 +77,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} error="Error text" />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -80,6 +87,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} error="Error text" checked />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -89,6 +97,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} inverted />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -98,6 +107,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} inverted checked />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -107,6 +117,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} inverted checked disabled />
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
   });
@@ -119,6 +130,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} onPress={onChangeMock} testID="checkbox" />
         </ThemeProvider>,
       );
+
       fireEvent.press(getByTestId('checkbox'));
       expect(onChangeMock).toHaveBeenCalled();
     });

--- a/packages/yoga/src/Checkbox/native/Switch.jsx
+++ b/packages/yoga/src/Checkbox/native/Switch.jsx
@@ -118,6 +118,7 @@ const CheckboxSwitch = ({
         duration: 100,
         useNativeDriver: false,
       };
+
       Animated.timing(position, animValue).start();
     };
 

--- a/packages/yoga/src/Checkbox/native/Switch.test.jsx
+++ b/packages/yoga/src/Checkbox/native/Switch.test.jsx
@@ -15,6 +15,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -24,6 +25,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch disabled />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -33,6 +35,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch checked />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -42,6 +45,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch disabled checked />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 

--- a/packages/yoga/src/Checkbox/web/Checkbox.test.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.test.jsx
@@ -28,6 +28,7 @@ describe('<Checkbox />', () => {
           <Checkbox />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -37,6 +38,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -46,6 +48,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} disabled />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -55,6 +58,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} checked />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -64,6 +68,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} disabled checked />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -73,6 +78,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} error="Error msg" />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -82,6 +88,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} error="Error msg" checked />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -91,6 +98,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} inverted />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -100,6 +108,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} inverted checked />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -109,6 +118,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} inverted checked disabled />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });
@@ -121,6 +131,7 @@ describe('<Checkbox />', () => {
           <Checkbox {...data} onChange={onChangeMock} />
         </ThemeProvider>,
       );
+
       fireEvent.click(getByRole('checkbox', { hidden: true }));
       expect(onChangeMock).toHaveBeenCalled();
     });

--- a/packages/yoga/src/Checkbox/web/Switch.test.jsx
+++ b/packages/yoga/src/Checkbox/web/Switch.test.jsx
@@ -13,6 +13,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -22,6 +23,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch disabled />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -31,6 +33,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch checked />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -40,6 +43,7 @@ describe('<Checkbox />', () => {
             <Checkbox.Switch disabled checked />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 

--- a/packages/yoga/src/Dropdown/native/Backdrop.test.jsx
+++ b/packages/yoga/src/Dropdown/native/Backdrop.test.jsx
@@ -13,6 +13,7 @@ describe('<Backdrop />', () => {
           <Backdrop title="Find an Activity">Some Content</Backdrop>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -24,6 +25,7 @@ describe('<Backdrop />', () => {
           </Backdrop>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Dropdown/native/Dropdown.test.jsx
+++ b/packages/yoga/src/Dropdown/native/Dropdown.test.jsx
@@ -24,6 +24,7 @@ describe('<Dropdown />', () => {
           <Dropdown {...dropdownProps} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -33,6 +34,7 @@ describe('<Dropdown />', () => {
           <Dropdown disabled {...dropdownProps} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -42,6 +44,7 @@ describe('<Dropdown />', () => {
           <Dropdown full {...dropdownProps} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -52,6 +55,7 @@ describe('<Dropdown />', () => {
         selected: true,
       };
       const props = dropdownProps;
+
       props.options.push(selectedOption);
 
       const { container } = render(
@@ -59,6 +63,7 @@ describe('<Dropdown />', () => {
           <Dropdown disabled {...props} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 

--- a/packages/yoga/src/Dropdown/native/Options.ios.jsx
+++ b/packages/yoga/src/Dropdown/native/Options.ios.jsx
@@ -40,6 +40,7 @@ const Options = ({
   },
 }) => {
   const [selected, setSelected] = useState(selectedOption);
+
   return (
     <>
       <PickerStyled

--- a/packages/yoga/src/Dropdown/web/Dropdown.test.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.test.jsx
@@ -22,6 +22,7 @@ describe('<Dropdown />', () => {
         <Dropdown {...dropdownProps} />
       </ThemeProvider>,
     );
+
     expect(container).toMatchSnapshot();
   });
 
@@ -31,6 +32,7 @@ describe('<Dropdown />', () => {
         <Dropdown {...dropdownProps} disabled />
       </ThemeProvider>,
     );
+
     expect(container).toMatchSnapshot();
   });
 
@@ -40,6 +42,7 @@ describe('<Dropdown />', () => {
         <Dropdown {...dropdownProps} full />
       </ThemeProvider>,
     );
+
     expect(container).toMatchSnapshot();
   });
 
@@ -50,6 +53,7 @@ describe('<Dropdown />', () => {
       selected: true,
     };
     const props = dropdownProps;
+
     props.options.push(selectedOption);
 
     const { container } = render(
@@ -57,6 +61,7 @@ describe('<Dropdown />', () => {
         <Dropdown {...props} disabled />
       </ThemeProvider>,
     );
+
     expect(container).toMatchSnapshot();
   });
 

--- a/packages/yoga/src/Grid/web/Col.test.jsx
+++ b/packages/yoga/src/Grid/web/Col.test.jsx
@@ -11,6 +11,7 @@ describe('<Col />', () => {
           <Col />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -20,6 +21,7 @@ describe('<Col />', () => {
           <Col xxs={6} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -29,6 +31,7 @@ describe('<Col />', () => {
           <Col md={6} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -38,6 +41,7 @@ describe('<Col />', () => {
           <Col md-start={3} md={6} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 

--- a/packages/yoga/src/Grid/web/Container.test.jsx
+++ b/packages/yoga/src/Grid/web/Container.test.jsx
@@ -11,6 +11,7 @@ describe('<Container />', () => {
           <Container />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Grid/web/Hide.test.jsx
+++ b/packages/yoga/src/Grid/web/Hide.test.jsx
@@ -13,6 +13,7 @@ describe('<Hide />', () => {
           </Hide>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -24,6 +25,7 @@ describe('<Hide />', () => {
           </Hide>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Grid/web/Row.test.jsx
+++ b/packages/yoga/src/Grid/web/Row.test.jsx
@@ -11,6 +11,7 @@ describe('<Row />', () => {
           <Row />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Input/native/Input.jsx
+++ b/packages/yoga/src/Input/native/Input.jsx
@@ -229,6 +229,7 @@ const Input = ({
   const { height = input.height, ...styles } = Array.isArray(style)
     ? Object.assign({}, ...style)
     : style;
+
   return (
     <Wrapper full={full} style={styles}>
       <Field

--- a/packages/yoga/src/Input/web/Input.test.jsx
+++ b/packages/yoga/src/Input/web/Input.test.jsx
@@ -79,6 +79,7 @@ describe('<Input />', () => {
   describe('Events', () => {
     it('should call onChange', () => {
       const onChangeMock = jest.fn();
+
       render(
         <ThemeProvider>
           <Input label="Input" onChange={onChangeMock} data-testid="input" />
@@ -94,6 +95,7 @@ describe('<Input />', () => {
 
     it('should call onFocus', () => {
       const onFocusMock = jest.fn();
+
       render(
         <ThemeProvider>
           <Input label="Input" data-testid="input" onFocus={onFocusMock} />

--- a/packages/yoga/src/List/native/List.test.jsx
+++ b/packages/yoga/src/List/native/List.test.jsx
@@ -33,6 +33,7 @@ describe('<List />', () => {
             />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -49,6 +50,7 @@ describe('<List />', () => {
             />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -65,6 +67,7 @@ describe('<List />', () => {
             />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -82,6 +85,7 @@ describe('<List />', () => {
             />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -101,6 +105,7 @@ describe('<List />', () => {
         );
 
         const selectableItem = getByText(a.key);
+
         fireEvent.press(selectableItem);
         expect(a.onPress).toHaveBeenCalled();
       });

--- a/packages/yoga/src/List/web/List.test.jsx
+++ b/packages/yoga/src/List/web/List.test.jsx
@@ -15,6 +15,7 @@ describe('<List />', () => {
             </List>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -32,6 +33,7 @@ describe('<List />', () => {
             </List>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -49,6 +51,7 @@ describe('<List />', () => {
             </List>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -62,6 +65,7 @@ describe('<List />', () => {
             </List>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -79,6 +83,7 @@ describe('<List />', () => {
             </List>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -96,6 +101,7 @@ describe('<List />', () => {
             </List>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -109,6 +115,7 @@ describe('<List />', () => {
             </List>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
     });

--- a/packages/yoga/src/RadioGroup/native/Button/RadioButton.test.jsx
+++ b/packages/yoga/src/RadioGroup/native/Button/RadioButton.test.jsx
@@ -14,6 +14,7 @@ describe('<RadioGroup />', () => {
             <RadioGroup.Button>Radio 1</RadioGroup.Button>
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -25,6 +26,7 @@ describe('<RadioGroup />', () => {
             </ThemeProvider>
           </RadioGroupContext.Provider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
     });

--- a/packages/yoga/src/RadioGroup/native/Radio/Radio.test.jsx
+++ b/packages/yoga/src/RadioGroup/native/Radio/Radio.test.jsx
@@ -14,6 +14,7 @@ describe('<RadioGroup />', () => {
             <RadioGroup.Radio />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -23,6 +24,7 @@ describe('<RadioGroup />', () => {
             <RadioGroup.Radio disabled />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -32,6 +34,7 @@ describe('<RadioGroup />', () => {
             <RadioGroup.Radio />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 

--- a/packages/yoga/src/RadioGroup/native/RadioGroup.test.jsx
+++ b/packages/yoga/src/RadioGroup/native/RadioGroup.test.jsx
@@ -16,6 +16,7 @@ describe('<RadioGroup />', () => {
           </RadioGroup>
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
       expect(getAllByText(/^Option/)).toHaveLength(3);
     });
@@ -30,6 +31,7 @@ describe('<RadioGroup />', () => {
           </RadioGroup>
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -43,6 +45,7 @@ describe('<RadioGroup />', () => {
           </RadioGroup>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
       expect(getByText('Option 2').props.checked).toBe(true);
     });

--- a/packages/yoga/src/RadioGroup/web/Button/RadioButton.test.jsx
+++ b/packages/yoga/src/RadioGroup/web/Button/RadioButton.test.jsx
@@ -26,6 +26,7 @@ describe('<RadioGroup />', () => {
             <RadioGroup.Button>Radio 1</RadioGroup.Button>
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -37,6 +38,7 @@ describe('<RadioGroup />', () => {
             </ThemeProvider>
           </RadioGroupContext.Provider>,
         );
+
         expect(container).toMatchSnapshot();
       });
     });
@@ -107,6 +109,7 @@ describe('<RadioGroup />', () => {
         );
 
         const radios = getAllByTestId('radio');
+
         radios.map(radio => expect(radio.name).toBe(name));
       });
     });

--- a/packages/yoga/src/RadioGroup/web/Radio/Radio.test.jsx
+++ b/packages/yoga/src/RadioGroup/web/Radio/Radio.test.jsx
@@ -26,6 +26,7 @@ describe('<RadioGroup />', () => {
             <RadioGroup.Radio />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
     });
@@ -81,6 +82,7 @@ describe('<RadioGroup />', () => {
         );
 
         const radios = getAllByTestId('radio');
+
         radios.map(radio => expect(radio.name).toBe(name));
       });
     });

--- a/packages/yoga/src/RadioGroup/web/RadioGroup.test.jsx
+++ b/packages/yoga/src/RadioGroup/web/RadioGroup.test.jsx
@@ -12,6 +12,7 @@ describe('<RadioGroup />', () => {
           <RadioGroup />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -21,6 +22,7 @@ describe('<RadioGroup />', () => {
           <RadioGroup full />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -34,6 +36,7 @@ describe('<RadioGroup />', () => {
           </RadioGroup>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
       expect(getAllByText(/^Option/)).toHaveLength(3);
     });
@@ -48,6 +51,7 @@ describe('<RadioGroup />', () => {
           </RadioGroup>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -61,6 +65,7 @@ describe('<RadioGroup />', () => {
           </RadioGroup>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
       expect(getByText('Option 2').checked).toBe(true);
     });
@@ -83,6 +88,7 @@ describe('<RadioGroup />', () => {
           </RadioGroup>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
 
       // use testid to get the input[type=radio] instead of label

--- a/packages/yoga/src/Rating/web/Rating.test.jsx
+++ b/packages/yoga/src/Rating/web/Rating.test.jsx
@@ -33,6 +33,7 @@ describe('<Rating />', () => {
           <Rating />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -61,6 +62,7 @@ describe('<Rating />', () => {
           <Rating value={4.5} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -76,6 +78,7 @@ describe('<Rating />', () => {
           <Rating max={3} value={3} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -93,6 +96,7 @@ describe('<Rating />', () => {
           <Rating icon={{ type: Circle }} value={2} />
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 

--- a/packages/yoga/src/Result/native/Details.jsx
+++ b/packages/yoga/src/Result/native/Details.jsx
@@ -56,6 +56,7 @@ const ResultDetails = ({
             const isLastItem = index === refinedList.length - 1;
             const showNumbersOfItemsLeft =
               isLastItem && limit !== 0 && limit < items.length - 1;
+
             return (
               // eslint-disable-next-line react/no-array-index-key
               <React.Fragment key={index}>

--- a/packages/yoga/src/Slider/native/Slider.jsx
+++ b/packages/yoga/src/Slider/native/Slider.jsx
@@ -29,6 +29,7 @@ const Slider = ({
 }) => {
   const renderSnapDots = () => {
     const items = [];
+
     for (let i = min; i <= max; i++) {
       if (values.length > 1) {
         items.push(<Step key={i} active={values[0] < i && values[1] > i} />);

--- a/packages/yoga/src/Slider/native/Slider.test.jsx
+++ b/packages/yoga/src/Slider/native/Slider.test.jsx
@@ -12,6 +12,7 @@ describe('<Slider />', () => {
             <Slider />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -21,6 +22,7 @@ describe('<Slider />', () => {
             <Slider minLabel={0} maxLabel={10} />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -30,6 +32,7 @@ describe('<Slider />', () => {
             <Slider snapped />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
     });
@@ -40,6 +43,7 @@ describe('<Slider />', () => {
             <Slider values={[3, 7]} />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
 
@@ -49,6 +53,7 @@ describe('<Slider />', () => {
             <Slider values={[3, 7]} snapped />
           </ThemeProvider>,
         );
+
         expect(toJSON(container)).toMatchSnapshot();
       });
     });
@@ -61,6 +66,7 @@ describe('<Slider />', () => {
           <Slider maxLabel="max" minLabel="min" />
         </ThemeProvider>,
       );
+
       expect(getByText('max')).toHaveTextContent('max');
       expect(getByText('min')).toHaveTextContent('min');
     });

--- a/packages/yoga/src/Slider/web/Slider.test.jsx
+++ b/packages/yoga/src/Slider/web/Slider.test.jsx
@@ -12,6 +12,7 @@ describe('<Slider />', () => {
             <Slider />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -21,6 +22,7 @@ describe('<Slider />', () => {
             <Slider minLabel={0} maxLabel={10} />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -30,6 +32,7 @@ describe('<Slider />', () => {
             <Slider snapped />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
     });
@@ -40,6 +43,7 @@ describe('<Slider />', () => {
             <Slider values={[3, 7]} />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
 
@@ -49,6 +53,7 @@ describe('<Slider />', () => {
             <Slider values={[3, 7]} snapped />
           </ThemeProvider>,
         );
+
         expect(container).toMatchSnapshot();
       });
     });
@@ -61,6 +66,7 @@ describe('<Slider />', () => {
           <Slider maxLabel="max" minLabel="min" />
         </ThemeProvider>,
       );
+
       expect(getByText('max').textContent).toBe('max');
       expect(getByText('min').textContent).toBe('min');
     });

--- a/packages/yoga/src/Stepper/native/Stepper.test.jsx
+++ b/packages/yoga/src/Stepper/native/Stepper.test.jsx
@@ -22,6 +22,7 @@ describe('<Stepper />', () => {
           </Stepper>
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
 
@@ -41,6 +42,7 @@ describe('<Stepper />', () => {
           </Stepper>
         </ThemeProvider>,
       );
+
       expect(toJSON(container)).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Stepper/web/Stepper.test.jsx
+++ b/packages/yoga/src/Stepper/web/Stepper.test.jsx
@@ -15,6 +15,7 @@ describe('<Stepper />', () => {
           </Stepper>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -28,6 +29,7 @@ describe('<Stepper />', () => {
           </Stepper>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Text/native/Text.jsx
+++ b/packages/yoga/src/Text/native/Text.jsx
@@ -11,50 +11,65 @@ const styledText = type => styled.Text`
 `;
 
 const H1 = styledText('h1');
+
 H1.displayName = 'Text.H1';
 
 const H2 = styledText('h2');
+
 H2.displayName = 'Text.H2';
 
 const H3 = styledText('h3');
+
 H3.displayName = 'Text.H3';
 
 const H4 = styledText('h4');
+
 H4.displayName = 'Text.H4';
 
 const H5 = styledText('h5');
+
 H5.displayName = 'Text.H5';
 
 const Small = styledText('small');
+
 Small.displayName = 'Text.Small';
 
 const Tiny = styledText('tiny');
+
 Tiny.displayName = 'Text.Tiny';
 
 const Light = styledText('light');
+
 Light.displayName = 'Text.Light';
 
 const Regular = styledText('regular');
+
 Regular.displayName = 'Text.Regular';
 
 const Medium = styledText('medium');
+
 Medium.displayName = 'Text.Medium';
 
 const Bold = styledText('bold');
+
 Bold.displayName = 'Text.Bold';
 
 const Black = styledText('black');
+
 Black.displayName = 'Text.Black';
 
 const SectionTitle = styledText('sectionTitle');
+
 SectionTitle.displayName = 'Text.SectionTitle';
 
 const SmallestException = styledText('smallestException');
+
 SmallestException.displayName = 'Text.SmallestException';
 
 const TextRenderer = styledText('p');
 
 const Text = props => <TextRenderer {...props} />;
+
 Text.displayName = 'Text';
 
 Text.propTypes = {

--- a/packages/yoga/src/Text/native/Text.test.jsx
+++ b/packages/yoga/src/Text/native/Text.test.jsx
@@ -23,6 +23,7 @@ describe('<Text />', () => {
           <Text.SmallestException>Live the mission</Text.SmallestException>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -34,6 +35,7 @@ describe('<Text />', () => {
           <Text.H3 variant="tertiary">Live the mission</Text.H3>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -45,6 +47,7 @@ describe('<Text />', () => {
           <Text.H3 light>Live the mission</Text.H3>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -57,6 +60,7 @@ describe('<Text />', () => {
           <Text.Medium size="xxxlarge">Live the xxxlarge mission</Text.Medium>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -66,6 +70,7 @@ describe('<Text />', () => {
           <Text inverted>Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -79,6 +84,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -90,6 +96,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -99,6 +106,7 @@ describe('<Text />', () => {
           <Text backgroundColor="vibin">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -108,6 +116,7 @@ describe('<Text />', () => {
           <Text elevation="medium">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -119,6 +128,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -135,6 +145,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -144,6 +155,7 @@ describe('<Text />', () => {
           <Text display="flex">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -155,6 +167,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -166,6 +179,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -175,6 +189,7 @@ describe('<Text />', () => {
           <Text overflow="scroll">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Text/web/Text.jsx
+++ b/packages/yoga/src/Text/web/Text.jsx
@@ -16,50 +16,65 @@ const styledText = (type, element = false) => (element
 `;
 
 const H1 = styledText('h1', true);
+
 H1.displayName = 'Text.H1';
 
 const H2 = styledText('h2', true);
+
 H2.displayName = 'Text.H2';
 
 const H3 = styledText('h3', true);
+
 H3.displayName = 'Text.H3';
 
 const H4 = styledText('h4', true);
+
 H4.displayName = 'Text.H4';
 
 const H5 = styledText('h5', true);
+
 H5.displayName = 'Text.H5';
 
 const Small = styledText('small');
+
 Small.displayName = 'Text.Small';
 
 const Tiny = styledText('tiny');
+
 Tiny.displayName = 'Text.Tiny';
 
 const Light = styledText('light');
+
 Light.displayName = 'Text.Light';
 
 const Regular = styledText('regular');
+
 Regular.displayName = 'Text.Regular';
 
 const Medium = styledText('medium');
+
 Medium.displayName = 'Text.Medium';
 
 const Bold = styledText('bold');
+
 Bold.displayName = 'Text.Bold';
 
 const Black = styledText('black');
+
 Black.displayName = 'Text.Black';
 
 const SectionTitle = styledText('sectionTitle');
+
 SectionTitle.displayName = 'Text.SectionTitle';
 
 const SmallestException = styledText('smallestException');
+
 SmallestException.displayName = 'Text.SmallestException';
 
 const TextRenderer = styledText('p');
 
 const Text = props => <TextRenderer {...props} />;
+
 Text.displayName = 'Text';
 
 Text.propTypes = {

--- a/packages/yoga/src/Text/web/Text.test.jsx
+++ b/packages/yoga/src/Text/web/Text.test.jsx
@@ -24,6 +24,7 @@ describe('<Text />', () => {
           <Text.SmallestException>Live the mission</Text.SmallestException>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -35,6 +36,7 @@ describe('<Text />', () => {
           <Text.H3 variant="tertiary">Live the mission</Text.H3>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -46,6 +48,7 @@ describe('<Text />', () => {
           <Text.H3 light>Live the mission</Text.H3>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -58,6 +61,7 @@ describe('<Text />', () => {
           <Text.Medium size="xxxlarge">Live the xxxlarge mission</Text.Medium>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -67,6 +71,7 @@ describe('<Text />', () => {
           <Text inverted>Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -80,6 +85,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -91,6 +97,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -100,6 +107,7 @@ describe('<Text />', () => {
           <Text backgroundColor="vibin">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -109,6 +117,7 @@ describe('<Text />', () => {
           <Text elevation="medium">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -120,6 +129,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -136,6 +146,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -145,6 +156,7 @@ describe('<Text />', () => {
           <Text display="inline-flex">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -156,6 +168,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -167,6 +180,7 @@ describe('<Text />', () => {
           </Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
 
@@ -176,6 +190,7 @@ describe('<Text />', () => {
           <Text overflow="scroll">Live the mission</Text>
         </ThemeProvider>,
       );
+
       expect(container).toMatchSnapshot();
     });
   });

--- a/packages/yoga/src/Theme/Provider/Provider.jsx
+++ b/packages/yoga/src/Theme/Provider/Provider.jsx
@@ -6,6 +6,7 @@ import yogaTheme from '../theme';
 
 const getTheme = ({ locale }) => {
   const token = tokens[locale] || tokens.default;
+
   return yogaTheme(token);
 };
 

--- a/packages/yoga/src/Theme/Provider/web/FontLoader.test.jsx
+++ b/packages/yoga/src/Theme/Provider/web/FontLoader.test.jsx
@@ -12,6 +12,7 @@ describe('FontLoader component', () => {
       </ThemeProvider>,
     );
     const link = document.getElementsByTagName('link').item(0).outerHTML;
+
     expect(link).toContain(
       `<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Rubik:300,400,500,700,900,300i,400i,500i,700i,900i">`,
     );

--- a/packages/yoga/src/Theme/Provider/web/expectCssMatches.js
+++ b/packages/yoga/src/Theme/Provider/web/expectCssMatches.js
@@ -18,6 +18,7 @@ const getCSS = scope =>
 const expectCSSMatches = expectation => {
   const _expectation = normalizeCSS(expectation.split('\n'));
   const css = getCSS(document);
+
   expect(css).toContain(_expectation);
   return css;
 };

--- a/packages/yoga/src/Theme/theme/theme.js
+++ b/packages/yoga/src/Theme/theme/theme.js
@@ -40,8 +40,10 @@ const theme = tokens => {
   ] = colors.feedback.attention;
 
   const components = {};
+
   Object.entries(componentThemes).forEach(([names, themed]) => {
     const [, name] = names.split('$');
+
     components[name.toLowerCase()] = themed({
       ...tokens,
       colors,

--- a/packages/yoga/src/shared/propTypes/deprecated.js
+++ b/packages/yoga/src/shared/propTypes/deprecated.js
@@ -4,6 +4,7 @@ const deprecated = (propType, explanation) => {
   return function validate(props, propName, componentName, ...rest) {
     if (props[propName] != null) {
       const message = `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`;
+
       console.warn(message);
     }
 

--- a/packages/yoga/src/shared/propTypes/typeof.js
+++ b/packages/yoga/src/shared/propTypes/typeof.js
@@ -7,6 +7,7 @@ const typeOf = ({ displayName: childType }) => (
 ) => {
   let error;
   const prop = props[propName];
+
   React.Children.forEach(prop, child => {
     if (child.type.displayName !== childType) {
       error = new Error(


### PR DESCRIPTION
### About
This gives us less concern while coding and reviewing PRs. Does you prefer to just write the code and let your editor's save fix it? Be our guest.

See [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements).

### New rules
What changes with them?

❌  **Bad** - No lines between declarations and other statements:
```js
const a = 42;
const b = 'coelhucas';
function getInfo() {
  return { a, b };
}
```

✅  **Good** - Blank line between declarations and other statements
```js
const a = 42;
const b = 'coelhucas';

function getInfo() {
  return { a, b };
}
```

❌  **Bad** - No lines between directives and other statements:
```js
"use strict"
const name = 'Lucas';
```

✅  **Good** - Blank line between directives and other statements:
```js
"use strict";

const name = 'Lucas';
```

You got the idea, right?

✅  Also, blank lines between declarations are **OK**:
```js
const sayMyName = 'Walter White';

const sum = (a, b) => a + b;
```

✅  And **NO** line breaks between directives are also **OK**:
```js
"use strict";
"use asm";
```