### PR TITLE
Adjust bottom sheet positioning for safari

### DIFF
--- a/packages/yoga/src/BottomSheet/web/BottomSheet.jsx
+++ b/packages/yoga/src/BottomSheet/web/BottomSheet.jsx
@@ -15,7 +15,7 @@ const StyledBottomSheet = styled(Dialog)`
   width: ${bottomsheet.width.default}%;
   border-radius: ${bottomsheet.border.radius}px ${bottomsheet.border.radius}px 0 0;
   `}
-  align-self: end;
+  align-self: flex-end;
   animation: content;
   animation-duration: 400ms;
   animation-fill-mode: forwards;

--- a/packages/yoga/src/BottomSheet/web/__snapshots__/BottomSheet.test.jsx.snap
+++ b/packages/yoga/src/BottomSheet/web/__snapshots__/BottomSheet.test.jsx.snap
@@ -149,9 +149,9 @@ exports[`<BottomSheet /> should match snapshot 1`] = `
   padding: 24px 20px 24px 20px;
   width: 100%;
   border-radius: 16px 16px 0 0;
-  -webkit-align-self: end;
+  -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
-  align-self: end;
+  align-self: flex-end;
   -webkit-animation: content;
   animation: content;
   -webkit-animation-duration: 400ms;


### PR DESCRIPTION

## Changes
- Change `align-self: end` to `align-self: flex-end`. 
- Update tests snapshots

## Screenshots
**Bug**

<img width="442" alt="Screen Shot 2021-11-17 at 08 42 48" src="https://user-images.githubusercontent.com/27781419/142204692-eb893ee1-edb0-4010-9391-393c61a98efd.png">

