### PR TITLE
🐛 Adjust style of progress bar label

### DIFF
--- a/packages/yoga/src/Progress/web/Progress.jsx
+++ b/packages/yoga/src/Progress/web/Progress.jsx
@@ -10,7 +10,6 @@ import {
   spacing as systemSpacing,
 } from '@gympass/yoga-system';
 
-import Text from '../../Text';
 import { charLength } from '../../shared';
 
 const ProgressBar = styled.progress`
@@ -60,7 +59,7 @@ const ProgressBar = styled.progress`
 `}
 `;
 
-const Label = styled(Text.Tiny)`
+const Label = styled.label`
   ${({
     theme: {
       yoga: {

--- a/packages/yoga/src/Progress/web/Progress.jsx
+++ b/packages/yoga/src/Progress/web/Progress.jsx
@@ -106,7 +106,7 @@ const Wrapper = styled.div`
         ${Label} {
           max-width: 280px;
 
-          margin-top: ${spacing.xxxsmall}px;
+          margin-top: ${spacing.xxsmall}px;
         }
       `
     }

--- a/packages/yoga/src/Progress/web/Progress.jsx
+++ b/packages/yoga/src/Progress/web/Progress.jsx
@@ -10,6 +10,7 @@ import {
   spacing as systemSpacing,
 } from '@gympass/yoga-system';
 
+import Text from '../../Text';
 import { charLength } from '../../shared';
 
 const ProgressBar = styled.progress`
@@ -59,14 +60,16 @@ const ProgressBar = styled.progress`
 `}
 `;
 
-const Label = styled.label`
+const Label = styled(Text.Tiny)`
   ${({
     theme: {
       yoga: {
         components: { progress },
+        colors: { text },
       },
     },
   }) => `
+  color: ${text.secondary};
   font-size: ${progress.label.font.size}px;
   letter-spacing: normal;
 `}

--- a/packages/yoga/src/Progress/web/__snapshots__/Progress.test.jsx.snap
+++ b/packages/yoga/src/Progress/web/__snapshots__/Progress.test.jsx.snap
@@ -612,13 +612,6 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
 }
 
 .c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 12px;
-  line-height: 16px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
   color: #6B6B78;
   font-size: 12px;
   -webkit-letter-spacing: normal;
@@ -679,11 +672,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -693,11 +686,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -707,11 +700,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -721,11 +714,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -735,11 +728,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -749,11 +742,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -763,11 +756,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -777,11 +770,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -791,11 +784,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -805,11 +798,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -819,11 +812,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -833,11 +826,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -847,11 +840,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -861,11 +854,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -875,11 +868,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -889,11 +882,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c0"
@@ -903,11 +896,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
 </div>
 `;
@@ -1182,13 +1175,6 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
 }
 
 .c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 12px;
-  line-height: 16px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
   color: #6B6B78;
   font-size: 12px;
   -webkit-letter-spacing: normal;
@@ -1262,11 +1248,11 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
       max="100"
       value="20"
     />
-    <p
+    <label
       class="c3 c4"
     >
       20
-    </p>
+    </label>
   </div>
   <div
     class="c5"
@@ -1276,11 +1262,11 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
       max="100"
       value="65"
     />
-    <p
+    <label
       class="c3 c4"
     >
       65
-    </p>
+    </label>
   </div>
 </div>
 `;
@@ -1322,13 +1308,6 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
 }
 
 .c3 {
-  margin: 0;
-  padding: 0;
-  font-size: 12px;
-  line-height: 16px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
   color: #6B6B78;
   font-size: 12px;
   -webkit-letter-spacing: normal;
@@ -1386,11 +1365,11 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
       class="c1"
       max="100"
     />
-    <p
+    <label
       class="c2 c3"
     >
       Some decription here
-    </p>
+    </label>
   </div>
   <div
     class="c4"
@@ -1400,11 +1379,11 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
       max="100"
       value="65"
     />
-    <p
+    <label
       class="c2 c3"
     >
       Some decription here
-    </p>
+    </label>
   </div>
 </div>
 `;

--- a/packages/yoga/src/Progress/web/__snapshots__/Progress.test.jsx.snap
+++ b/packages/yoga/src/Progress/web/__snapshots__/Progress.test.jsx.snap
@@ -53,7 +53,7 @@ exports[`<Progress /> should match snapshot 1`] = `
 
 .c0 .c2 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 <div>
@@ -612,6 +612,14 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
 }
 
 .c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
   font-size: 12px;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -621,12 +629,12 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
 
 .c19 .c3 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 .c20 .c3 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 .c0 {
@@ -671,11 +679,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -685,11 +693,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -699,11 +707,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -713,11 +721,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -727,11 +735,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -741,11 +749,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -755,11 +763,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -769,11 +777,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -783,11 +791,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -797,11 +805,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -811,11 +819,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -825,11 +833,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -839,11 +847,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -853,11 +861,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -867,11 +875,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -881,11 +889,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c0"
@@ -895,11 +903,11 @@ exports[`<Progress /> should match snapshot with all variants 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
 </div>
 `;
@@ -966,7 +974,7 @@ exports[`<Progress /> should match snapshot with background color prop system 1`
 
 .c0 .c5 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 <div>
@@ -1044,7 +1052,7 @@ exports[`<Progress /> should match snapshot with border prop system 1`] = `
 
 .c0 .c5 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 <div>
@@ -1121,7 +1129,7 @@ exports[`<Progress /> should match snapshot with elevation prop system 1`] = `
 
 .c0 .c5 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 <div>
@@ -1174,6 +1182,14 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
 }
 
 .c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
   font-size: 12px;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -1183,12 +1199,12 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
 
 .c6 .c3 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 .c7 .c3 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 .c0 {
@@ -1246,11 +1262,11 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
       max="100"
       value="20"
     />
-    <label
+    <p
       class="c3 c4"
     >
       20
-    </label>
+    </p>
   </div>
   <div
     class="c5"
@@ -1260,11 +1276,11 @@ exports[`<Progress /> should match snapshot with label number 1`] = `
       max="100"
       value="65"
     />
-    <label
+    <p
       class="c3 c4"
     >
       65
-    </label>
+    </p>
   </div>
 </div>
 `;
@@ -1306,6 +1322,14 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
 }
 
 .c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
   font-size: 12px;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -1330,7 +1354,7 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
 
 .c0 .c2 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 .c4 {
@@ -1351,7 +1375,7 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
 
 .c4 .c2 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 <div>
@@ -1362,11 +1386,11 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
       class="c1"
       max="100"
     />
-    <label
+    <p
       class="c2 c3"
     >
       Some decription here
-    </label>
+    </p>
   </div>
   <div
     class="c4"
@@ -1376,11 +1400,11 @@ exports[`<Progress /> should match snapshot with label string 1`] = `
       max="100"
       value="65"
     />
-    <label
+    <p
       class="c2 c3"
     >
       Some decription here
-    </label>
+    </p>
   </div>
 </div>
 `;
@@ -1449,7 +1473,7 @@ exports[`<Progress /> should match snapshot with positions prop system 1`] = `
 
 .c0 .c5 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 <div>
@@ -1527,7 +1551,7 @@ exports[`<Progress /> should match snapshot with spacing prop system 1`] = `
 
 .c0 .c5 {
   max-width: 280px;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 <div>


### PR DESCRIPTION
# Description

This PR change color and spacing on progress bar label and update test snapshot to fit the new file adjusted:

color: primary -> **secondary**
spacing: xxxsmall -> **xxsmall**

### Screenshots:

| Before | After |
| :-: | :-: |
| <img width="547" alt="image" src="https://user-images.githubusercontent.com/61520601/153887476-eb001e7c-475e-48f1-b71a-01215af1c1dc.png"> | <img width="547" alt="image" src="https://user-images.githubusercontent.com/61520601/153888691-c3010800-8158-49aa-a9bb-74e49c153f31.png"> |
