### PR TITLE
fix(npm-publish): use correct format for GH access token

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - name: Configure CI Git User
         run: |
-          git remote set-url origin https://${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
           git config --global user.email yoga@gympass.com
           git config --global user.name Yoga
         env:
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Configure CI Git User
         run: |
-          git remote set-url origin https://${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
           git checkout master
           git config --global user.email yoga@gympass.com
           git config --global user.name Yoga


### PR DESCRIPTION
## Problem

After we started using a Github Actions provided token instead of a personal one, we needed to also update the format we're using to authenticate with NPM, which this PR fixes in `npmpublish`'s workflow.