### PR TITLE
Fix at Tag.Informative

### DIFF
--- a/packages/doc/content/components/components/tag/informative-native.mdx
+++ b/packages/doc/content/components/components/tag/informative-native.mdx
@@ -3,6 +3,11 @@ import { Link as GatsbyLink } from 'gatsby';
 ### Usage
 
 ```javascript type=expo
+  <Tag.Informative mv="medium">default</Tag.Informative>
+  <Tag.Informative variant="success">
+    default with custom icon
+  </Tag.Informative>
+
   <Tag.Informative mv="medium" variant="success">success</Tag.Informative>
   <Tag.Informative variant="success" icon={Building}>
     success with custom icon

--- a/packages/doc/content/components/components/tag/informative-web.mdx
+++ b/packages/doc/content/components/components/tag/informative-web.mdx
@@ -8,6 +8,7 @@ const Wrapper = props => (
     display="inline-flex"
     alignItems="center"
     flexDirection="column"
+    mh="xsmall"
     {...props}
   />
 );
@@ -15,50 +16,43 @@ const Wrapper = props => (
 render(
   <>
     <Wrapper>
-      <Tag.Informative mb="xxxsmall" mr="medium" variant="success">
+      <Tag.Informative>default</Tag.Informative>
+      <Tag.Informative mv="xxxsmall" icon={Building}>
+          default with icon
+      </Tag.Informative>
+      <Tag.Informative icon={Building} small>
+        default small with icon
+      </Tag.Informative>
+    </Wrapper>
+    <Wrapper>
+      <Tag.Informative variant="success">
         success
       </Tag.Informative>
-      <Tag.Informative mr="medium" variant="success" icon={Building}>
-        success with custom icon
+      <Tag.Informative mv="xxxsmall" variant="success" icon={Building}>
+        success with icon
       </Tag.Informative>
-      <Tag.Informative
-        mt="xxxsmall"
-        mr="medium"
-        variant="success"
-        icon={Building}
-        small
-      >
-        success small with custom icon
+      <Tag.Informative variant="success" icon={Building} small>
+        success small with icon
       </Tag.Informative>
     </Wrapper>
     <Wrapper>
       <Tag.Informative variant="informative">informative</Tag.Informative>
-      <Tag.Informative mv="medium" variant="informative" icon={Building}>
-        informative with custom icon
+      <Tag.Informative mv="xxxsmall" variant="informative" icon={Building}>
+        informative with icon
       </Tag.Informative>
       <Tag.Informative variant="informative" icon={Building} small>
-        informative small with custom icon
+        informative small with icon
       </Tag.Informative>
     </Wrapper>
     <Wrapper>
-      <Tag.Informative marginLeft="medium" variant="attention">
+      <Tag.Informative variant="attention">
         attention
       </Tag.Informative>
-      <Tag.Informative
-        marginLeft="medium"
-        marginVertical="xxxsmall"
-        variant="attention"
-        icon={Building}
-      >
-        attention with custom icon
+      <Tag.Informative mv="xxxsmall" variant="attention" icon={Building}>
+        attention with icon
       </Tag.Informative>
-      <Tag.Informative
-        marginLeft="medium"
-        variant="attention"
-        icon={Building}
-        small
-      >
-        attention small with custom icon
+      <Tag.Informative variant="attention" icon={Building} small>
+        attention small with icon
       </Tag.Informative>
     </Wrapper>
   </>,

--- a/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
+++ b/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
@@ -195,6 +195,11 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   font-weight: 500;
 }
 
+.c15 {
+  width: 16px;
+  height: 16px;
+}
+
 .c3 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -210,10 +215,6 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   border-color: #E0DFFF;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c3 svg {
-  margin-right: 4px;
 }
 
 .c4 {
@@ -302,11 +303,6 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.c15 {
-  width: 16px;
-  height: 16px;
 }
 
 <div>

--- a/packages/yoga/src/Tag/Tag.theme.js
+++ b/packages/yoga/src/Tag/Tag.theme.js
@@ -5,7 +5,7 @@ const Tag = ({ spacing, fontSizes, fontWeights, radii, borders }) => ({
       small: spacing.xsmall,
     },
     margin: {
-      right: spacing.xxxsmall,
+      right: 'xxxsmall',
     },
   },
   font: {

--- a/packages/yoga/src/Tag/native/Informative.jsx
+++ b/packages/yoga/src/Tag/native/Informative.jsx
@@ -4,6 +4,7 @@ import { func, oneOf, node, bool } from 'prop-types';
 import { margins } from '@gympass/yoga-system';
 
 import { StyledTag, StyledText } from './Tag';
+import Icon from '../../Icon';
 
 const Informative = styled(StyledTag)`
   ${({
@@ -54,12 +55,10 @@ const StyledTextInformative = styled(StyledText)`
 /** Tags should be keywords to categorize or organize an item. */
 const TagInformative = ({
   children,
-  icon: Icon,
+  icon,
   theme: {
     yoga: {
-      colors: {
-        text: { primary },
-      },
+      colors: { text },
       components: { tag },
     },
   },
@@ -68,12 +67,12 @@ const TagInformative = ({
 }) => (
   <Informative small={small} {...props}>
     <Wrapper>
-      {Icon && (
+      {icon && (
         <Icon
-          width={small ? tag.icon.size.small : tag.icon.size.default}
-          height={small ? tag.icon.size.small : tag.icon.size.default}
-          fill={primary}
-          style={{ marginRight: tag.icon.margin.right }}
+          as={icon}
+          size={small ? tag.icon.size.small : tag.icon.size.default}
+          fill={text.primary}
+          marginRight={tag.icon.margin.right}
         />
       )}
       <StyledTextInformative>{children}</StyledTextInformative>

--- a/packages/yoga/src/Tag/native/Informative.jsx
+++ b/packages/yoga/src/Tag/native/Informative.jsx
@@ -11,8 +11,10 @@ const Informative = styled(StyledTag)`
     theme: {
       yoga: {
         colors: {
-          text,
-          feedback: { [variant]: color = { light: text.secondary } },
+          elements,
+          feedback: {
+            [variant]: color = { light: elements.backgroundAndDisabled },
+          },
         },
         components: { tag },
       },
@@ -81,7 +83,7 @@ const TagInformative = ({
 
 TagInformative.propTypes = {
   /** style the tag following the theme (success, informative, attention) */
-  variant: oneOf(['success', 'informative', 'attention']).isRequired,
+  variant: oneOf(['', 'success', 'informative', 'attention']),
   icon: func,
   children: node.isRequired,
   /** Can send small to use this variant */
@@ -89,6 +91,7 @@ TagInformative.propTypes = {
 };
 
 TagInformative.defaultProps = {
+  variant: '',
   icon: undefined,
   small: false,
 };

--- a/packages/yoga/src/Tag/native/Tag.test.jsx
+++ b/packages/yoga/src/Tag/native/Tag.test.jsx
@@ -15,6 +15,16 @@ describe('<Tag />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should match snapshot with informative type', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <Tag.Informative>default</Tag.Informative>
+      </ThemeProvider>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
   it('should match snapshot with custom icon and informative type', () => {
     const { container } = render(
       <ThemeProvider>

--- a/packages/yoga/src/Tag/native/__snapshots__/Tag.test.jsx.snap
+++ b/packages/yoga/src/Tag/native/__snapshots__/Tag.test.jsx.snap
@@ -101,15 +101,20 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
         fill="#231B22"
         focusable={false}
         height={16}
+        marginRight="xxxsmall"
         style={
           Array [
             Object {
               "backgroundColor": "transparent",
               "borderWidth": 0,
             },
-            Object {
-              "marginRight": 4,
-            },
+            Array [
+              Object {
+                "height": 16,
+                "marginRight": 4,
+                "width": 16,
+              },
+            ],
             Object {
               "opacity": 1,
             },
@@ -228,15 +233,20 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
         fill="#231B22"
         focusable={false}
         height={12}
+        marginRight="xxxsmall"
         style={
           Array [
             Object {
               "backgroundColor": "transparent",
               "borderWidth": 0,
             },
-            Object {
-              "marginRight": 4,
-            },
+            Array [
+              Object {
+                "height": 12,
+                "marginRight": 4,
+                "width": 12,
+              },
+            ],
             Object {
               "opacity": 1,
             },

--- a/packages/yoga/src/Tag/native/__snapshots__/Tag.test.jsx.snap
+++ b/packages/yoga/src/Tag/native/__snapshots__/Tag.test.jsx.snap
@@ -320,6 +320,73 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
 </View>
 `;
 
+exports[`<Tag /> should match snapshot with informative type 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    small={false}
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#F5F5FA",
+          "borderColor": "#F5F5FA",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "justifyContent": "center",
+          "paddingBottom": 4,
+          "paddingLeft": 8,
+          "paddingRight": 8,
+          "paddingTop": 4,
+          "width": "auto",
+        },
+      ]
+    }
+    variant=""
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#231B22",
+              "fontFamily": "Rubik",
+              "fontSize": 16,
+              "fontWeight": "500",
+            },
+            Object {
+              "color": "#231B22",
+              "fontSize": 12,
+              "fontWeight": "500",
+              "lineHeight": 16,
+            },
+          ]
+        }
+      >
+        default
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`<Tag /> should match snapshot with variant and margin prop  1`] = `
 <View
   collapsable={true}

--- a/packages/yoga/src/Tag/web/Informative.jsx
+++ b/packages/yoga/src/Tag/web/Informative.jsx
@@ -15,7 +15,10 @@ const Informative = styled(Tag)`
       yoga: {
         colors: {
           text,
-          feedback: { [variant]: color = { light: text.secondary } },
+          elements,
+          feedback: {
+            [variant]: color = { light: elements.backgroundAndDisabled },
+          },
         },
         components: { tag },
       },
@@ -64,7 +67,7 @@ const TagInformative = ({
 
 TagInformative.propTypes = {
   /** style the tag following the theme (success, informative, attention) */
-  variant: oneOf(['success', 'informative', 'attention']).isRequired,
+  variant: oneOf(['', 'success', 'informative', 'attention']),
   icon: func,
   children: node.isRequired,
   /** Can send small to use this variant */
@@ -72,6 +75,7 @@ TagInformative.propTypes = {
 };
 
 TagInformative.defaultProps = {
+  variant: '',
   icon: undefined,
   small: false,
 };

--- a/packages/yoga/src/Tag/web/Informative.jsx
+++ b/packages/yoga/src/Tag/web/Informative.jsx
@@ -4,6 +4,7 @@ import { func, oneOf, node, bool } from 'prop-types';
 import { margins } from '@gympass/yoga-system';
 
 import Tag from './Tag';
+import Icon from '../../Icon';
 
 const Informative = styled(Tag)`
   justify-content: center;
@@ -31,10 +32,6 @@ const Informative = styled(Tag)`
 
     font-size: ${tag.font.size}px;
     font-weight: ${tag.font.weight};
-
-    svg {
-      margin-right: ${tag.icon.margin.right}px;
-    }
   `}
 
   ${margins}
@@ -43,7 +40,7 @@ const Informative = styled(Tag)`
 /** Tags should be keywords to categorize or organize an item. */
 const TagInformative = ({
   children,
-  icon: Icon,
+  icon,
   theme: {
     yoga: {
       colors: { text },
@@ -54,11 +51,12 @@ const TagInformative = ({
   ...props
 }) => (
   <Informative small={small} {...props}>
-    {Icon && (
+    {icon && (
       <Icon
-        width={small ? tag.icon.size.small : tag.icon.size.default}
-        height={small ? tag.icon.size.small : tag.icon.size.default}
+        as={icon}
+        size={small ? tag.icon.size.small : tag.icon.size.default}
         fill={text.primary}
+        marginRight={tag.icon.margin.right}
       />
     )}
     {children}

--- a/packages/yoga/src/Tag/web/Tag.test.jsx
+++ b/packages/yoga/src/Tag/web/Tag.test.jsx
@@ -15,6 +15,16 @@ describe('<Tag />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should match snapshot with informative type', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <Tag.Informative>default</Tag.Informative>
+      </ThemeProvider>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
   it('should match snapshot with custom icon and informative type', () => {
     const { container } = render(
       <ThemeProvider>

--- a/packages/yoga/src/Tag/web/__snapshots__/Tag.test.jsx.snap
+++ b/packages/yoga/src/Tag/web/__snapshots__/Tag.test.jsx.snap
@@ -94,6 +94,61 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
 </div>
 `;
 
+exports[`<Tag /> should match snapshot with informative type 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-style: solid;
+  padding: 4px 8px 4px 8px;
+  color: #6B6B78;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: #9898A6;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
+}
+
+.c1 {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #F5F5FA;
+  color: #231B22;
+  border-radius: 4px;
+  border-color: #F5F5FA;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.c1 svg {
+  margin-right: 4px;
+}
+
+<div>
+  <div
+    class="c0 c1"
+  >
+    default
+  </div>
+</div>
+`;
+
 exports[`<Tag /> should match snapshot with variant and margin prop  1`] = `
 .c0 {
   display: -webkit-inline-box;

--- a/packages/yoga/src/Tag/web/__snapshots__/Tag.test.jsx.snap
+++ b/packages/yoga/src/Tag/web/__snapshots__/Tag.test.jsx.snap
@@ -59,6 +59,12 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
   font-weight: 500;
 }
 
+.c2 {
+  margin-right: 4px;
+  width: 16px;
+  height: 16px;
+}
+
 .c1 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -76,17 +82,15 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
   font-weight: 500;
 }
 
-.c1 svg {
-  margin-right: 4px;
-}
-
 <div>
   <div
     class="c0 c1"
   >
     <svg
+      class="c2"
       fill="#231B22"
       height="16"
+      marginRight="xxxsmall"
       width="16"
     />
     success with custom icon
@@ -134,10 +138,6 @@ exports[`<Tag /> should match snapshot with informative type 1`] = `
   border-color: #F5F5FA;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c1 svg {
-  margin-right: 4px;
 }
 
 <div>
@@ -425,10 +425,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type 1`
   font-weight: 500;
 }
 
-.c1 svg {
-  margin-right: 4px;
-}
-
 .c3 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -446,10 +442,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type 1`
   font-weight: 500;
 }
 
-.c3 svg {
-  margin-right: 4px;
-}
-
 .c5 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -465,10 +457,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type 1`
   border-color: #FCD6C3;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c5 svg {
-  margin-right: 4px;
 }
 
 <div>
@@ -582,10 +570,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type wi
   font-weight: 500;
 }
 
-.c1 svg {
-  margin-right: 4px;
-}
-
 .c5 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -601,10 +585,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type wi
   border-color: #FCD6C3;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c5 svg {
-  margin-right: 4px;
 }
 
 .c3 {
@@ -624,10 +604,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type wi
   font-weight: 500;
   margin-top: 20px;
   margin-bottom: 20px;
-}
-
-.c3 svg {
-  margin-right: 4px;
 }
 
 <div>
@@ -689,10 +665,6 @@ exports[`<Tag /> should match snapshot with without icon and informative type 1`
   border-color: #C1EEDB;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c1 svg {
-  margin-right: 4px;
 }
 
 <div>


### PR DESCRIPTION
## Changes:

- Set variant props as optional;
- Fix the color used at the default variant;
- Start to use the `Icon` component at the web `Tag`;
- Refactor some details using the system that is integrated at the `Icon`.

## Doc

![image (1)](https://user-images.githubusercontent.com/5889973/135333139-6b76d457-1376-43ab-a38a-6fc39b03d45d.png)
