### PR TITLE
fix(dialog): replace relative import with package import

### DIFF
--- a/packages/yoga/src/Dialog/web/Dialog.jsx
+++ b/packages/yoga/src/Dialog/web/Dialog.jsx
@@ -3,9 +3,9 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { func, bool, node } from 'prop-types';
 
+import { Close } from '@gympass/yoga-icons';
 import { usePortal } from '../../hooks';
 import { Button, Card, Box } from '../..';
-import { Close } from '../../../../icons/src';
 
 const StyledDialog = styled(Card)`
   ${({


### PR DESCRIPTION
We were importing content from the icons package relative while it's actually another package.

![image](https://user-images.githubusercontent.com/28108272/141497214-bf601a6e-38ed-4c3a-9dcc-2bbb15aca588.png)

Thanks for reporting @frgiovanna 