### PR TITLE
[Theme Generator] Add CodeSandbox project to documentation

### DIFF
--- a/packages/doc/content/components/theming/themeGenerator.mdx
+++ b/packages/doc/content/components/theming/themeGenerator.mdx
@@ -13,7 +13,7 @@ Yoga exposes a function that let you create your very own theme which can later 
 You can refer to <GatsbyLink to="/components/theming/theme">Theme</GatsbyLink> in order to see our theme object schema.
 
 ### Live Demo
-We prepared [this](https://codesandbox.io/s/theming-in-yoga-rh4th) CodeSandbox project containing a minimal demo of all this concept in action as a practical reference. Feel free to report any issues, suggestions or even submiting pull requests in our [repository](https://github.com/gympas/yoga).
+There is also a [CodeSandbox project](https://codesandbox.io/s/theming-in-yoga-rh4th) containing a minimal demo of all this concept in action as a practical reference. Feel free to report any issues, suggestions or even submiting pull requests in our [repository](https://github.com/gympas/yoga).
 
 ### Usage
 

--- a/packages/doc/content/components/theming/themeGenerator.mdx
+++ b/packages/doc/content/components/theming/themeGenerator.mdx
@@ -12,6 +12,9 @@ import { Link as GatsbyLink } from 'gatsby';
 Yoga exposes a function that let you create your very own theme which can later be injected into <GatsbyLink to="/components/theming/themeProvider">`<ThemeProvider>`</GatsbyLink>.
 You can refer to <GatsbyLink to="/components/theming/theme">Theme</GatsbyLink> in order to see our theme object schema.
 
+### Live Demo
+We prepared [this](https://codesandbox.io/s/theming-in-yoga-rh4th) CodeSandbox project containing a minimal demo of all this concept in action as a practical reference. Feel free to report any issues, suggestions or even submiting pull requests in our [repository](https://github.com/gympas/yoga).
+
 ### Usage
 
 This is a simple usage:


### PR DESCRIPTION
I made a proper demo showing our theme generator in action as part of documentation, as well as some minor additions to doc's message.

| Theme | Screenshot |
| --- | --- |
| Default | ![image](https://user-images.githubusercontent.com/28108272/135345089-9e5e06f4-d3b2-4129-ba8e-d47712350fe4.png) |
| Custom | ![image](https://user-images.githubusercontent.com/28108272/135345140-21e79e5f-9d07-4ebb-b5af-87f0aba2629d.png) |