### PR TITLE
[Fix | Snackbar] Use proper `box-sizing: border-box;` inside its container

### DIFF
--- a/packages/yoga/src/Snackbar/web/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/web/Snackbar.jsx
@@ -48,6 +48,7 @@ const StyledSnackbar = styled.div`
       display: flex;
       align-items: center;
       justify-content: space-between;
+      box-sizing: border-box;
   
       position: fixed;
       bottom: ${snackbar.position.mobile.bottom}px;

--- a/packages/yoga/src/Snackbar/web/__snapshots__/Snackbar.test.jsx.snap
+++ b/packages/yoga/src/Snackbar/web/__snapshots__/Snackbar.test.jsx.snap
@@ -65,6 +65,7 @@ exports[`<Snackbar /> should match snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  box-sizing: border-box;
   position: fixed;
   bottom: 16px;
   right: 16px;


### PR DESCRIPTION
Our Snackbar use the default `box-sizing` value of `content-box`, which "breaks" the desired style if the client project doesn't reset the box-sizing CSS for a project. 

This changes make it opt-out the usage of `box-sizing: border-box` instead of opt-in, this way we can quickly make projects using Yoga without having to extend the snackbar just to make it have the correct style.

| Before (without rewriting box-sizing) | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/28108272/138452267-6f3c26fd-9a17-4199-8feb-742973c65724.png) | ![image](https://user-images.githubusercontent.com/28108272/138452303-3ac37e0b-de93-45d3-98ae-c76e977eca13.png) |

Check [this codesandbox demo](https://codesandbox.io/s/brave-oskar-jg8id?file=/src/App.js) to see the fix in action.