### PR TITLE
fix(dropdown): fix behavior when we have the error prop

### DIFF
--- a/packages/yoga/src/Divider/native/__snapshots__/Divider.test.jsx.snap
+++ b/packages/yoga/src/Divider/native/__snapshots__/Divider.test.jsx.snap
@@ -728,7 +728,6 @@ exports[`<Divider /> should create a divider component 1`] = `
               "divider": Object {},
               "dropdown": Object {
                 "arrow": Object {
-                  "error": "#FF874C",
                   "fill": "#6B6B78",
                 },
                 "backdrop": Object {
@@ -2201,7 +2200,6 @@ exports[`<Divider /> should create vertical divider component 1`] = `
               "divider": Object {},
               "dropdown": Object {
                 "arrow": Object {
-                  "error": "#FF874C",
                   "fill": "#6B6B78",
                 },
                 "backdrop": Object {

--- a/packages/yoga/src/Divider/native/__snapshots__/Divider.test.jsx.snap
+++ b/packages/yoga/src/Divider/native/__snapshots__/Divider.test.jsx.snap
@@ -728,6 +728,7 @@ exports[`<Divider /> should create a divider component 1`] = `
               "divider": Object {},
               "dropdown": Object {
                 "arrow": Object {
+                  "error": "#FF874C",
                   "fill": "#6B6B78",
                 },
                 "backdrop": Object {
@@ -798,6 +799,7 @@ exports[`<Divider /> should create a divider component 1`] = `
                   "selector": Object {
                     "border": Object {
                       "color": "#231B22",
+                      "error": "#FF874C",
                     },
                   },
                 },
@@ -2199,6 +2201,7 @@ exports[`<Divider /> should create vertical divider component 1`] = `
               "divider": Object {},
               "dropdown": Object {
                 "arrow": Object {
+                  "error": "#FF874C",
                   "fill": "#6B6B78",
                 },
                 "backdrop": Object {
@@ -2269,6 +2272,7 @@ exports[`<Divider /> should create vertical divider component 1`] = `
                   "selector": Object {
                     "border": Object {
                       "color": "#231B22",
+                      "error": "#FF874C",
                     },
                   },
                 },

--- a/packages/yoga/src/Dropdown/Dropdown.theme.js
+++ b/packages/yoga/src/Dropdown/Dropdown.theme.js
@@ -26,7 +26,6 @@ const Dropdown = ({
   },
   arrow: {
     fill: colors.text.secondary,
-    error: colors.verve,
   },
   input: {
     font: {

--- a/packages/yoga/src/Dropdown/Dropdown.theme.js
+++ b/packages/yoga/src/Dropdown/Dropdown.theme.js
@@ -26,6 +26,7 @@ const Dropdown = ({
   },
   arrow: {
     fill: colors.text.secondary,
+    error: colors.verve,
   },
   input: {
     font: {
@@ -129,6 +130,7 @@ const Dropdown = ({
     selector: {
       border: {
         color: colors.text.primary,
+        error: colors.verve,
       },
     },
     option: {

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -251,7 +251,6 @@ const ArrowIcon = styled(({ isOpen, selected, ...props }) => (
     isOpen,
     selected,
     disabled,
-    error,
     theme: {
       yoga: {
         components: { dropdown },
@@ -261,7 +260,6 @@ const ArrowIcon = styled(({ isOpen, selected, ...props }) => (
     fill: ${dropdown.arrow.fill};
     ${disabled ? `fill: ${dropdown.disabled.arrow.fill};` : ''};
     ${selected && !disabled ? `fill: ${dropdown.selected.arrow.fill};` : ''};
-    ${error && !disabled && !isOpen ? `fill: ${dropdown.arrow.error} ;` : ''};
     transform: rotate(${isOpen ? '180deg' : '0'});
   `}
 `;
@@ -320,7 +318,6 @@ const Dropdown = ({
               isOpen={isOpen}
               selected={selectedItem !== null}
               disabled={disabled}
-              error={error}
             />
           </Button>
         </Selector>

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -77,9 +77,6 @@ const Selector = styled.div`
             ${
               error && !isOpen
                 ? `border-color: ${colors.feedback.attention[1]};
-                label {
-                  color:${colors.feedback.attention[1]}; 
-                };
                 `
                 : ''
             }

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -84,20 +84,14 @@ const Selector = styled.div`
                 : ''
             }
           }
-          ${
-            error && !isOpen
-              ? `
-              &:hover {
-              fieldset {
-                border-color: ${dropdown.hover.selector.border.error};
-              }
-            }`
-              : ` 
-              &:hover {
-              fieldset {
-                border-color: ${dropdown.hover.selector.border.color};
-              }
-            }`
+          &:hover {
+            fieldset {
+              border-color: ${
+                error && !isOpen
+                  ? dropdown.hover.selector.border.error
+                  : dropdown.hover.selector.border.color
+              };
+            }
           }
         `
       : ''}

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -76,14 +76,28 @@ const Selector = styled.div`
 
             ${
               error && !isOpen
-                ? `border-color: ${colors.feedback.attention[1]};`
+                ? `border-color: ${colors.feedback.attention[1]};
+                label {
+                  color:${colors.feedback.attention[1]}; 
+                };
+                `
                 : ''
             }
           }
-          &:hover {
-            fieldset {
-              border-color: ${dropdown.hover.selector.border.color};
-            }
+          ${
+            error && !isOpen
+              ? `
+              &:hover {
+              fieldset {
+                border-color: ${dropdown.hover.selector.border.error};
+              }
+            }`
+              : ` 
+              &:hover {
+              fieldset {
+                border-color: ${dropdown.hover.selector.border.color};
+              }
+            }`
           }
         `
       : ''}
@@ -134,8 +148,8 @@ const Button = styled.button`
     left: 0;
 
     width: 100%;
-    height: 100%;
     padding-right: ${dropdown.button.padding.right}px;
+    padding-top: ${dropdown.button.padding.top}px;
 
     border: none;
     outline: none;
@@ -246,6 +260,7 @@ const ArrowIcon = styled(({ isOpen, selected, ...props }) => (
     isOpen,
     selected,
     disabled,
+    error,
     theme: {
       yoga: {
         components: { dropdown },
@@ -255,6 +270,7 @@ const ArrowIcon = styled(({ isOpen, selected, ...props }) => (
     fill: ${dropdown.arrow.fill};
     ${disabled ? `fill: ${dropdown.disabled.arrow.fill};` : ''};
     ${selected && !disabled ? `fill: ${dropdown.selected.arrow.fill};` : ''};
+    ${error && !disabled && !isOpen ? `fill: ${dropdown.arrow.error} ;` : ''};
     transform: rotate(${isOpen ? '180deg' : '0'});
   `}
 `;
@@ -313,6 +329,7 @@ const Dropdown = ({
               isOpen={isOpen}
               selected={selectedItem !== null}
               disabled={disabled}
+              error={error}
             />
           </Button>
         </Selector>

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -1374,7 +1374,6 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
 .c10 {
   fill: #6B6B78;
   fill: #231B22;
-  fill: undefined;
   -webkit-transform: rotate(0);
   -ms-transform: rotate(0);
   transform: rotate(0);
@@ -1433,7 +1432,6 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
       >
         <svg
           class="c10"
-          error="Please, select one activity"
           height="20"
           width="20"
         />

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -192,8 +192,8 @@ exports[`<Dropdown /> should match snapshot 1`] = `
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
   padding-right: 16px;
+  padding-top: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -459,8 +459,8 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
   padding-right: 16px;
+  padding-top: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -735,8 +735,8 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
   padding-right: 16px;
+  padding-top: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -1022,8 +1022,8 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
   padding-right: 16px;
+  padding-top: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -1320,8 +1320,12 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
   border-color: #FF874C;
 }
 
+.c1 fieldset label {
+  color: #FF874C;
+}
+
 .c1:hover fieldset {
-  border-color: #231B22;
+  border-color: #FF874C;
 }
 
 .c5 {
@@ -1363,8 +1367,8 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
   padding-right: 16px;
+  padding-top: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -1374,6 +1378,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
 .c10 {
   fill: #6B6B78;
   fill: #231B22;
+  fill: #FF874C;
   -webkit-transform: rotate(0);
   -ms-transform: rotate(0);
   transform: rotate(0);
@@ -1432,6 +1437,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
       >
         <svg
           class="c10"
+          error="Please, select one activity"
           height="20"
           width="20"
         />

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -1320,10 +1320,6 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
   border-color: #FF874C;
 }
 
-.c1 fieldset label {
-  color: #FF874C;
-}
-
 .c1:hover fieldset {
   border-color: #FF874C;
 }
@@ -1378,7 +1374,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
 .c10 {
   fill: #6B6B78;
   fill: #231B22;
-  fill: #FF874C;
+  fill: undefined;
   -webkit-transform: rotate(0);
   -ms-transform: rotate(0);
   transform: rotate(0);


### PR DESCRIPTION
Was noticed that the last version of the dropdown component has a weird behavior when we pass an error text to it. 
This PR fixes it. 

**Changes:**
- Fix arrow Icon behavior
- Change label color 

**Screenshots**

Before:
![Screenshot from 2021-12-16 14-49-34](https://user-images.githubusercontent.com/54802614/146422973-17cfd156-f372-4d16-8e79-e2d354e093e5.png)

After:
![Screenshot from 2021-12-16 14-47-29](https://user-images.githubusercontent.com/54802614/146422855-2d3beaa9-d3b7-48e0-a8d0-bde0dfd297cf.png)

