### PR TITLE
refactor(input): change color of label and border

### DIFF
--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -176,6 +176,7 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
       <fieldset
         class="c2"
         label="Label"
+        value=""
       >
         <input
           aria-autocomplete="list"
@@ -382,6 +383,7 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
       <fieldset
         class="c2"
         label="Label"
+        value=""
       >
         <input
           aria-autocomplete="list"
@@ -528,6 +530,7 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
   border-width: 1px;
   border-style: solid;
   border-color: #D7D7E0;
+  border-color: #231B22;
 }
 
 .c2:hover,
@@ -695,6 +698,7 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
       <fieldset
         class="c2"
         label="Label"
+        value="s"
       >
         <input
           aria-autocomplete="list"
@@ -885,6 +889,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
   border-width: 1px;
   border-style: solid;
   border-color: #D7D7E0;
+  border-color: #231B22;
 }
 
 .c2:hover,
@@ -1052,6 +1057,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
       <fieldset
         class="c2"
         label="Label"
+        value="s"
       >
         <input
           aria-autocomplete="list"

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -224,6 +224,7 @@ exports[`<Dropdown /> should match snapshot 1`] = `
         <fieldset
           class="c3"
           label="Find an activity to love"
+          value=""
         >
           <input
             aria-autocomplete="list"
@@ -494,6 +495,7 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
           class="c2"
           disabled=""
           label="Find an activity to love"
+          value=""
         >
           <input
             aria-autocomplete="list"
@@ -767,6 +769,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
         <fieldset
           class="c3"
           label="Find an activity to love"
+          value=""
         >
           <input
             aria-autocomplete="list"
@@ -928,6 +931,7 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
   border-width: 1px;
   border-style: solid;
   border-color: #D7D7E0;
+  border-color: #231B22;
 }
 
 .c2:hover,
@@ -1057,6 +1061,7 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
           class="c2"
           disabled=""
           label="Find an activity to love"
+          value="Swimming"
         >
           <input
             aria-autocomplete="list"
@@ -1247,6 +1252,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
   border-width: 1px;
   border-style: solid;
   border-color: #D7D7E0;
+  border-color: #231B22;
 }
 
 .c3:hover,
@@ -1396,6 +1402,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
         <fieldset
           class="c3"
           label="Find an activity to love"
+          value="Swimming"
         >
           <input
             aria-autocomplete="list"

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -74,8 +74,11 @@ const Field = styled.input`
 
         font-weight: ${input.label.font.weight};
         color: ${
-          error ? `${colors.feedback.attention[1]}` : `${colors.text.primary}`
+          error || (value && error)
+            ? `${colors.feedback.attention[1]}`
+            : `${colors.text.primary}`
         };
+
       }
     }
 

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -74,9 +74,7 @@ const Field = styled.input`
 
         font-weight: ${input.label.font.weight};
         color: ${
-          error || (value && error)
-            ? `${colors.feedback.attention[1]}`
-            : `${colors.text.primary}`
+          error ? `${colors.feedback.attention[1]}` : `${colors.text.primary}`
         };
 
       }
@@ -98,6 +96,7 @@ const Field = styled.input`
         }
 
         & ~ label {
+          color: ${error ? `${colors.feedback.attention[1]}` : ''};
           ${labelTransition}
         }
       `}

--- a/packages/yoga/src/Input/web/Fieldset.jsx
+++ b/packages/yoga/src/Input/web/Fieldset.jsx
@@ -11,6 +11,7 @@ const Fieldset = styled.fieldset`
     error,
     disabled,
     full,
+    value,
     theme: {
       yoga: {
         colors,
@@ -29,6 +30,8 @@ const Fieldset = styled.fieldset`
     border-color: ${
       error ? colors.feedback.attention[1] : input.border.color.default
     };
+
+    ${value && !error ? `border-color: ${input.border.color.typed};` : ''}
 
     &:hover, &:focus-within {
       border-color: ${

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -109,6 +109,7 @@ const Input = React.forwardRef(
           full={full}
           label={label}
           style={style}
+          value={value}
         >
           <Field
             {...props}

--- a/packages/yoga/src/Input/web/Label.jsx
+++ b/packages/yoga/src/Input/web/Label.jsx
@@ -7,7 +7,6 @@ const Label = styled.label`
   user-select: none;
 
   ${({
-    error,
     disabled,
     theme: {
       yoga: {
@@ -28,7 +27,6 @@ const Label = styled.label`
     transition-duration: ${transition.duration[1]}ms;
     transition-timing-function: cubic-bezier(${transition.timing[0].join()});
 
-    ${error ? `color: ${colors.feedback.attention[1]};` : ''}
     ${disabled ? `color: ${colors.text.disabled};` : ''}
   `}
 `;

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -164,6 +164,7 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -164,6 +164,7 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"
@@ -356,6 +357,7 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
       class="c1"
       disabled=""
       label="Label"
+      value=""
     >
       <input
         class="c2"
@@ -558,7 +560,6 @@ exports[`<Input /> Snapshots should match with error 1`] = `
   transition-duration: 500ms;
   -webkit-transition-timing-function: cubic-bezier(0,0.75,0.1,1);
   transition-timing-function: cubic-bezier(0,0.75,0.1,1);
-  color: #FF874C;
 }
 
 .c0 {
@@ -573,6 +574,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"
@@ -771,6 +773,7 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"
@@ -985,6 +988,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"
@@ -1216,6 +1220,7 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"
@@ -1415,6 +1420,7 @@ exports[`<Input /> Snapshots should match with label 1`] = `
     <fieldset
       class="c1"
       label="Input"
+      value=""
     >
       <input
         class="c2"

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -164,6 +164,7 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -198,6 +198,7 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
       <fieldset
         class="c2"
         label="Label"
+        value=""
       >
         <input
           class="c3 c4"
@@ -439,6 +440,7 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
         class="c2"
         disabled=""
         label="Label"
+        value=""
       >
         <input
           class="c3 c4"
@@ -676,6 +678,7 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
       <fieldset
         class="c2"
         label="Label"
+        value=""
       >
         <input
           class="c3 c4"

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -164,6 +164,7 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
     <fieldset
       class="c1"
       label="Label"
+      value=""
     >
       <input
         class="c2"


### PR DESCRIPTION
# Description

In order to follow the last design of the Input and keep the consistency of our fields, this PR changes the **color of the label in the error state** and the **color of the border in the activated state**.

You can check the design specs [here](https://www.figma.com/file/wn9grDi9mM29Wt7LmQjol7/Yoga-Design-System-7.1?node-id=4670%3A4105).

# Screenshots 

Before: 
![Screenshot from 2022-01-13 17-25-14](https://user-images.githubusercontent.com/54802614/149404689-a6b7d41a-ab36-4f03-9d69-ff32f8c86bb9.png)![Screenshot from 2022-01-13 17-25-27](https://user-images.githubusercontent.com/54802614/149404695-027d9299-01a3-44c6-b38a-65d0ed1d2685.png)

After:
![Screenshot from 2022-01-13 17-32-17](https://user-images.githubusercontent.com/54802614/149404899-0cafc077-c3d4-4d9d-8ea4-b96836f5dcfd.png)![Screenshot from 2022-01-13 17-24-15](https://user-images.githubusercontent.com/54802614/149404725-34c29c31-592d-4f9b-a087-638c8d823597.png)




