### PR TITLE
[REFACTOR] - Improved placeholder view in Input and TextArea Component

### DIFF
--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -54,6 +54,22 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
   color: #231B22;
 }
 
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -184,6 +200,7 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
           autocomplete="off"
           class="c3"
           id="downshift-1-input"
+          label="Label"
           value=""
         />
         <label
@@ -259,6 +276,22 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c3:disabled {
@@ -391,6 +424,7 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
           autocomplete="off"
           class="c3"
           id="downshift-0-input"
+          label="Label"
           value=""
         />
         <label
@@ -466,6 +500,22 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c3:disabled {
@@ -707,6 +757,7 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
           autocomplete="off"
           class="c3"
           id="downshift-3-input"
+          label="Label"
           value="s"
         />
         <label
@@ -825,6 +876,22 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c3:disabled {
@@ -1066,6 +1133,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
           autocomplete="off"
           class="c3"
           id="downshift-2-input"
+          label="Label"
           value="s"
         />
         <label

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -54,6 +54,22 @@ exports[`<Dropdown /> should match snapshot 1`] = `
   color: #231B22;
 }
 
+.c4:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c4:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -232,6 +248,7 @@ exports[`<Dropdown /> should match snapshot 1`] = `
             autocomplete="off"
             class="c4 c5"
             id="downshift-0-input"
+            label="Find an activity to love"
             readonly=""
             value=""
           />
@@ -322,6 +339,22 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c3:disabled {
@@ -504,6 +537,7 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
             class="c3 c4"
             disabled=""
             id="downshift-1-input"
+            label="Find an activity to love"
             readonly=""
             value=""
           />
@@ -597,6 +631,22 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c4:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c4:disabled {
@@ -777,6 +827,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
             autocomplete="off"
             class="c4 c5"
             id="downshift-2-input"
+            label="Find an activity to love"
             readonly=""
             value=""
           />
@@ -867,6 +918,22 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c3:disabled {
@@ -1070,6 +1137,7 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
             class="c3 c4"
             disabled=""
             id="downshift-3-input"
+            label="Find an activity to love"
             readonly=""
             value="Swimming"
           />
@@ -1163,6 +1231,22 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c4:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c4:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c4:disabled {
@@ -1410,6 +1494,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
             autocomplete="off"
             class="c4 c5"
             id="downshift-4-input"
+            label="Find an activity to love"
             readonly=""
             value="Swimming"
           />

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -35,6 +35,8 @@ const Field = styled.input`
   box-sizing: border-box;
 
   ${({
+    label,
+    placeholder,
     cleanable,
     error,
     value,
@@ -78,6 +80,10 @@ const Field = styled.input`
         };
 
       }
+
+      &::placeholder {
+        color: ${input.label.color.default};
+      }
     }
 
     &:disabled {
@@ -85,8 +91,18 @@ const Field = styled.input`
       color: ${colors.text.disabled};
     }
 
-    &::placeholder {
-      color: ${input.label.color.default};
+    ${
+      placeholder && label
+        ? css`
+            &::placeholder {
+              color: transparent;
+            }
+          `
+        : css`
+            &::placeholder {
+              color: ${input.label.color.default};
+            }
+          `
     }
 
     ${value &&

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -114,6 +114,7 @@ const Input = React.forwardRef(
           <Field
             {...props}
             {...{
+              label,
               cleanable,
               disabled,
               error,
@@ -180,6 +181,7 @@ Input.propTypes = {
   onClean: func,
   /** when max length helper is unnecessary to appear */
   hideMaxLength: bool,
+  placeholder: string,
 };
 
 Input.defaultProps = {
@@ -197,6 +199,7 @@ Input.defaultProps = {
   onChange: () => {},
   onClean: () => {},
   hideMaxLength: false,
+  placeholder: undefined,
 };
 
 export default Input;

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -54,6 +54,22 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
   color: #231B22;
 }
 
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -168,6 +184,7 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
     >
       <input
         class="c2"
+        label="Label"
         type="email"
         value=""
       />

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -54,6 +54,22 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
   color: #231B22;
 }
 
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -168,6 +184,7 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
     >
       <input
         class="c2"
+        label="Label"
         value=""
       />
       <label
@@ -242,6 +259,22 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c2:disabled {
@@ -362,6 +395,7 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
       <input
         class="c2"
         disabled=""
+        label="Label"
         value=""
       />
       <label
@@ -437,6 +471,22 @@ exports[`<Input /> Snapshots should match with error 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #FF874C;
+}
+
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c2:disabled {
@@ -578,6 +628,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
     >
       <input
         class="c2"
+        label="Label"
         value=""
       />
       <label
@@ -663,6 +714,22 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
   color: #231B22;
 }
 
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -777,6 +844,7 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
     >
       <input
         class="c2"
+        label="Label"
         value=""
       />
       <label
@@ -851,6 +919,22 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c2:disabled {
@@ -992,6 +1076,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
     >
       <input
         class="c2"
+        label="Label"
         maxlength="20"
         value=""
       />
@@ -1085,6 +1170,22 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
   color: #231B22;
 }
 
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -1224,6 +1325,7 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
     >
       <input
         class="c2"
+        label="Label"
         maxlength="20"
         value=""
       />
@@ -1308,6 +1410,22 @@ exports[`<Input /> Snapshots should match with label 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c2:disabled {
@@ -1424,6 +1542,7 @@ exports[`<Input /> Snapshots should match with label 1`] = `
     >
       <input
         class="c2"
+        label="Input"
         value=""
       />
       <label

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -54,6 +54,22 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
   color: #231B22;
 }
 
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -168,6 +184,7 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
     >
       <input
         class="c2"
+        label="Label"
         type="number"
         value=""
       />

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -54,6 +54,22 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
   color: #231B22;
 }
 
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -202,6 +218,7 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
       >
         <input
           class="c3 c4"
+          label="Label"
           type="password"
           value=""
         />
@@ -287,6 +304,22 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c3:disabled {
@@ -445,6 +478,7 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
         <input
           class="c3 c4"
           disabled=""
+          label="Label"
           type="password"
           value=""
         />
@@ -531,6 +565,22 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
   font-size: 12px;
   font-weight: 400;
   color: #231B22;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c3:focus::placeholder {
+  color: #6B6B78;
 }
 
 .c3:disabled {
@@ -682,6 +732,7 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
       >
         <input
           class="c3 c4"
+          label="Label"
           type="password"
           value=""
         />

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -54,6 +54,22 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
   color: #231B22;
 }
 
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
@@ -168,6 +184,7 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
     >
       <input
         class="c2"
+        label="Label"
         type="tel"
         value=""
       />

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -121,6 +121,22 @@ exports[`<TextArea /> should match snapshot 1`] = `
   color: #231B22;
 }
 
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;


### PR DESCRIPTION
## What was done
In this PR, the visualization of the **placeholder** in the **Input** and **TextArea** components was adjusted, when there was `placeholder` and `label` one was overlapping the other.

## Current behavior
Label appears over the placeholder.

## Expected behavior
The placeholder only appears when `focus` occurs on the component.

## Screenshots

| Before - Input |
| --- |
![image](https://user-images.githubusercontent.com/53584223/151481618-a45e7d4a-da82-4223-beee-139e279623e2.png)

| After - Input |
| --- |
![image](https://user-images.githubusercontent.com/53584223/151480777-2c590913-6cb2-4ccf-be2e-d9835bc88d16.png)
![image](https://user-images.githubusercontent.com/53584223/151480667-e02ecc59-f914-4e49-a842-426475a95b5b.png)

| Before - TextArea |
| --- |
![image](https://user-images.githubusercontent.com/53584223/151481495-a19282b3-2b20-45b2-9082-6c8664cb8b99.png)

| After - TextArea |
| --- |
![image](https://user-images.githubusercontent.com/53584223/151480998-5b77377b-0864-4eff-8068-b5590053ad89.png)
![image](https://user-images.githubusercontent.com/53584223/151481110-c525250d-191e-414f-b9de-6964f0bf7862.png)

