### PR TITLE
ci: Use actions-provided GitHub token

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/labeler@v2
         with:
-          repo-token: '${{ secrets.GH_TOKEN }}'
+          repo-token: '${{ github.token }}'

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,11 +17,11 @@ jobs:
           persist-credentials: false
       - name: Configure CI Git User
         run: |
-          git remote set-url origin https://${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
           git config --global user.email yoga@gympass.com
           git config --global user.name Yoga
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -37,13 +37,13 @@ jobs:
           yarn build:packages
       - name: Publish
         run: |
-          GH_TOKEN=${GH_TOKEN}
+          GH_TOKEN=${{ github.token }}
           NPM_TOKEN=${NPM_TOKEN}
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ./.npmrc
           chmod +x ./scripts/publish
           ./scripts/publish
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   doc:
     runs-on: ubuntu-latest
@@ -52,12 +52,12 @@ jobs:
       - uses: actions/checkout@v1
       - name: Configure CI Git User
         run: |
-          git remote set-url origin https://${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
           git checkout master
           git config --global user.email yoga@gympass.com
           git config --global user.name Yoga
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12


### PR DESCRIPTION
This updates workflows to use a token provided by GitHub Actions instead of relying on a pre-configured one.