### PR TITLE
[Docs] Reorder component pages and improve ordering inference

### DIFF
--- a/packages/doc/content/components/components/index.mdx
+++ b/packages/doc/content/components/components/index.mdx
@@ -3,7 +3,7 @@ title: 'Components'
 metaTitle: 'Components List Page'
 metaDescription: 'This is the list of Components'
 linkable: false
-order: 1
+order: 4
 ---
 
 <Redirect url="/components/getting-started" />

--- a/packages/doc/content/components/helpers/index.mdx
+++ b/packages/doc/content/components/helpers/index.mdx
@@ -3,4 +3,5 @@ title: 'Helpers'
 metaTitle: 'Helpers'
 metaDescription: 'A collection of helpers from Yoga'
 linkable: false
+order: 3
 ---

--- a/packages/doc/content/components/icons/index.mdx
+++ b/packages/doc/content/components/icons/index.mdx
@@ -2,6 +2,7 @@
 title: 'Icons'
 metaTitle: 'Icons'
 metaDescription: 'Icons Component'
+order: 2
 ---
 
 import * as YogaIcons from '@gympass/yoga-icons';

--- a/packages/doc/content/components/theming/index.mdx
+++ b/packages/doc/content/components/theming/index.mdx
@@ -4,4 +4,5 @@ metaTitle: 'Theming'
 metaDescription: 'Theming Utilities'
 linkable: false
 open: false
+order: 1
 ---

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -83,12 +83,16 @@ const StyledList = styled(MDXElements.Ul)`
   width: 100%;
 `;
 
-const ArrowIcon = styled(Arrow)`
-  width: 0.6rem;
-  transition: all 200ms ease-out;
-  ${({ isOpen }) => `
-    transform: rotate(${isOpen ? 180 : 0}deg);
+const ChevronContainer = styled.div.attrs({
+  rotation: props => (props.isOpen ? 180 : 0),
+})`
+  > svg {
+    width: 0.6rem;
+    transition: all 200ms ease-out;
+    ${({ rotation }) => `
+    transform: rotate(${rotation}deg);
   `}
+  }
 `;
 
 const NavigationLabel = styled.button`
@@ -191,7 +195,10 @@ const ListItem = ({
         level={level}
         aria-checked={isOpen.toString()}
       >
-        {title} <ArrowIcon isOpen={isOpen} />
+        {title}{' '}
+        <ChevronContainer isOpen={isOpen}>
+          <Arrow />
+        </ChevronContainer>
       </Collapsible>
       {hasChildren && (
         <StyledList level={level}>

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { hexToRgb } from '@gympass/yoga-common';
 import { navigate } from 'gatsby';
-import { arrayOf, func, oneOf, bool, shape, number, string } from 'prop-types';
+import { arrayOf, func, bool, shape, number, string } from 'prop-types';
 
 import Arrow from 'images/arrow-dropdown.svg';
 import createTree from './tree';
@@ -217,11 +217,10 @@ ListItem.propTypes = {
   open: bool.isRequired,
 };
 
-const List = ({ tree, level, toggleMenu, prefix, sorting }) => {
-  const sortingFunction =
-    sorting || Object.keys(tree).some(child => child?.order)
-      ? SORTING.orderAscending
-      : SORTING.alphabeticAscending;
+const List = ({ tree, level, toggleMenu, prefix }) => {
+  const sortingFunction = Object.keys(tree).some(child => tree[child]?.order)
+    ? SORTING.orderAscending
+    : SORTING.alphabeticAscending;
 
   return (
     <StyledList>
@@ -251,12 +250,10 @@ List.propTypes = {
   level: number,
   toggleMenu: func.isRequired,
   prefix: bool.isRequired,
-  sorting: oneOf(Object.values(SORTING)),
 };
 
 List.defaultProps = {
   level: 0,
-  sorting: 'order',
 };
 
 const Navigation = ({ items, toggleMenu, opened, prefix }) => {
@@ -271,12 +268,7 @@ const Navigation = ({ items, toggleMenu, opened, prefix }) => {
   return (
     <Wrapper opened={opened}>
       <Nav>
-        <List
-          tree={tree}
-          toggleMenu={toggleMenu}
-          prefix={prefix}
-          sorting={SORTING.orderAscending}
-        />
+        <List tree={tree} toggleMenu={toggleMenu} prefix={prefix} />
       </Nav>
     </Wrapper>
   );


### PR DESCRIPTION
- Improve order inference (by removing unneeded 'sorting' prop)
- Fix console errors due to svg receiving directly the `isOpen` prop
- Add explicit order to component screen pages
The goal is to have consistency across browsers and also make more sense for one reading our docs:

| New (default) | New (collapsed) |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/28108272/141503236-a208e9f9-2771-46b7-b0ac-f2aafd58b616.png) | ![image](https://user-images.githubusercontent.com/28108272/141503282-ec6cf8f5-8afe-446b-a45a-443e97992677.png) |
