### PR TITLE
Start to use Icon Component inside the Tag instead of SVG

### DIFF
--- a/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
+++ b/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
@@ -195,6 +195,11 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   font-weight: 500;
 }
 
+.c15 {
+  width: 16px;
+  height: 16px;
+}
+
 .c3 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -210,10 +215,6 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   border-color: #E0DFFF;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c3 svg {
-  margin-right: 4px;
 }
 
 .c4 {
@@ -302,11 +303,6 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.c15 {
-  width: 16px;
-  height: 16px;
 }
 
 <div>

--- a/packages/yoga/src/Tag/Tag.theme.js
+++ b/packages/yoga/src/Tag/Tag.theme.js
@@ -5,7 +5,7 @@ const Tag = ({ spacing, fontSizes, fontWeights, radii, borders }) => ({
       small: spacing.xsmall,
     },
     margin: {
-      right: spacing.xxxsmall,
+      right: 'xxxsmall',
     },
   },
   font: {

--- a/packages/yoga/src/Tag/native/Informative.jsx
+++ b/packages/yoga/src/Tag/native/Informative.jsx
@@ -4,6 +4,7 @@ import { func, oneOf, node, bool } from 'prop-types';
 import { margins } from '@gympass/yoga-system';
 
 import { StyledTag, StyledText } from './Tag';
+import Icon from '../../Icon';
 
 const Informative = styled(StyledTag)`
   ${({
@@ -52,12 +53,10 @@ const StyledTextInformative = styled(StyledText)`
 /** Tags should be keywords to categorize or organize an item. */
 const TagInformative = ({
   children,
-  icon: Icon,
+  icon,
   theme: {
     yoga: {
-      colors: {
-        text: { primary },
-      },
+      colors: { text },
       components: { tag },
     },
   },
@@ -66,12 +65,12 @@ const TagInformative = ({
 }) => (
   <Informative small={small} {...props}>
     <Wrapper>
-      {Icon && (
+      {icon && (
         <Icon
-          width={small ? tag.icon.size.small : tag.icon.size.default}
-          height={small ? tag.icon.size.small : tag.icon.size.default}
-          fill={primary}
-          style={{ marginRight: tag.icon.margin.right }}
+          as={icon}
+          size={small ? tag.icon.size.small : tag.icon.size.default}
+          fill={text.primary}
+          marginRight={tag.icon.margin.right}
         />
       )}
       <StyledTextInformative>{children}</StyledTextInformative>

--- a/packages/yoga/src/Tag/native/__snapshots__/Tag.test.jsx.snap
+++ b/packages/yoga/src/Tag/native/__snapshots__/Tag.test.jsx.snap
@@ -101,15 +101,20 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
         fill="#231B22"
         focusable={false}
         height={16}
+        marginRight="xxxsmall"
         style={
           Array [
             Object {
               "backgroundColor": "transparent",
               "borderWidth": 0,
             },
-            Object {
-              "marginRight": 4,
-            },
+            Array [
+              Object {
+                "height": 16,
+                "marginRight": 4,
+                "width": 16,
+              },
+            ],
             Object {
               "opacity": 1,
             },
@@ -228,15 +233,20 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
         fill="#231B22"
         focusable={false}
         height={12}
+        marginRight="xxxsmall"
         style={
           Array [
             Object {
               "backgroundColor": "transparent",
               "borderWidth": 0,
             },
-            Object {
-              "marginRight": 4,
-            },
+            Array [
+              Object {
+                "height": 12,
+                "marginRight": 4,
+                "width": 12,
+              },
+            ],
             Object {
               "opacity": 1,
             },

--- a/packages/yoga/src/Tag/web/Informative.jsx
+++ b/packages/yoga/src/Tag/web/Informative.jsx
@@ -4,6 +4,7 @@ import { func, oneOf, node, bool } from 'prop-types';
 import { margins } from '@gympass/yoga-system';
 
 import Tag from './Tag';
+import Icon from '../../Icon';
 
 const Informative = styled(Tag)`
   justify-content: center;
@@ -28,10 +29,6 @@ const Informative = styled(Tag)`
 
     font-size: ${tag.font.size}px;
     font-weight: ${tag.font.weight};
-
-    svg {
-      margin-right: ${tag.icon.margin.right}px;
-    }
   `}
 
   ${margins}
@@ -40,7 +37,7 @@ const Informative = styled(Tag)`
 /** Tags should be keywords to categorize or organize an item. */
 const TagInformative = ({
   children,
-  icon: Icon,
+  icon,
   theme: {
     yoga: {
       colors: { text },
@@ -51,11 +48,12 @@ const TagInformative = ({
   ...props
 }) => (
   <Informative small={small} {...props}>
-    {Icon && (
+    {icon && (
       <Icon
-        width={small ? tag.icon.size.small : tag.icon.size.default}
-        height={small ? tag.icon.size.small : tag.icon.size.default}
+        as={icon}
+        size={small ? tag.icon.size.small : tag.icon.size.default}
         fill={text.primary}
+        marginRight={tag.icon.margin.right}
       />
     )}
     {children}

--- a/packages/yoga/src/Tag/web/__snapshots__/Tag.test.jsx.snap
+++ b/packages/yoga/src/Tag/web/__snapshots__/Tag.test.jsx.snap
@@ -59,6 +59,12 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
   font-weight: 500;
 }
 
+.c2 {
+  margin-right: 4px;
+  width: 16px;
+  height: 16px;
+}
+
 .c1 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -76,17 +82,15 @@ exports[`<Tag /> should match snapshot with custom icon and informative type 1`]
   font-weight: 500;
 }
 
-.c1 svg {
-  margin-right: 4px;
-}
-
 <div>
   <div
     class="c0 c1"
   >
     <svg
+      class="c2"
       fill="#231B22"
       height="16"
+      marginRight="xxxsmall"
       width="16"
     />
     success with custom icon
@@ -370,10 +374,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type 1`
   font-weight: 500;
 }
 
-.c1 svg {
-  margin-right: 4px;
-}
-
 .c3 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -391,10 +391,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type 1`
   font-weight: 500;
 }
 
-.c3 svg {
-  margin-right: 4px;
-}
-
 .c5 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -410,10 +406,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type 1`
   border-color: #FCD6C3;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c5 svg {
-  margin-right: 4px;
 }
 
 <div>
@@ -527,10 +519,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type wi
   font-weight: 500;
 }
 
-.c1 svg {
-  margin-right: 4px;
-}
-
 .c5 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -546,10 +534,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type wi
   border-color: #FCD6C3;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c5 svg {
-  margin-right: 4px;
 }
 
 .c3 {
@@ -569,10 +553,6 @@ exports[`<Tag /> should match snapshot with variant prop and informative type wi
   font-weight: 500;
   margin-top: 20px;
   margin-bottom: 20px;
-}
-
-.c3 svg {
-  margin-right: 4px;
 }
 
 <div>
@@ -634,10 +614,6 @@ exports[`<Tag /> should match snapshot with without icon and informative type 1`
   border-color: #C1EEDB;
   font-size: 12px;
   font-weight: 500;
-}
-
-.c1 svg {
-  margin-right: 4px;
 }
 
 <div>


### PR DESCRIPTION
## Description

Changed the icon usage at the Tag component, start using the Yoga Icon component instead of rendering the icon as an SVG.

As you can see in the below doc screenshot the icon `marginRight` is set as `xxxsmall` and the SVG style has the `margin-right` as `4px`.

## Doc screenshot

![image](https://user-images.githubusercontent.com/5889973/135901220-b5993ddc-b8c6-40a2-af9f-cd9e29a6cb9b.png)
