### PR TITLE
refactor(input-web-legend): replace hacky numbers

### DIFF
--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -29,7 +29,9 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
 }
 
 .c3:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -233,7 +235,9 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
 }
 
 .c3:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -437,7 +441,9 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
 }
 
 .c3:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -482,7 +488,9 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
 }
 
 .c3 ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
 }
 
 .c3 ~ label {
@@ -790,7 +798,9 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 }
 
 .c3:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -835,7 +845,9 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 }
 
 .c3 ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
 }
 
 .c3 ~ label {

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -64,7 +64,7 @@ const Field = styled.input`
       color: ${input.font.color.focus};
 
       & ~ legend {
-        max-width: 1000px;
+        max-width: max-content;
         transition-property: max-width;
         transition-duration: ${transition.duration[1]}ms;
       }
@@ -91,7 +91,7 @@ const Field = styled.input`
     ${value &&
       css`
         & ~ legend {
-          max-width: 1000px;
+          max-width: max-content;
         }
 
         & ~ label {

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -29,7 +29,9 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -29,7 +29,9 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -216,7 +218,9 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -408,7 +412,9 @@ exports[`<Input /> Snapshots should match with error 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -630,7 +636,9 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -817,7 +825,9 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -1046,7 +1056,9 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -1268,7 +1280,9 @@ exports[`<Input /> Snapshots should match with label 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -29,7 +29,9 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -29,7 +29,9 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
 }
 
 .c3:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -261,7 +263,9 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
 }
 
 .c3:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;
@@ -502,7 +506,9 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
 }
 
 .c3:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -29,7 +29,9 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -96,7 +96,9 @@ exports[`<TextArea /> should match snapshot 1`] = `
 }
 
 .c2:focus ~ legend {
-  max-width: 1000px;
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
   -webkit-transition-property: max-width;
   transition-property: max-width;
   -webkit-transition-duration: 500ms;


### PR DESCRIPTION
This intend to remove the "magical" `1000px` width for the legend tag that prevents the input border from overlapping the input label layout (example below)

![image](https://user-images.githubusercontent.com/28108272/140560860-bafc1a6d-18a3-4b87-a9f7-8b3318d1510c.png)

The update keeps the current behavior of it. We should look forward the future to replace this workaround (kinda gambiarra) with some proper way of preventing it.

https://user-images.githubusercontent.com/28108272/140560003-a274b3bf-e605-4b49-afa2-a0cd8a8e698c.mp4

