### PR TITLE
fix(dropdown-native): options require cycle in android

### DIFF
--- a/packages/yoga/src/Dropdown/native/Options.android.jsx
+++ b/packages/yoga/src/Dropdown/native/Options.android.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { func, arrayOf, string, shape, number, oneOfType } from 'prop-types';
 import { TouchableWithoutFeedback } from 'react-native';
-import { Text, List } from '../..';
+import Text from '../../Text';
+import List from '../../List';
 
 const Option = styled(List.Item)`
   ${({


### PR DESCRIPTION
There was a missing require cycle occurring in Android Options (from native dropdown). This import update fixes it.