### PR TITLE
Fix `padding-line-between-statements` rule usage inside `typography`'s spec

### DIFF
--- a/packages/system/src/typography.test.js
+++ b/packages/system/src/typography.test.js
@@ -191,6 +191,7 @@ describe('Web and iOS', () => {
         expect(ta1).toStrictEqual(ta2);
 
         const textAlignOptions = [ta1, ta2];
+
         textAlignOptions.map(ta => expect(ta).toStrictEqual(expectedTextAlign));
       });
     });


### PR DESCRIPTION
I believe the title is pretty self-explanatory 😅 

Fixes this:
![image](https://user-images.githubusercontent.com/28108272/135334960-5a67b015-cb2a-4432-bad3-280597865a7e.png)
