### PR TITLE
Dropdown: Adjust misaligned Chevron

### DIFF
--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -135,7 +135,6 @@ const Button = styled.button`
 
     width: 100%;
     height: 100%;
-    padding-top: ${dropdown.button.padding.top}px;
     padding-right: ${dropdown.button.padding.right}px;
 
     border: none;

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -193,7 +193,6 @@ exports[`<Dropdown /> should match snapshot 1`] = `
   left: 0;
   width: 100%;
   height: 100%;
-  padding-top: 16px;
   padding-right: 16px;
   border: none;
   outline: none;
@@ -461,7 +460,6 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
   left: 0;
   width: 100%;
   height: 100%;
-  padding-top: 16px;
   padding-right: 16px;
   border: none;
   outline: none;
@@ -738,7 +736,6 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
   left: 0;
   width: 100%;
   height: 100%;
-  padding-top: 16px;
   padding-right: 16px;
   border: none;
   outline: none;
@@ -1026,7 +1023,6 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
   left: 0;
   width: 100%;
   height: 100%;
-  padding-top: 16px;
   padding-right: 16px;
   border: none;
   outline: none;
@@ -1368,7 +1364,6 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
   left: 0;
   width: 100%;
   height: 100%;
-  padding-top: 16px;
   padding-right: 16px;
   border: none;
   outline: none;


### PR DESCRIPTION
During the rebase I did in @frgiovanna's PR I accidentally updated the height of the dropdown without removing the padding, which misaligned our Chevron. This PRs removes the padding in order to rely on flex to center the element, making it aligned again. 😅 

**Current:**
![image](https://user-images.githubusercontent.com/28108272/141460991-922ef755-d4fb-44e5-b3f3-2761536cfb54.png)

**Now:**

https://user-images.githubusercontent.com/28108272/141460953-4211704f-0ff3-4564-b0fd-2279b83de5a1.mp4

