### PR TITLE
fix(result): fix conditional to show additional items in the activiti…

### DIFF
--- a/packages/yoga/src/Result/native/Details.jsx
+++ b/packages/yoga/src/Result/native/Details.jsx
@@ -55,7 +55,7 @@ const ResultDetails = ({
           ({ icon: IconComponent, variant, ...props }, index) => {
             const isLastItem = index === refinedList.length - 1;
             const showNumbersOfItemsLeft =
-              isLastItem && limit !== 0 && limit < items.length - 1;
+              isLastItem && limit !== 0 && limit < items.length;
 
             return (
               // eslint-disable-next-line react/no-array-index-key


### PR DESCRIPTION
## Description 📄
The problem fixed in this PR only happened when the item limit was less than the total array by 1 item. So in a scenario where we have an array with 3 items and the limit is set to 2 the text '+1' would not be shown at the end of the activity list.

#### Array example
`[
  {
    children: 'Yoga',
    variant: 'deep',
    icon: PinFilled,
  },
  {
    children: 'Meditation',
    variant: 'deep',
  },
  {
    children: 'Pilates',
    variant: 'deep',
  }
]`


## Screenshots 📸

| Before |  After | 
| ------ | ------ | 
|    ![image](https://user-images.githubusercontent.com/44280864/143073649-a9253940-d523-47fa-b589-e1d14f55ab3a.png)    |        ![image](https://user-images.githubusercontent.com/44280864/143073685-842aa1f9-da5f-44a6-8d8a-9f93ab1fa65d.png)    |   