### PR TITLE
fix(dropdown): pass the full prop to input component

### DIFF
--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -301,6 +301,7 @@ const Dropdown = ({
             selected={selectedItem !== null}
             isOpen={isOpen}
             label={label}
+            full={full}
             {...getInputProps()}
           />
           <Button

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -632,7 +632,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  width: 320px;
+  width: 100%;
   height: 52px;
   padding-left: 12px;
   border-radius: 8px;
@@ -697,7 +697,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
 
 .c2 {
   box-sizing: border-box;
-  width: 320px;
+  width: 100%;
 }
 
 .c0 {


### PR DESCRIPTION
Was noticed that our current Dropdown wasn't working properly with the full prop. 
The problem was happening because, on the previous PR about the component, we weren't passing the `full` prop to Input component. 
In this PR we are solving this

**Before:**
![image](https://user-images.githubusercontent.com/54802614/141511885-560661be-c617-43e5-9219-20f7721558e0.png)

**After:**
![image](https://user-images.githubusercontent.com/54802614/141511756-1748742e-831b-4439-b997-19157e5833b4.png)
