### PR TITLE
fix(chips): add 'function' option in propTypes of icon prop in Chips component

### DIFF
--- a/packages/yoga/src/Chips/web/Chips.jsx
+++ b/packages/yoga/src/Chips/web/Chips.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { withTheme } from 'styled-components';
-import { node, number, arrayOf, bool, func } from 'prop-types';
+import { node, number, arrayOf, bool, func, oneOfType } from 'prop-types';
 import { hexToRgb } from '@gympass/yoga-common';
 
 import { theme } from '../../Theme';
@@ -170,7 +170,7 @@ Chips.propTypes = {
   /** disable chip */
   disabled: bool,
   /** a list of max two icons from @gympass/yoga-icons package */
-  icons: arrayOf(node),
+  icons: arrayOf(oneOfType([node, func])),
   /** click event */
   onToggle: func,
   onClick: func,


### PR DESCRIPTION
Hi :wave:

This PR fix a little problem when we use icons from yoga icons and pass it as a param in Chips component.  

The error:

![Captura de tela de 2022-01-24 16-43-16](https://user-images.githubusercontent.com/97263883/150853179-f2021de8-067f-47c1-a95b-3da536750b97.png)

