### PR TITLE
refactor: Allow number with slice as progress label and update native font color

### DIFF
--- a/packages/yoga/src/Progress/native/Progress.jsx
+++ b/packages/yoga/src/Progress/native/Progress.jsx
@@ -90,6 +90,7 @@ const Label = styled.Text`
       yoga: {
         baseFont,
         spacing,
+        colors,
         components: { progress },
       },
     },
@@ -97,6 +98,7 @@ const Label = styled.Text`
   font-family: ${baseFont.family};
   font-size: ${progress.label.font.size}px;
   text-align: ${align};
+  color: ${colors.deep};
 
   ${
     isNumber

--- a/packages/yoga/src/Progress/native/Progress.jsx
+++ b/packages/yoga/src/Progress/native/Progress.jsx
@@ -116,7 +116,7 @@ const Label = styled.Text`
  * of quantity.  The use of labels numeric or alphabetic can increase the user
  * understanding. */
 const Progress = ({ label, max, value, variant, ...props }) => {
-  const isNumber = !isNaN(label.value);
+  const isNumber = !/[a-zA-Z]/g.test(label.value);
   const align = label.placement || 'left';
 
   return (

--- a/packages/yoga/src/Progress/native/__snapshots__/Progress.test.jsx.snap
+++ b/packages/yoga/src/Progress/native/__snapshots__/Progress.test.jsx.snap
@@ -212,6 +212,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -275,6 +276,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -338,6 +340,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -401,6 +404,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -464,6 +468,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -527,6 +532,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -590,6 +596,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -653,6 +660,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -716,6 +724,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -779,6 +788,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -842,6 +852,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -905,6 +916,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -968,6 +980,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -1031,6 +1044,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -1094,6 +1108,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -1157,6 +1172,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -1220,6 +1236,7 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -1489,6 +1506,7 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginRight": 8,
@@ -1552,6 +1570,7 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginLeft": 8,
@@ -1628,6 +1647,7 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginTop": 4,
@@ -1690,6 +1710,7 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
       style={
         Array [
           Object {
+            "color": "#6B6B78",
             "fontFamily": "Rubik",
             "fontSize": 12,
             "marginTop": 4,

--- a/packages/yoga/src/Progress/web/Progress.jsx
+++ b/packages/yoga/src/Progress/web/Progress.jsx
@@ -138,7 +138,7 @@ Wrapper.defaultProps = {
  * of quantity. The use of labels numeric or alphabetic can increase the user
  * understanding. */
 const Progress = ({ label, max, value, variant, ...props }) => {
-  const isNumber = !isNaN(label.value);
+  const isNumber = !/[a-zA-Z]/g.test(label.value);
 
   return (
     <Wrapper isNumber={isNumber} align={label.placement} {...props}>


### PR DESCRIPTION
- Update `Progress` component allowing number with slice (`/`) label to be placed next to the bar and update font color that was using `stamina` as default.

- [Yoga Figma](https://www.figma.com/file/wn9grDi9mM29Wt7LmQjol7/Yoga-Design-System-7.1?node-id=4623%3A3850)
- [Feature Figma](https://www.figma.com/file/WI7iB8gTsIrY4WhWybpDwN/%5BHercules%5D-Product-Restrictions?node-id=3%3A2)

| Mobile Before | Mobile After |
| ------ | ----- |
|   <img src="https://user-images.githubusercontent.com/18318587/145090274-1b942244-192e-44cd-b866-d319d4a7f6ad.png" width="300">     |    <img src="https://user-images.githubusercontent.com/18318587/145090284-ce1092f1-55ab-47a2-9f97-63f205154d23.png" width="300">     |

| Web Before | Web After |
| ------ | ----- |
|   <img src="https://user-images.githubusercontent.com/18318587/145090902-44a4bbdc-5f7b-438a-aac0-e6e0e7f5bd71.png">     |    <img src="https://user-images.githubusercontent.com/18318587/145090951-9cdf4486-3b76-4f83-96d5-dd022043d35c.png" >     |