### PR TITLE
fix(npm-publish): use custom token with greater permissions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - name: Configure CI Git User
         run: |
-          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://x-access-token:${{ secrets.GYMPASS_YOGA_DEPLOY_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
           git config --global user.email yoga@gympass.com
           git config --global user.name Yoga
         env:
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Configure CI Git User
         run: |
-          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://x-access-token:${{ secrets.GYMPASS_YOGA_DEPLOY_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
           git checkout master
           git config --global user.email yoga@gympass.com
           git config --global user.name Yoga


### PR DESCRIPTION
## Problem
Continues #389 
We needed to create a new token with a greater push permission in order to making the CI able to work by itself