### PR TITLE
[Navigation list] Fix components list sorting behaviour across browsers

### DIFF
--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -12,7 +12,7 @@ import MDXElements from '../MDXElements';
 /**
  * Gets the sorting function for the given sorting type.
  * 'alphabetic' stands for ascendent alphabetical order.
- * 'order'      stands for elemento.order ascendent order.
+ * 'order'      stands for element.order ascendent order.
  *
  * @param {string} kind - 'alphabetic' or 'order', default to 'order'
  * @returns {function} - sorting function


### PR DESCRIPTION
Due to how Chromium handles JS internals + how we were doing our ordering before, `components` section were ordered right in alphabetical order, while in Firefox it was being displayed "upside down". I explicitly defined a different ordering function to this section that can be reused in other sections if needed in the future.

| Before (Firefox Developer Edition) | After (Firefox Developer Edition) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/28108272/138160441-76ae0cee-60e9-4f72-a623-11d890f8144e.png) | ![image](https://user-images.githubusercontent.com/28108272/138160379-c4b57eb6-a4cd-4b8a-909d-7ae35da89d03.png) |
