### PR TITLE
feat(button link): add href prop to the link button render as an anchor

### DIFF
--- a/packages/doc/content/components/components/button/link-web.mdx
+++ b/packages/doc/content/components/components/button/link-web.mdx
@@ -1,18 +1,20 @@
-### Usage default
-
-```javascript
-<Box display="flex" justifyContent="space-evenly" width="100%">
-  <Button.Link>Find an activity</Button.Link>
-  <Button.Link secondary>Find an activity</Button.Link>
-</Box>
-```
-
-#### Using as an anchor
+### Usage default (as an anchor)
 
 ```javascript
 <Box display="flex" justifyContent="space-evenly" width="100%">
   <Button.Link href="http://www.gympass.com" target="blank">
     Find an activity (external link)
+  </Button.Link>
+</Box>
+```
+
+#### Using as a button
+
+```javascript
+<Box display="flex" justifyContent="space-evenly" width="100%">
+  <Button.Link as="button">Find an activity</Button.Link>
+  <Button.Link as="button" secondary>
+    Find an activity
   </Button.Link>
 </Box>
 ```

--- a/packages/doc/content/components/components/button/link-web.mdx
+++ b/packages/doc/content/components/components/button/link-web.mdx
@@ -1,9 +1,19 @@
-### Usage
+### Usage default
 
 ```javascript
 <Box display="flex" justifyContent="space-evenly" width="100%">
   <Button.Link>Find an activity</Button.Link>
   <Button.Link secondary>Find an activity</Button.Link>
+</Box>
+```
+
+#### Using as an anchor
+
+```javascript
+<Box display="flex" justifyContent="space-evenly" width="100%">
+  <Button.Link href="http://www.gympass.com" target="blank">
+    Find an activity (external link)
+  </Button.Link>
 </Box>
 ```
 

--- a/packages/yoga/src/Button/web/Button.test.jsx
+++ b/packages/yoga/src/Button/web/Button.test.jsx
@@ -377,6 +377,18 @@ describe('<Button />', () => {
           expect(container).toMatchSnapshot();
         });
       });
+
+      it('Link Button with href prop', () => {
+        const { container } = render(
+          <ThemeProvider>
+            <Button.Link href="http://www.gympass.com" target="blank">
+              Link as an anchor
+            </Button.Link>
+          </ThemeProvider>,
+        );
+
+        expect(container).toMatchSnapshot();
+      });
     });
 
     describe('secondary buttons', () => {

--- a/packages/yoga/src/Button/web/Button.test.jsx
+++ b/packages/yoga/src/Button/web/Button.test.jsx
@@ -378,10 +378,22 @@ describe('<Button />', () => {
         });
       });
 
-      it('Link Button with href prop', () => {
+      it('Link Button rendering as an anchor (default)', () => {
         const { container } = render(
           <ThemeProvider>
             <Button.Link href="http://www.gympass.com" target="blank">
+              Link as an anchor
+            </Button.Link>
+          </ThemeProvider>,
+        );
+
+        expect(container).toMatchSnapshot();
+      });
+
+      it('Link Button rendering as an button (as=button)', () => {
+        const { container } = render(
+          <ThemeProvider>
+            <Button.Link as="button" target="blank">
               Link as an anchor
             </Button.Link>
           </ThemeProvider>,

--- a/packages/yoga/src/Button/web/Link.jsx
+++ b/packages/yoga/src/Button/web/Link.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool } from 'prop-types';
+import { bool, string } from 'prop-types';
 import styled from 'styled-components';
 import { hexToRgb } from '@gympass/yoga-common';
 
@@ -50,16 +50,29 @@ const Link = styled(StyledButton)`
   }}
 `;
 
-const ButtonLink = props => <Link {...props} />;
+const ButtonLink = props => {
+  const { href } = props;
+  const finalProps = {
+    ...props,
+  };
+
+  if (href) {
+    finalProps.as = 'a';
+  }
+
+  return <Link {...finalProps} />;
+};
 
 ButtonLink.propTypes = {
   disabled: bool,
   secondary: bool,
+  href: string,
 };
 
 ButtonLink.defaultProps = {
   disabled: false,
   secondary: false,
+  href: undefined,
 };
 
 ButtonLink.displayName = 'Button.Link';

--- a/packages/yoga/src/Button/web/Link.jsx
+++ b/packages/yoga/src/Button/web/Link.jsx
@@ -50,29 +50,18 @@ const Link = styled(StyledButton)`
   }}
 `;
 
-const ButtonLink = props => {
-  const { href } = props;
-  const finalProps = {
-    ...props,
-  };
-
-  if (href) {
-    finalProps.as = 'a';
-  }
-
-  return <Link {...finalProps} />;
-};
+const ButtonLink = props => <Link {...props} />;
 
 ButtonLink.propTypes = {
   disabled: bool,
   secondary: bool,
-  href: string,
+  as: string,
 };
 
 ButtonLink.defaultProps = {
   disabled: false,
   secondary: false,
-  href: undefined,
+  as: 'a',
 };
 
 ButtonLink.displayName = 'Button.Link';

--- a/packages/yoga/src/Button/web/__snapshots__/Button.test.jsx.snap
+++ b/packages/yoga/src/Button/web/__snapshots__/Button.test.jsx.snap
@@ -887,6 +887,117 @@ exports[`<Button /> Snapshots disabled buttons With disabled prop should match s
 </div>
 `;
 
+exports[`<Button /> Snapshots primary buttons Link Button with href prop 1`] = `
+.c0 {
+  box-sizing: border-box;
+  text-align: center;
+  outline: none;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: auto;
+  height: 48px;
+  padding-left: 24px;
+  padding-right: 24px;
+  background-color: #D8385E;
+  border: none;
+  border-radius: 9999px;
+  color: #FFFFFF;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: Rubik;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  height: unset;
+  padding: 0;
+  background-color: unset;
+  border: none;
+  border-radius: 0;
+  color: #D8385E;
+}
+
+.c0 svg {
+  width: 24px;
+  height: 24px;
+  fill: #FFFFFF;
+  margin-right: 8px;
+  -webkit-transition: fill 0.2s;
+  transition: fill 0.2s;
+}
+
+.c0:not([disabled]):hover,
+.c0:not([disabled]):focus {
+  box-shadow: 0 4px 8px rgba(216,56,94,0.45);
+}
+
+.c0:active {
+  background-color: rgba(216,56,94,0.75);
+  color: #FFFFFF;
+}
+
+.c0:active svg {
+  fill: #FFFFFF;
+}
+
+.c0:disabled {
+  background-color: #F5F5FA;
+  color: #D7D7E0;
+  cursor: not-allowed;
+}
+
+.c0:disabled svg {
+  fill: #D7D7E0;
+}
+
+.c0:disabled,
+.c0:not([disabled]):hover,
+.c0:not([disabled]):focus,
+.c0:not([disabled]):active {
+  box-shadow: unset;
+  background-color: unset;
+}
+
+.c0:not([disabled]):hover {
+  color: rgba(216,56,94,0.5);
+}
+
+.c0:not([disabled]):focus,
+.c0:not([disabled]):active {
+  color: rgba(216,56,94,0.75);
+}
+
+.c0:disabled {
+  color: #D7D7E0;
+}
+
+<div>
+  <a
+    class="c0"
+    href="http://www.gympass.com"
+    target="blank"
+  >
+    Link as an anchor
+  </a>
+</div>
+`;
+
 exports[`<Button /> Snapshots primary buttons With disabled prop should match snapshot with default Button 1`] = `
 .c0 {
   box-sizing: border-box;

--- a/packages/yoga/src/Button/web/__snapshots__/Button.test.jsx.snap
+++ b/packages/yoga/src/Button/web/__snapshots__/Button.test.jsx.snap
@@ -370,7 +370,7 @@ exports[`<Button /> Snapshots disabled buttons With disabled prop should match s
 }
 
 <div>
-  <button
+  <a
     class="c0"
     disabled=""
   />
@@ -887,7 +887,7 @@ exports[`<Button /> Snapshots disabled buttons With disabled prop should match s
 </div>
 `;
 
-exports[`<Button /> Snapshots primary buttons Link Button with href prop 1`] = `
+exports[`<Button /> Snapshots primary buttons Link Button rendering as an anchor (default) 1`] = `
 .c0 {
   box-sizing: border-box;
   text-align: center;
@@ -995,6 +995,116 @@ exports[`<Button /> Snapshots primary buttons Link Button with href prop 1`] = `
   >
     Link as an anchor
   </a>
+</div>
+`;
+
+exports[`<Button /> Snapshots primary buttons Link Button rendering as an button (as=button) 1`] = `
+.c0 {
+  box-sizing: border-box;
+  text-align: center;
+  outline: none;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: auto;
+  height: 48px;
+  padding-left: 24px;
+  padding-right: 24px;
+  background-color: #D8385E;
+  border: none;
+  border-radius: 9999px;
+  color: #FFFFFF;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: Rubik;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  line-height: 1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  height: unset;
+  padding: 0;
+  background-color: unset;
+  border: none;
+  border-radius: 0;
+  color: #D8385E;
+}
+
+.c0 svg {
+  width: 24px;
+  height: 24px;
+  fill: #FFFFFF;
+  margin-right: 8px;
+  -webkit-transition: fill 0.2s;
+  transition: fill 0.2s;
+}
+
+.c0:not([disabled]):hover,
+.c0:not([disabled]):focus {
+  box-shadow: 0 4px 8px rgba(216,56,94,0.45);
+}
+
+.c0:active {
+  background-color: rgba(216,56,94,0.75);
+  color: #FFFFFF;
+}
+
+.c0:active svg {
+  fill: #FFFFFF;
+}
+
+.c0:disabled {
+  background-color: #F5F5FA;
+  color: #D7D7E0;
+  cursor: not-allowed;
+}
+
+.c0:disabled svg {
+  fill: #D7D7E0;
+}
+
+.c0:disabled,
+.c0:not([disabled]):hover,
+.c0:not([disabled]):focus,
+.c0:not([disabled]):active {
+  box-shadow: unset;
+  background-color: unset;
+}
+
+.c0:not([disabled]):hover {
+  color: rgba(216,56,94,0.5);
+}
+
+.c0:not([disabled]):focus,
+.c0:not([disabled]):active {
+  color: rgba(216,56,94,0.75);
+}
+
+.c0:disabled {
+  color: #D7D7E0;
+}
+
+<div>
+  <button
+    class="c0"
+    target="blank"
+  >
+    Link as an anchor
+  </button>
 </div>
 `;
 
@@ -1368,7 +1478,7 @@ exports[`<Button /> Snapshots primary buttons With disabled prop should match sn
 }
 
 <div>
-  <button
+  <a
     class="c0"
     disabled=""
   />
@@ -4736,7 +4846,7 @@ exports[`<Button /> Snapshots primary buttons Without props should match snapsho
 }
 
 <div>
-  <button
+  <a
     class="c0"
   />
 </div>
@@ -8259,7 +8369,7 @@ exports[`<Button /> Snapshots secondary buttons Without props should match snaps
 }
 
 <div>
-  <button
+  <a
     class="c0"
   />
 </div>

--- a/packages/yoga/src/Snackbar/web/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/web/Snackbar.jsx
@@ -150,7 +150,7 @@ const Snackbar = ({
 
         <ActionsWrapper>
           {onAction && actionLabel && (
-            <Button.Link onClick={onAction} secondary small>
+            <Button.Link as="button" onClick={onAction} secondary small>
               {actionLabel}
             </Button.Link>
           )}


### PR DESCRIPTION
## Motivation
To fix the [issue 418](https://github.com/Gympass/yoga/issues/418) I'm adding a new prop to the `Button.Link` component.
If you add the `href` prop to the component it will render as an anchor.

Example:
```js
<Button.Link href="http://www.google.com" target="blank">Open external url</Button.Link>
```

How the component will be rendered:
```js
<a href="http://www.google.com" target="blank">Open external url</a>
```

## Snapshot

### Default value is an anchor
<img width="924" alt="Screen Shot 2022-04-06 at 09 36 25" src="https://user-images.githubusercontent.com/8313529/161975918-3614b53b-f51f-4ea0-aed5-d86bde40d9e3.png">

### To render as a button, you should add the "as"
<img width="923" alt="Screen Shot 2022-04-06 at 09 36 32" src="https://user-images.githubusercontent.com/8313529/161975925-388806e8-914c-4118-a650-5e02551005ca.png">

### Table of props
<img width="925" alt="Screen Shot 2022-04-06 at 09 36 39" src="https://user-images.githubusercontent.com/8313529/161975929-5fe0fd5f-bc30-40ff-86d5-8755afe43321.png">


## Changes
- Using [styled component "as" ](https://styled-components.com/docs/api#as-polymorphic-prop)to render the the component as an anchor element by default
- If the user want to use as button, they should add `as="button"`
- Add snapshot test
- Add more info to the documentation
