### PR TITLE
✨ Add new props gap to system

### DIFF
--- a/packages/doc/content/system/system/flex.mdx
+++ b/packages/doc/content/system/system/flex.mdx
@@ -199,7 +199,7 @@ The `flexes` module has all the listed above
         <inlineCode>gap</inlineCode>
       </td>
       <td>
-        <inlineCode>gap</inlineCode>, <inlineCode>g</inlineCode>
+        <inlineCode>gap</inlineCode>
       </td>
       <td>
         <inlineCode>gap</inlineCode>

--- a/packages/system/src/flex.js
+++ b/packages/system/src/flex.js
@@ -96,7 +96,7 @@ const order = props =>
 const gap = props =>
   generator({
     props,
-    prop: ['gap', 'g'],
+    prop: ['gap'],
     cssProperty: 'gap',
     getter: getSpacing,
     transform: toPx,

--- a/packages/system/src/flex.test.js
+++ b/packages/system/src/flex.test.js
@@ -192,31 +192,20 @@ describe('flex', () => {
         gap: spacings.medium,
       });
 
-      const zero1 = gap({ theme, g: 'zero' });
-      const zero2 = gap({ theme, gap: 'zero' });
+      const zero = gap({ theme, gap: 'zero' });
+      const medium = gap({ theme, gap: 'medium' });
 
-      expect(zero1).toStrictEqual(zero2);
+      expect(zero).toStrictEqual(expectedZeroSpacing);
 
-      const medium1 = gap({ theme, g: 'medium' });
-      const medium2 = gap({ theme, gap: 'medium' });
-
-      expect(medium1).toStrictEqual(medium2);
-
-      const zeroOptions = [zero1, zero2];
-
-      zeroOptions.map(z => expect(z).toStrictEqual(expectedZeroSpacing));
-
-      const mediumOptions = [medium1, medium2];
-
-      mediumOptions.map(m => expect(m).toStrictEqual(expectedMediumSpacing));
+      expect(medium).toStrictEqual(expectedMediumSpacing);
     });
 
     it('Should return the value if there is no theme match', () => {
       const expectedNoTheme = css({
-        gap: 20,
+        gap: '50%',
       });
 
-      const g = gap({ theme, g: 20 });
+      const g = gap({ theme, gap: '50%' });
 
       expect(g).toStrictEqual(expectedNoTheme);
     });


### PR DESCRIPTION
## Motivation

Keeping the work in `@gympass/system`, we're adding the follow new props:

- `gap`


Those updates will be reflected into our Box component as it makes use of the `system` module

### Checklist

- [x] Unit tests