### PR TITLE
Add text align css property into typography module (Yoga system)

### DIFF
--- a/packages/doc/content/system/system/typography.mdx
+++ b/packages/doc/content/system/system/typography.mdx
@@ -75,5 +75,16 @@ The `typography` module has all the listed above
         <inlineCode>line-height</inlineCode>
       </td>
     </tr>
+    <tr>
+      <td>
+        <inlineCode>textAlign</inlineCode>
+      </td>
+      <td>
+        <inlineCode>textAlign</inlineCode>, <inlineCode>ta</inlineCode>
+      </td>
+      <td>
+        <inlineCode>text-align</inlineCode>
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/packages/doc/content/system/system/typography.mdx
+++ b/packages/doc/content/system/system/typography.mdx
@@ -13,7 +13,13 @@ const Typography = styled.div`
 
 render(() => {
   return (
-    <Typography c="deepPurple" lineHeight="huge" fw="light" fs="huge">
+    <Typography
+      c="deepPurple"
+      lineHeight="huge"
+      fw="light"
+      fs="huge"
+      ta="center"
+    >
       Making wellbeing universal
     </Typography>
   );

--- a/packages/system/src/typography.js
+++ b/packages/system/src/typography.js
@@ -35,11 +35,19 @@ const lineHeight = props =>
     transform: toPx,
   });
 
+const textAlign = props =>
+  generator({
+    props,
+    prop: ['textAlign', 'ta'],
+    cssProperty: 'text-align',
+  });
+
 const typography = compose(
   color,
   fontSize,
   fontWeight,
   lineHeight,
+  textAlign,
 );
 
-export { fontSize, fontWeight, color, lineHeight, typography };
+export { fontSize, fontWeight, color, lineHeight, textAlign, typography };

--- a/packages/system/src/typography.test.js
+++ b/packages/system/src/typography.test.js
@@ -170,20 +170,16 @@ describe('Web and iOS', () => {
     });
 
     describe('textAlign', () => {
-      it('Should return values for text align prop', () => {
+      it('Should return values for textAlign prop', () => {
         const expectedTextAlign = css({ textAlign: 'center' });
 
-        const useSystemTextAlign = textAlign({ textAlign: 'center' });
+        const ta1 = textAlign({ textAlign: 'center' });
+        const ta2 = textAlign({ ta: 'center' });
 
-        expect(useSystemTextAlign).toStrictEqual(expectedTextAlign);
-      });
+        expect(ta1).toStrictEqual(ta2);
 
-      it('Should return values for text align prop when using the abbreviation version', () => {
-        const useSystemTextAlign = css({ textAlign: 'center' });
-
-        const textAlignProperty = textAlign({ ta: 'center' });
-
-        expect(textAlignProperty).toStrictEqual(useSystemTextAlign);
+        const textAlignOptions = [ta1, ta2];
+        textAlignOptions.map(ta => expect(ta).toStrictEqual(expectedTextAlign));
       });
     });
   });

--- a/packages/system/src/typography.test.js
+++ b/packages/system/src/typography.test.js
@@ -4,6 +4,7 @@ import {
   fontWeight,
   color,
   lineHeight,
+  textAlign,
   typography,
 } from './typography';
 
@@ -165,6 +166,24 @@ describe('Web and iOS', () => {
 
         const c = color({ theme, color: 'tomato' });
         expect(c).toStrictEqual(expectedNoTheme);
+      });
+    });
+
+    describe('textAlign', () => {
+      it('Should return values for text align prop', () => {
+        const expectedTextAlign = css({ textAlign: 'center' });
+
+        const useSystemTextAlign = textAlign({ textAlign: 'center' });
+
+        expect(useSystemTextAlign).toStrictEqual(expectedTextAlign);
+      });
+
+      it('Should return values for text align prop when using the abbreviation version', () => {
+        const useSystemTextAlign = css({ textAlign: 'center' });
+
+        const textAlignProperty = textAlign({ ta: 'center' });
+
+        expect(textAlignProperty).toStrictEqual(useSystemTextAlign);
       });
     });
   });


### PR DESCRIPTION
# ✨ Add text align prop to system

![image](https://user-images.githubusercontent.com/85311965/134740294-33675a16-1689-4555-8b2b-3ed8abdaa22e.png)

## Motivation

Keeping the work in `@gympass/system`, we're adding the text align property to typography's module:

- `textAlign`, `ta`

Those updates will be reflected into components that are currently using the `yoga-system` module.

### Checklist

- [x] Unit tests