### PR TITLE
Add Header Component

### DIFF
--- a/packages/doc/content/components/components/header/index.mdx
+++ b/packages/doc/content/components/components/header/index.mdx
@@ -9,4 +9,33 @@ metaDescription: 'Header Component'
 # Header
 
 
-  
+### Default
+
+```javascript
+<Box display="flex" width="100%">
+  <Header />
+</Box>
+```
+
+### Logo with link
+
+```javascript
+<Box display="flex" width="100%">
+  <Header link='/'/>
+</Box>
+```
+
+### Receiving children
+
+```javascript
+<Box width="100%">
+  <Header>
+    <Button.Text>First step</Button.Text>
+    <Button.Text>Second step</Button.Text>
+  </Header>
+</Box>
+```
+
+### Props
+
+<PropsTable component="Header" platform="web" />

--- a/packages/doc/content/components/components/header/index.mdx
+++ b/packages/doc/content/components/components/header/index.mdx
@@ -1,0 +1,12 @@
+---
+title: 'Header'
+metaTitle: 'Header'
+metaDescription: 'Header Component'
+---
+
+
+
+# Header
+
+
+  

--- a/packages/doc/content/components/components/header/index.mdx
+++ b/packages/doc/content/components/components/header/index.mdx
@@ -5,14 +5,18 @@ metaDescription: 'Header Component'
 ---
 
 
-
 # Header
 
+### Reference
+
+The Header displays information and actions relating to the current screen.
+
+### Usage
 
 ### Default
 
 ```javascript
-<Box display="flex" width="100%">
+<Box width="100%">
   <Header />
 </Box>
 ```
@@ -20,7 +24,7 @@ metaDescription: 'Header Component'
 ### Logo with link
 
 ```javascript
-<Box display="flex" width="100%">
+<Box width="100%">
   <Header link='/'/>
 </Box>
 ```

--- a/packages/doc/content/components/components/header/index.mdx
+++ b/packages/doc/content/components/components/header/index.mdx
@@ -4,15 +4,16 @@ metaTitle: 'Header'
 metaDescription: 'Header Component'
 ---
 
+import styled from 'styled-components';
+import { media } from '@gympass/yoga-helpers';
 
 # Header
 
 ### Reference
 
-The Header displays information and actions relating to the current screen.
+The Header defines the top of a page, and displays information and actions relating to the current page. 
 
 ### Usage
-
 ### Default
 
 ```javascript
@@ -23,21 +24,70 @@ The Header displays information and actions relating to the current screen.
 
 ### Logo with link
 
+The header is prepared to have a link to redirect the user clicking on the Gympass' logo.
+
 ```javascript
 <Box width="100%">
-  <Header link='/'/>
+  <Header link="/" />
 </Box>
 ```
 
 ### Receiving children
 
-```javascript
-<Box width="100%">
-  <Header>
-    <Button.Text>First step</Button.Text>
-    <Button.Text>Second step</Button.Text>
-  </Header>
-</Box>
+The header can have a children with components that you want to put inside.
+
+```javascript state
+const LeftContent = styled.div`
+  display: flex;
+  flex-grow: 3;
+`;
+
+const RightContent = styled.div`
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
+  align-items: center;
+`;
+
+const LinkButton = styled(Button.Link)`
+  margin-right: 32px;
+`;
+
+const SmallButton = styled(Button)`
+  margin-left: 20px;
+  ${media.lg`
+    margin-left: 8px;
+  `}
+`;
+
+render(() => {
+  return (
+    <Box width="100%">
+      <Header>
+        <>
+          <Hide xxs xs sm md>
+            <LeftContent>
+              <LinkButton>Link button</LinkButton>
+              <LinkButton>Link button</LinkButton>
+            </LeftContent>
+          </Hide>
+          <RightContent>
+            <Button.Outline small />
+            <SmallButton small />
+            <Hide lg-start>
+              <Icon
+                size="medium"
+                fill="vibin"
+                as={MenuList}
+                style={{ marginLeft: '20px' }}
+              />
+            </Hide>
+          </RightContent>
+        </>
+      </Header>
+    </Box>
+  );
+});
 ```
 
 ### Props

--- a/packages/doc/content/components/components/header/index.mdx
+++ b/packages/doc/content/components/components/header/index.mdx
@@ -54,9 +54,9 @@ const LinkButton = styled(Button.Link)`
 `;
 
 const SmallButton = styled(Button)`
-  margin-left: 20px;
+  margin-left: 8px;
   ${media.lg`
-    margin-left: 8px;
+    margin-left: 20px;
   `}
 `;
 

--- a/packages/yoga/src/Header/Header.theme.js
+++ b/packages/yoga/src/Header/Header.theme.js
@@ -1,0 +1,24 @@
+const Header = ({ colors, elevations, spacing }) => ({
+  logo: {
+    width: {
+      xxs: 80,
+      lg: 130,
+    },
+    margin: {
+      xxs: spacing.medium,
+      lg: 48,
+    },
+  },
+  shadow: elevations.medium,
+  background: colors.white,
+  padding: {
+    xxs: spacing.medium,
+    lg: spacing.huge,
+  },
+  height: {
+    xxs: 56,
+    lg: 72,
+  },
+});
+
+export default Header;

--- a/packages/yoga/src/Header/Header.theme.js
+++ b/packages/yoga/src/Header/Header.theme.js
@@ -1,4 +1,4 @@
-const Header = ({ colors, elevations, spacing }) => ({
+const Header = ({ spacing }) => ({
   logo: {
     width: {
       xxs: 80,
@@ -9,8 +9,6 @@ const Header = ({ colors, elevations, spacing }) => ({
       lg: 48,
     },
   },
-  shadow: elevations.medium,
-  background: colors.white,
   padding: {
     xxs: spacing.medium,
     lg: spacing.huge,

--- a/packages/yoga/src/Header/index.js
+++ b/packages/yoga/src/Header/index.js
@@ -1,0 +1,3 @@
+import Header from './web';
+
+export default Header;

--- a/packages/yoga/src/Header/web/Header.jsx
+++ b/packages/yoga/src/Header/web/Header.jsx
@@ -3,7 +3,9 @@ import styled, { css } from 'styled-components';
 import { string, node } from 'prop-types';
 
 import { media } from '@gympass/yoga-helpers';
+
 import Gympass from 'images/gympass-logo.svg';
+import Box from '../../Box';
 
 const GympassLogo = styled(Gympass)`
   ${({
@@ -22,7 +24,7 @@ const GympassLogo = styled(Gympass)`
   `}
 `;
 
-const Heading = styled.header`
+const Heading = styled(Box)`
   ${({
     theme: {
       yoga: {
@@ -30,11 +32,6 @@ const Heading = styled.header`
       },
     },
   }) => css`
-    display: flex;
-    align-items: center;
-    background: ${header.background};
-    box-shadow: ${header.shadow};
-    width: 100%;
     padding: 0 ${header.padding.xxs}px;
     height: ${header.height.xxs}px;
 
@@ -47,7 +44,14 @@ const Heading = styled.header`
 
 const Header = ({ link, children }) => {
   return (
-    <Heading>
+    <Heading
+      as="header"
+      d="flex"
+      elevation="medium"
+      bgColor="white"
+      alignItems="center"
+      w="100%"
+    >
       {link ? (
         <a href={link}>
           <GympassLogo />

--- a/packages/yoga/src/Header/web/Header.jsx
+++ b/packages/yoga/src/Header/web/Header.jsx
@@ -61,7 +61,9 @@ const Header = ({ link, children }) => {
 };
 
 Header.propTypes = {
+  /** Use link to redirect clicking on the Gympass' logo */
   link: string,
+  /** Use children to add whatever you want inside the header */
   children: node,
 };
 

--- a/packages/yoga/src/Header/web/Header.jsx
+++ b/packages/yoga/src/Header/web/Header.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { string, node } from 'prop-types';
+
+import { media } from '@gympass/yoga-helpers';
+import Gympass from 'images/gympass-logo.svg';
+
+const GympassLogo = styled(Gympass)`
+  ${({
+    theme: {
+      yoga: {
+        components: { header },
+      },
+    },
+  }) => css`
+    margin-right: ${header.logo.margin.xxs}px;
+    width: ${header.logo.width.xxs}px;
+    ${media.lg`
+    width: ${header.logo.width.lg}px;
+    margin-right: ${header.logo.margin.lg}px;
+  `}
+  `}
+`;
+
+const Heading = styled.header`
+  ${({
+    theme: {
+      yoga: {
+        components: { header },
+      },
+    },
+  }) => css`
+    display: flex;
+    align-items: center;
+    background: ${header.background};
+    box-shadow: ${header.shadow};
+    width: 100%;
+    padding: 0 ${header.padding.xxs}px;
+    height: ${header.height.xxs}px;
+
+    ${media.lg`
+    padding: 0 ${header.padding.lg}px;
+    height: ${header.height.lg}px;
+  `}
+  `}
+`;
+
+const Header = ({ link, children }) => {
+  return (
+    <Heading>
+      {link ? (
+        <a href={link}>
+          <GympassLogo />
+        </a>
+      ) : (
+        <GympassLogo />
+      )}
+      {children}
+    </Heading>
+  );
+};
+
+Header.propTypes = {
+  link: string,
+  children: node,
+};
+
+Header.defaultProps = {
+  link: null,
+  children: null,
+};
+
+export default Header;

--- a/packages/yoga/src/Header/web/Header.test.jsx
+++ b/packages/yoga/src/Header/web/Header.test.jsx
@@ -14,6 +14,18 @@ describe('<Header />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should have link', () => {
+    const gympassLink = 'https://site.gympass.com/br';
+
+    render(
+      <ThemeProvider>
+        <Header link={gympassLink} />
+      </ThemeProvider>,
+    );
+
+    screen.getByRole('link', { href: gympassLink });
+  });
+
   it('should show children', () => {
     render(
       <ThemeProvider>

--- a/packages/yoga/src/Header/web/Header.test.jsx
+++ b/packages/yoga/src/Header/web/Header.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+
+import { ThemeProvider, Header } from '../..';
+
+describe('<Header />', () => {
+  it('should match snapshot', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <Header />
+      </ThemeProvider>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should show children', () => {
+    render(
+      <ThemeProvider>
+        <Header>
+          <p>Make wellbeing universal</p>
+        </Header>
+      </ThemeProvider>,
+    );
+
+    screen.getByText('Make wellbeing universal');
+  });
+});

--- a/packages/yoga/src/Header/web/__snapshots__/Header.test.jsx.snap
+++ b/packages/yoga/src/Header/web/__snapshots__/Header.test.jsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Header /> should match snapshot 1`] = `
+.c1 {
+  margin-right: 20px;
+  width: 80px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFFFFF;
+  box-shadow: 0 5px 5px -3px rgba(152,152,166,0.2),0 8px 10px 1px rgba(152,152,166,0.14),0 3px 14px 2px rgba(152,152,166,0.12);
+  width: 100%;
+  padding: 0 20px;
+  height: 56px;
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 130px;
+    margin-right: 48px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding: 0 72px;
+    height: 72px;
+  }
+}
+
+<div>
+  <header
+    class="c0"
+  >
+    <svg
+      class="c1"
+    />
+  </header>
+</div>
+`;

--- a/packages/yoga/src/Header/web/__snapshots__/Header.test.jsx.snap
+++ b/packages/yoga/src/Header/web/__snapshots__/Header.test.jsx.snap
@@ -7,6 +7,9 @@ exports[`<Header /> should match snapshot 1`] = `
 }
 
 .c0 {
+  background-color: #FFFFFF;
+  box-shadow: 0 5px 5px -3px rgba(152,152,166,0.2),0 8px 10px 1px rgba(152,152,166,0.14),0 3px 14px 2px rgba(152,152,166,0.12);
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15,9 +18,6 @@ exports[`<Header /> should match snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #FFFFFF;
-  box-shadow: 0 5px 5px -3px rgba(152,152,166,0.2),0 8px 10px 1px rgba(152,152,166,0.14),0 3px 14px 2px rgba(152,152,166,0.12);
-  width: 100%;
   padding: 0 20px;
   height: 56px;
 }
@@ -39,6 +39,8 @@ exports[`<Header /> should match snapshot 1`] = `
 <div>
   <header
     class="c0"
+    d="flex"
+    elevation="medium"
   >
     <svg
       class="c1"

--- a/packages/yoga/src/Header/web/index.js
+++ b/packages/yoga/src/Header/web/index.js
@@ -1,0 +1,3 @@
+import Header from './Header';
+
+export default Header;

--- a/packages/yoga/src/index.js
+++ b/packages/yoga/src/index.js
@@ -28,6 +28,7 @@ import Avatar from './Avatar';
 import BottomSheet from './BottomSheet';
 import Dialog from './Dialog';
 import Divider from './Divider';
+import Header from './Header';
 
 export {
   ThemeProvider,
@@ -64,4 +65,5 @@ export {
   BottomSheet,
   Dialog,
   Divider,
+  Header,
 };


### PR DESCRIPTION
Now Yoga will have its own Header component. :tada: 
This PR adds the flexible Header component in the web version for devs to be able to add what's necessary inside the component.

Check [here](https://www.figma.com/file/wn9grDi9mM29Wt7LmQjol7/branch/Sj85zBa955QwYXRCC8DBWe/Yoga-Design-System-7.1?node-id=20243%3A101373) the specs.

> ℹ️ **INFO**
We don't have the final version of some components used on the Header's design yet, such as the language dropdown and the menu component. When finished, we will need to update the Header's documentation to have all the use cases.



**Desktop:**
<img width="785" alt="Screen Shot 2022-01-31 at 18 38 02" src="https://user-images.githubusercontent.com/54802614/151877555-5b22e574-f8df-4047-b9f8-15a042dddbe3.png">
<img width="783" alt="Screen Shot 2022-01-31 at 18 48 14" src="https://user-images.githubusercontent.com/54802614/151878634-da53f51e-fe6e-4a80-872c-85a875b951d1.png">




**Mobile:**
<img width="414" alt="Screen Shot 2022-01-31 at 18 42 40" src="https://user-images.githubusercontent.com/54802614/151878005-4513a1a8-152b-4249-8cb3-0581529845ec.png">
<img width="417" alt="Screen Shot 2022-01-31 at 18 46 42" src="https://user-images.githubusercontent.com/54802614/151878520-d7f1c957-4487-455e-a7e7-ddd23dc88eb5.png">





