### PR TITLE
🎨  Adjust snackbar

### DIFF
--- a/packages/doc/content/components/components/snackbar/index.mdx
+++ b/packages/doc/content/components/components/snackbar/index.mdx
@@ -171,6 +171,7 @@ render(() => {
         duration={4000}
         onAction={handleOnAction}
         actionLabel="Custom Action"
+        onClose={handleOnClose}
       />
     </>
   );

--- a/packages/doc/content/components/components/snackbar/index.mdx
+++ b/packages/doc/content/components/components/snackbar/index.mdx
@@ -134,6 +134,7 @@ render(() => {
         message="We are making wellbeing universal."
         duration={4000}
         onClose={handleOnClose}
+        hideCloseButton
       />
     </>
   );

--- a/packages/yoga/src/Snackbar/web/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/web/Snackbar.jsx
@@ -103,6 +103,7 @@ const Snackbar = ({
   actionLabel,
   onAction,
   onClose,
+  hideCloseButton,
   theme: {
     yoga: {
       components: { snackbar },
@@ -154,9 +155,9 @@ const Snackbar = ({
             </Button.Link>
           )}
 
-          {!duration && onClose && (
+          {!hideCloseButton && onClose && (
             <IconButtonWrapper role="button" onClick={onClose}>
-              <Icon as={Close} fill="secondary" width="large" height="large" />
+              <Icon as={Close} fill="secondary" size="medium" />
             </IconButtonWrapper>
           )}
         </ActionsWrapper>
@@ -169,7 +170,13 @@ Snackbar.propTypes = {
   /** Controls the snackbar visibility. */
   open: bool,
 
-  /** A number in milliseconds to close snackbar automaticaly. The `onClose` function becomes required when passing this function. */
+  /** The message shown when snackbar is opened. */
+  message: string.isRequired,
+
+  /** Function to close the snackbar. */
+  onClose: func.isRequired,
+
+  /** A number in milliseconds to close snackbar automaticaly. */
   duration: number,
 
   /** Label for a custom action. */
@@ -178,17 +185,14 @@ Snackbar.propTypes = {
   /** Controls the snackbar icon visibility. */
   hideIcon: bool,
 
-  /** The message shown when snackbar is opened. */
-  message: string.isRequired,
-
   /** Function for the custom action. The `actionLabel` becomes required when passing this function. */
   onAction: func,
 
-  /** Function to close the snackbar. */
-  onClose: func,
-
   /** The style variant, it may be "success", "failure" or "info". */
   variant: oneOf(['success', 'failure', 'info']),
+
+  /** Hides the close button. */
+  hideCloseButton: bool,
 };
 
 Snackbar.defaultProps = {
@@ -197,8 +201,8 @@ Snackbar.defaultProps = {
   actionLabel: undefined,
   hideIcon: false,
   onAction: undefined,
-  onClose: undefined,
   variant: 'success',
+  hideCloseButton: false,
 };
 
 export default memo(withTheme(Snackbar));

--- a/packages/yoga/src/Snackbar/web/Snackbar.test.jsx
+++ b/packages/yoga/src/Snackbar/web/Snackbar.test.jsx
@@ -92,6 +92,7 @@ describe('<Snackbar />', () => {
           duration={1000}
           message="Make wellbeing universal"
           onClose={onCloseMock}
+          hideCloseButton
         />
       </ThemeProvider>,
     );
@@ -99,6 +100,27 @@ describe('<Snackbar />', () => {
     expect(screen.queryByRole('button')).toBeNull();
 
     jest.runAllTimers();
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close with timeout set up', async () => {
+    const onCloseMock = jest.fn();
+
+    render(
+      <ThemeProvider>
+        <Snackbar
+          open
+          duration={1000}
+          message="Make wellbeing universal"
+          onClose={onCloseMock}
+        />
+      </ThemeProvider>,
+    );
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
 
     expect(onCloseMock).toHaveBeenCalledTimes(1);
   });

--- a/packages/yoga/src/Snackbar/web/Snackbar.test.jsx
+++ b/packages/yoga/src/Snackbar/web/Snackbar.test.jsx
@@ -9,7 +9,7 @@ describe('<Snackbar />', () => {
   it('should match snapshot', () => {
     const { container } = render(
       <ThemeProvider>
-        <Snackbar open message="Make wellbeing universal" />
+        <Snackbar open message="Make wellbeing universal" onClose={jest.fn()} />
       </ThemeProvider>,
     );
 
@@ -19,7 +19,7 @@ describe('<Snackbar />', () => {
   it('should render a minimal snackbar', () => {
     render(
       <ThemeProvider>
-        <Snackbar open message="Make wellbeing universal" />
+        <Snackbar open message="Make wellbeing universal" onClose={jest.fn()} />
       </ThemeProvider>,
     );
 
@@ -32,7 +32,12 @@ describe('<Snackbar />', () => {
   it('should not render an icon', () => {
     render(
       <ThemeProvider>
-        <Snackbar open message="Make wellbeing universal" hideIcon />
+        <Snackbar
+          open
+          message="Make wellbeing universal"
+          onClose={jest.fn()}
+          hideIcon
+        />
       </ThemeProvider>,
     );
 
@@ -48,6 +53,7 @@ describe('<Snackbar />', () => {
           open
           message="Make wellbeing universal"
           onAction={onActionMock}
+          onClose={jest.fn()}
           actionLabel="Let's go"
         />
       </ThemeProvider>,

--- a/packages/yoga/src/Snackbar/web/__snapshots__/Snackbar.test.jsx.snap
+++ b/packages/yoga/src/Snackbar/web/__snapshots__/Snackbar.test.jsx.snap
@@ -18,6 +18,11 @@ exports[`<Snackbar /> should match snapshot 1`] = `
   height: 24px;
 }
 
+.c6 {
+  width: 20px;
+  height: 20px;
+}
+
 .c3 {
   margin: 0;
   padding: 0;
@@ -34,6 +39,22 @@ exports[`<Snackbar /> should match snapshot 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+}
+
+.c5:hover svg {
+  fill: #6B6B78;
 }
 
 .c4 {
@@ -117,7 +138,19 @@ exports[`<Snackbar /> should match snapshot 1`] = `
     </p>
     <aside
       class="c4"
-    />
+    >
+      <div
+        class="c5"
+        role="button"
+      >
+        <svg
+          class="c6"
+          fill="#231B22"
+          height="20"
+          width="20"
+        />
+      </div>
+    </aside>
   </div>
 </div>
 `;


### PR DESCRIPTION
# 🎨  Adjust snackbar

## Motivation
We noticed that our current `<Snackbar/>` was missing a behavior. We would like to show the close button even when we've added the `duration` prop to make it close automatically

## Changes
- add `hideCloseButton` prop to hide the button when the user needs
- add tests
- adjust snapshot
- adjust documentation

## Useful links
[Figma prototype](https://www.figma.com/file/wn9grDi9mM29Wt7LmQjol7/Yoga-Design-System-7.1?node-id=15654%3A44275)