### PR TITLE
Update main job and remove bloat from `npmpublish` workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
     - name: Install dependencies
       run: yarn
     - name: Run linter
-      run: yarn eslint
+      run: yarn lint:all
     - name: Run tests
       run: yarn test

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -28,10 +28,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn --pure-lockfile --non-interactive
-      - name: Lint
-        run: yarn lint:all
-      - name: Test
-        run: yarn test
       - name: Build
         run: |
           yarn build:packages


### PR DESCRIPTION
- Use the correct lint command in `linter_and_tests` job
- Remove redundant steps from `npmpublish` (every PR will already have them, so we don't need to repeat it) job in order to make it faster