### PR TITLE
[DOCS: A11y | Navigation] Make it accessible through keyboard

### DIFF
--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -239,7 +239,7 @@ const Navigation = ({ items, toggleMenu, opened, prefix }) => {
 
   return (
     <Wrapper opened={opened}>
-      <Nav aria-label="Contents navigation">
+      <Nav>
         <List tree={tree} toggleMenu={toggleMenu} prefix={prefix} />
       </Nav>
     </Wrapper>

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -138,7 +138,7 @@ const ListItem = ({
 
   const { pathname } = window.location;
   const linkPath = prefix ? `/yoga${filteredUrl}` : filteredUrl;
-  const isActive = pathname === linkPath;
+  const isActive = window && pathname.replace(/\/$/, '') === linkPath;
 
   const onNavigate = () => {
     if (filteredUrl !== pathname) {

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -37,7 +37,7 @@ const Wrapper = styled.aside`
       left: 0;
 
       width: 100%;
-      height: calc(100vh - 70px);
+      height: calc(100% - 70px);
 
       overflow: auto;
       z-index: 3;

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { hexToRgb } from '@gympass/yoga-common';
-import { Link, navigate } from 'gatsby';
+import { navigate } from 'gatsby';
 import { arrayOf, func, bool, shape, number, string } from 'prop-types';
 
 import Arrow from 'images/arrow-dropdown.svg';
@@ -65,39 +65,17 @@ const StyledList = styled(MDXElements.Ul)`
   width: 100%;
 `;
 
-const AnchorLink = styled(Link)``;
-
 const ArrowIcon = styled(Arrow)`
+  width: 0.6rem;
+  transition: all 200ms ease-out;
   ${({ isOpen }) => `
-    width: 0.6rem;
-    transition: all 200ms ease-out;
     transform: rotate(${isOpen ? 180 : 0}deg);
-  `}
-`;
-
-const StyledListItem = styled.li`
-  ${({
-    active,
-    theme: {
-      yoga: {
-        colors: { primary },
-      },
-    },
-  }) => `
-    & > ${AnchorLink} {
-      ${
-        active
-          ? `
-          color: ${primary};
-            `
-          : ''
-      }
-    }
   `}
 `;
 
 const NavigationLabel = styled.button`
   ${({
+    active,
     level,
     theme: {
       yoga: {
@@ -105,6 +83,14 @@ const NavigationLabel = styled.button`
       },
     },
   }) => `
+  color: ${active ? primary : hexToRgb(text.secondary, 0.75)};
+  text-indent: calc(15px * ${level});
+
+  :hover, :focus {
+    color: ${primary};
+  }
+`}
+
   display: flex;
   justify-content: space-between;
   padding: 10px 0;
@@ -119,15 +105,11 @@ const NavigationLabel = styled.button`
   background: none;
   border: none;
   transition: all 200ms ease-out;
-  color: ${hexToRgb(text.secondary, 0.75)};
-  text-indent: calc(15px * ${level});
   outline-offset: 2px;
 
-  :hover, :focus {
-    color: ${primary};
+  :hover {
     cursor: pointer;
   }
-`};
 `;
 
 const Collapsible = styled(NavigationLabel)`
@@ -156,7 +138,7 @@ const ListItem = ({
 
   const { pathname } = window.location;
   const linkPath = prefix ? `/yoga${filteredUrl}` : filteredUrl;
-  const isActive = window ? pathname.replace(/\/%/, '') === linkPath : false;
+  const isActive = pathname === linkPath;
 
   const onNavigate = () => {
     if (filteredUrl !== pathname) {
@@ -167,21 +149,21 @@ const ListItem = ({
 
   if (linkable) {
     return (
-      <StyledListItem key={url} active={isActive}>
-        <AnchorLink
-          as={NavigationLabel}
+      <li key={url}>
+        <NavigationLabel
           level={level}
           tabindex="0"
+          active={isActive}
           onClick={onNavigate}
         >
           {title}
-        </AnchorLink>
-      </StyledListItem>
+        </NavigationLabel>
+      </li>
     );
   }
 
   return (
-    <StyledListItem key={url} active={isActive}>
+    <li key={url}>
       <Collapsible
         displayChildren={isCollapsed}
         onClick={() => setCollapsed(!isCollapsed)}
@@ -201,7 +183,7 @@ const ListItem = ({
           />
         </StyledList>
       )}
-    </StyledListItem>
+    </li>
   );
 };
 

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -57,35 +57,22 @@ const Nav = styled.div`
 `;
 
 const StyledList = styled(MDXElements.Ul)`
-  font-size: 14px;
+  font-size: 2rem;
+  font-weight: 300;
   list-style-type: none;
   padding: 0;
   margin: 0;
   width: 100%;
 `;
 
-const AnchorLink = styled(Link)`
-  ${({
-    level,
-    theme: {
-      yoga: {
-        colors: { text, primary },
-      },
-    },
-  }) => `
-    color: ${text.secondary};
-    display: flex;
-    justify-content: space-between;
-    padding: 10px 0px 10px 0px;
-    text-decoration: none;
-    text-indent: calc(15px * ${level});
-    transition: all 0.3s;
-    width: 100%;
+const AnchorLink = styled(Link)``;
 
-    :hover {
-      color: ${primary};
-    }
-  `};
+const ArrowIcon = styled(Arrow)`
+  ${({ isOpen }) => `
+    width: 0.6rem;
+    transition: all 200ms ease-out;
+    transform: rotate(${isOpen ? 180 : 0}deg);
+  `}
 `;
 
 const StyledListItem = styled.li`
@@ -109,23 +96,44 @@ const StyledListItem = styled.li`
   `}
 `;
 
-const Colapsible = styled.div`
+const NavigationLabel = styled.button`
   ${({
+    level,
     theme: {
       yoga: {
-        colors: { text },
+        colors: { text, primary },
       },
     },
   }) => `
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  font-family: inherit;
+  letter-spacing: 0.5px;
+  line-height: 2;
+  font-size: 0.9rem;
+  text-decoration: none;
+  font-weight: 300;
+  align-items: center;
+  width: 100%;
+  background: none;
+  border: none;
+  transition: all 200ms ease-out;
+  color: ${hexToRgb(text.secondary, 0.75)};
+  text-indent: calc(15px * ${level});
+  outline-offset: 2px;
+
+  :hover, :focus {
+    color: ${primary};
     cursor: pointer;
-    color: ${hexToRgb(text.secondary, 0.75)};
-    svg {
-      width: 10px;
-      margin-left: 5px;
-    }
-  `};
+  }
+`};
+`;
+
+const Collapsible = styled(NavigationLabel)`
   + ul {
-    display: ${({ visible }) => (visible === 'true' ? 'block' : 'none')};
+    display: ${({ displayChildren }) =>
+      displayChildren === true ? 'block' : 'none'};
   }
 `;
 
@@ -139,7 +147,7 @@ const ListItem = ({
   prefix,
   collapsed,
 }) => {
-  const [collapse, toggleCollapse] = useState(collapsed);
+  const [isCollapsed, setCollapsed] = useState(collapsed);
   const hasChild = Boolean(Object.keys(childs).length);
 
   const filteredUrl = `/${[
@@ -147,33 +155,39 @@ const ListItem = ({
   ].join('/')}`;
 
   const { pathname } = window.location;
+  const linkPath = prefix ? `/yoga${filteredUrl}` : filteredUrl;
+  const isActive = window ? pathname.replace(/\/%/, '') === linkPath : false;
+
+  const onNavigate = () => {
+    if (filteredUrl !== pathname) {
+      navigate(filteredUrl);
+      toggleMenu(false);
+    }
+  };
+
+  if (linkable) {
+    return (
+      <StyledListItem key={url} active={isActive}>
+        <AnchorLink
+          as={NavigationLabel}
+          level={level}
+          tabindex="0"
+          onClick={onNavigate}
+        >
+          {title}
+        </AnchorLink>
+      </StyledListItem>
+    );
+  }
 
   return (
-    <StyledListItem
-      key={url}
-      active={
-        typeof window !== 'undefined' &&
-        pathname.replace(/\/$/, '') ===
-          (prefix ? `/yoga${filteredUrl}` : filteredUrl)
-      }
-    >
-      <AnchorLink
-        level={level}
-        as={Colapsible}
-        visible={collapse.toString()}
-        onClick={() => {
-          if (hasChild) {
-            toggleCollapse(!collapse);
-          }
-          if (filteredUrl !== pathname && linkable) {
-            navigate(filteredUrl);
-            toggleMenu(false);
-          }
-        }}
+    <StyledListItem key={url} active={isActive}>
+      <Collapsible
+        displayChildren={isCollapsed}
+        onClick={() => setCollapsed(!isCollapsed)}
       >
-        {title}{' '}
-        {hasChild ? <Arrow style={{ height: '100%', paddingTop: 10 }} /> : ''}
-      </AnchorLink>
+        {title} <ArrowIcon isOpen={isCollapsed} />
+      </Collapsible>
       {hasChild && (
         <StyledList level={level}>
           <List

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -9,7 +9,7 @@ import createTree from './tree';
 
 import MDXElements from '../MDXElements';
 
-const Wrapper = styled.div`
+const Wrapper = styled.aside`
   ${({
     opened,
     theme: {
@@ -45,7 +45,7 @@ const Wrapper = styled.div`
   `};
 `;
 
-const Nav = styled.div`
+const Nav = styled.nav`
   height: auto;
   padding: 30px;
   width: 100%;
@@ -185,6 +185,9 @@ const ListItem = ({
       <Collapsible
         displayChildren={isCollapsed}
         onClick={() => setCollapsed(!isCollapsed)}
+        aria-label={`Toggle ${title} collapsible section`}
+        role="switch"
+        aria-checked={isCollapsed.toString()}
       >
         {title} <ArrowIcon isOpen={isCollapsed} />
       </Collapsible>
@@ -254,7 +257,7 @@ const Navigation = ({ items, toggleMenu, opened, prefix }) => {
 
   return (
     <Wrapper opened={opened}>
-      <Nav>
+      <Nav aria-label="Contents navigation">
         <List tree={tree} toggleMenu={toggleMenu} prefix={prefix} />
       </Nav>
     </Wrapper>

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -74,23 +74,6 @@ const ArrowIcon = styled(Arrow)`
 `;
 
 const NavigationLabel = styled.button`
-  ${({
-    active,
-    level,
-    theme: {
-      yoga: {
-        colors: { text, primary },
-      },
-    },
-  }) => `
-  color: ${active ? primary : hexToRgb(text.secondary, 0.75)};
-  text-indent: calc(15px * ${level});
-
-  :hover, :focus {
-    color: ${primary};
-  }
-`}
-
   display: flex;
   justify-content: space-between;
   padding: 10px 0;
@@ -110,6 +93,23 @@ const NavigationLabel = styled.button`
   :hover {
     cursor: pointer;
   }
+
+  ${({
+    active,
+    level,
+    theme: {
+      yoga: {
+        colors: { text, primary },
+      },
+    },
+  }) => `
+  color: ${active ? primary : hexToRgb(text.secondary, 0.75)};
+  text-indent: calc(15px * ${level});
+
+  :hover, :focus {
+    color: ${primary};
+  }
+`}
 `;
 
 const Collapsible = styled(NavigationLabel)`


### PR DESCRIPTION
> "That's one small step for man, one giant leap for mankind."

This PR enables keyboard navigation through our sidebar. ✨ This brings us:
- Improved semantics;
- More accessibility (still room to improve in our documentation in general);
- Room and example for future improvements regarding a11y;
- Fix for #343;

It also apply some considerable refactoring into our Navigation component inside docs
This is the current status of the navigation using macOS' VoiceOver (turn sound on)

https://user-images.githubusercontent.com/28108272/136059501-ce994485-a55a-462d-8eed-7c328d9fb040.mp4

Some decisions made:
- Replace px font-size with rem, since rem adapts based on user's font size configuration;
- Add a little transition and rotation to the Collapsible arrow, illustrating its current state
- Use an if statement to conditionally render collapsible of link, since it improved a lot this code readability
- Move some booleans to declarations outside, also improving JSX readability

| Before | After | Focused (after) |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/28108272/136058750-fe9b726e-4f6d-4678-96bd-3ae341563412.png) | ![image](https://user-images.githubusercontent.com/28108272/136058839-76f9c180-56ce-45ff-9c14-7ce3dfb43a44.png) | ![image](https://user-images.githubusercontent.com/28108272/136058867-439061dc-3a60-43c3-96d7-f10daaa3cf69.png) |

There is a slightly difference between before and after due to the change to rem.

