### PR TITLE
fix: add inline-react-svg to prevent missing SVGs after build in esm

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,7 @@ module.exports = {
         ['@babel/preset-env', { loose: true, modules: false }],
         '@babel/preset-react',
       ],
-      plugins: ['import-glob'],
+      plugins: ['inline-react-svg', 'import-glob'],
     },
     native: {
       ignore: ['**/*.test.jsx'],


### PR DESCRIPTION
After both #431 and #432 PRs are merged, the lib started to throw `ModuleNotFound` error when te latest version is used. The problem is that the logo svg used in the Header component is not added to the `dist` package after babel's build.

Many thx to @frgiovanna for helping me during the discover process.

fix #434