### PR TITLE
[Fix | Doc] Apply indentation to collapsibles

### DIFF
--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -169,6 +169,7 @@ const ListItem = ({
         onClick={() => setCollapsed(!isCollapsed)}
         aria-label={`Toggle ${title} collapsible section`}
         role="switch"
+        level={level}
         aria-checked={isCollapsed.toString()}
       >
         {title} <ArrowIcon isOpen={isCollapsed} />


### PR DESCRIPTION
I mistakenly forgot to apply indentation (level prop) to this new `<Collapsible />` button. Already fixed, just a visual issue!

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/28108272/136252933-167b8ca9-8101-40fd-88ed-d26a68456db2.png) | ![image](https://user-images.githubusercontent.com/28108272/136253073-46e1b5ef-8d37-489a-9643-795b6d5e6059.png)[^1] |

[^1]: Look at 'Tag' component text indent.


