### PR TITLE
Feat/close native snackbar 🚀

### DIFF
--- a/packages/doc/content/components/components/snackbar/snackbar-native.mdx
+++ b/packages/doc/content/components/components/snackbar/snackbar-native.mdx
@@ -12,6 +12,10 @@ const App = () => {
     snackbarRef.current.open();
   };
 
+  const closeSnackbar = () => {
+    snackbarRef.current.close();
+  };
+
   return (
     <View flex={1} width="100%" alignItems="center">
       <Button onPress={handleOpenSnackbar}>Tap to open snackbar</Button>
@@ -22,13 +26,13 @@ const App = () => {
         message="Feedback message."
         actionLabel="Action"
         onAction={() => {}}
+        onClose={closeSnackbar}
         duration="default"
         bottomOffset={0}
         ref={snackbarRef}
       />
     </View>
   );
-  
 };
 export default App;
 ```

--- a/packages/labnative/pages/Snackbar.jsx
+++ b/packages/labnative/pages/Snackbar.jsx
@@ -11,6 +11,9 @@ const SnackbarPage = () => {
   const handleOpenSnackbar = () => {
     snackbarRef.current.open();
   };
+  const closeSnackbar = () => {
+    snackbarRef.current.close();
+  };
 
   return (
     <View flex={1} width="100%" alignItems="center">
@@ -23,6 +26,7 @@ const SnackbarPage = () => {
         icon={CheckedFull}
         message="Feedback message"
         actionLabel="Action"
+        onClose={closeSnackbar}
         onAction={() => {}}
         duration="default"
         bottomOffset={0}

--- a/packages/yoga/src/Snackbar/native/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/native/Snackbar.jsx
@@ -193,7 +193,10 @@ const Snackbar = forwardRef((props, ref) => {
           </Box>
         )}
         {onClose && (
-          <IconButtonWrapper testID="closeSnackbar" onPress={currentProps.onClose}>
+          <IconButtonWrapper
+            testID="closeSnackbar"
+            onPress={currentProps.onClose}
+          >
             <Icon as={Close} fill="secondary" size="large" />
           </IconButtonWrapper>
         )}

--- a/packages/yoga/src/Snackbar/native/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/native/Snackbar.jsx
@@ -193,7 +193,7 @@ const Snackbar = forwardRef((props, ref) => {
           </Box>
         )}
         {onClose && (
-          <IconButtonWrapper onPress={currentProps.onClose}>
+          <IconButtonWrapper testID="closeSnackbar" onPress={currentProps.onClose}>
             <Icon as={Close} fill="secondary" size="large" />
           </IconButtonWrapper>
         )}

--- a/packages/yoga/src/Snackbar/native/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/native/Snackbar.jsx
@@ -9,12 +9,12 @@ import styled from 'styled-components';
 import { string, oneOf, func, elementType, number } from 'prop-types';
 
 import { PanResponder, TouchableOpacity } from 'react-native';
+import { Close } from '@gympass/yoga-icons';
 import Box from '../../Box';
 import Button from '../../Button';
 import Icon from '../../Icon';
 import Text from '../../Text';
 import SnackbarAnimationWrapper from './SnackbarAnimationWrapper';
-import { Close } from '@gympass/yoga-icons';
 
 const SWIPE_THRESHOLD = 32;
 

--- a/packages/yoga/src/Snackbar/native/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/native/Snackbar.jsx
@@ -8,14 +8,23 @@ import React, {
 import styled from 'styled-components';
 import { string, oneOf, func, elementType, number } from 'prop-types';
 
-import { PanResponder } from 'react-native';
+import { PanResponder, TouchableOpacity } from 'react-native';
 import Box from '../../Box';
 import Button from '../../Button';
 import Icon from '../../Icon';
 import Text from '../../Text';
 import SnackbarAnimationWrapper from './SnackbarAnimationWrapper';
+import { Close } from '@gympass/yoga-icons';
 
 const SWIPE_THRESHOLD = 32;
+
+const IconButtonWrapper = styled(TouchableOpacity)`
+  height: 32px;
+  justify-content: center;
+  align-items: center;
+  padding-left: 4px;
+  padding-right: 4px;
+`;
 
 const SnackbarContainer = styled.View`
   ${({
@@ -64,6 +73,7 @@ const Snackbar = forwardRef((props, ref) => {
     onSnackbarClose,
     duration,
     bottomOffset,
+    onClose,
     ...rest
   } = props;
   const wrapperRef = useRef();
@@ -73,6 +83,7 @@ const Snackbar = forwardRef((props, ref) => {
     message,
     actionLabel,
     onAction,
+    onClose,
     variant,
   });
 
@@ -93,6 +104,7 @@ const Snackbar = forwardRef((props, ref) => {
           message,
           actionLabel,
           onAction,
+          onClose,
           variant,
         });
         wrapperRef.current.open();
@@ -103,6 +115,7 @@ const Snackbar = forwardRef((props, ref) => {
         message,
         actionLabel,
         onAction,
+        onClose,
         variant,
       });
     }
@@ -179,6 +192,11 @@ const Snackbar = forwardRef((props, ref) => {
             {currentProps.actionLabel}
           </Box>
         )}
+        {onClose && (
+          <IconButtonWrapper onPress={currentProps.onClose}>
+            <Icon as={Close} fill="secondary" size="large" />
+          </IconButtonWrapper>
+        )}
       </SnackbarContainer>
     </SnackbarAnimationWrapper>
   );
@@ -195,6 +213,8 @@ Snackbar.propTypes = {
   actionLabel: string,
   /** Function for the custom action. The `actionLabel` becomes required when passing this function. */
   onAction: func,
+  /**   Function for the action to close the snackbar */
+  onClose: func,
   /** Callback function triggered by the Snackbar close action. Can be used for events, for example. */
   onSnackbarClose: func,
   /** The duration sets how long it will take to close snackbar automatically, it may be "fast" (4 seconds), "default" (8 seconds), "slow" (10 seconds) or "indefinite" (it doesn't close automatically). */
@@ -209,6 +229,7 @@ Snackbar.defaultProps = {
   message: '',
   actionLabel: undefined,
   onAction: undefined,
+  onClose: undefined,
   onSnackbarClose: undefined,
   duration: 'default',
   bottomOffset: 0,

--- a/packages/yoga/src/Snackbar/native/Snackbar.test.jsx
+++ b/packages/yoga/src/Snackbar/native/Snackbar.test.jsx
@@ -26,6 +26,7 @@ const Component = overrideProps => {
       <Snackbar
         ref={snackbarRef}
         message="Feedback Message"
+        onClose={() => snackbarRef.current.close()}
         {...overrideProps}
       />
     </ThemeProvider>
@@ -98,6 +99,23 @@ describe('<Snackbar />', () => {
     });
 
     fireEvent.press(getByText('Action'));
+
+    expect(RN.Animated.spring.mock.calls[1][1]).toEqual({
+      toValue: 200,
+      bounciness: 0,
+      useNativeDriver: true,
+    });
+  });
+
+  it('should match snapshot when snackbar with onClose', () => {
+    const overrideProps = {
+      icon: CheckedFull,
+      actionLabel: 'Action',
+      onAction: () => {},
+    };
+    const { getByTestId } = render(<Component {...overrideProps} />);
+
+    fireEvent.press(getByTestId('closeSnackbar'));
 
     expect(RN.Animated.spring.mock.calls[1][1]).toEqual({
       toValue: 200,

--- a/packages/yoga/src/Snackbar/native/__snapshots__/Snackbar.test.jsx.snap
+++ b/packages/yoga/src/Snackbar/native/__snapshots__/Snackbar.test.jsx.snap
@@ -279,6 +279,97 @@ exports[`<Snackbar /> should match snapshot when have a long text 1`] = `
             </View>
           </View>
         </TouchableWithoutFeedback>
+        <TouchableOpacity
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "height": 32,
+                "justifyContent": "center",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+              },
+            ]
+          }
+          testID="closeSnackbar"
+        >
+          <RNSVGSvgView
+            bbHeight={24}
+            bbWidth={24}
+            fill="#231B22"
+            focusable={false}
+            height={24}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                Array [
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  },
+                ],
+                Object {
+                  "opacity": 1,
+                },
+                Object {
+                  "flex": 0,
+                  "height": 24,
+                  "width": 24,
+                },
+              ]
+            }
+            width={24}
+          >
+            <RNSVGGroup
+              fill={
+                Array [
+                  0,
+                  4280490786,
+                ]
+              }
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            />
+          </RNSVGSvgView>
+        </TouchableOpacity>
       </View>
     </View>
   </View>
@@ -423,6 +514,97 @@ exports[`<Snackbar /> should match snapshot when have a variant informative or a
         >
           Feedback Message
         </Text>
+        <TouchableOpacity
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "height": 32,
+                "justifyContent": "center",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+              },
+            ]
+          }
+          testID="closeSnackbar"
+        >
+          <RNSVGSvgView
+            bbHeight={24}
+            bbWidth={24}
+            fill="#231B22"
+            focusable={false}
+            height={24}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                Array [
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  },
+                ],
+                Object {
+                  "opacity": 1,
+                },
+                Object {
+                  "flex": 0,
+                  "height": 24,
+                  "width": 24,
+                },
+              ]
+            }
+            width={24}
+          >
+            <RNSVGGroup
+              fill={
+                Array [
+                  0,
+                  4280490786,
+                ]
+              }
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            />
+          </RNSVGSvgView>
+        </TouchableOpacity>
       </View>
     </View>
   </View>
@@ -708,6 +890,97 @@ exports[`<Snackbar /> should match snapshot when have an icon and action 1`] = `
             </View>
           </View>
         </TouchableWithoutFeedback>
+        <TouchableOpacity
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "height": 32,
+                "justifyContent": "center",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+              },
+            ]
+          }
+          testID="closeSnackbar"
+        >
+          <RNSVGSvgView
+            bbHeight={24}
+            bbWidth={24}
+            fill="#231B22"
+            focusable={false}
+            height={24}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                Array [
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  },
+                ],
+                Object {
+                  "opacity": 1,
+                },
+                Object {
+                  "flex": 0,
+                  "height": 24,
+                  "width": 24,
+                },
+              ]
+            }
+            width={24}
+          >
+            <RNSVGGroup
+              fill={
+                Array [
+                  0,
+                  4280490786,
+                ]
+              }
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            />
+          </RNSVGSvgView>
+        </TouchableOpacity>
       </View>
     </View>
   </View>
@@ -852,6 +1125,97 @@ exports[`<Snackbar /> should match snapshot when snackbar is default 1`] = `
         >
           Feedback Message
         </Text>
+        <TouchableOpacity
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "height": 32,
+                "justifyContent": "center",
+                "paddingLeft": 4,
+                "paddingRight": 4,
+              },
+            ]
+          }
+          testID="closeSnackbar"
+        >
+          <RNSVGSvgView
+            bbHeight={24}
+            bbWidth={24}
+            fill="#231B22"
+            focusable={false}
+            height={24}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                Array [
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  },
+                ],
+                Object {
+                  "opacity": 1,
+                },
+                Object {
+                  "flex": 0,
+                  "height": 24,
+                  "width": 24,
+                },
+              ]
+            }
+            width={24}
+          >
+            <RNSVGGroup
+              fill={
+                Array [
+                  0,
+                  4280490786,
+                ]
+              }
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            />
+          </RNSVGSvgView>
+        </TouchableOpacity>
       </View>
     </View>
   </View>


### PR DESCRIPTION



## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add: close button on snackbar

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [ ] Web
- [x] Mobile

## Type of change 🔍

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://www.figma.com/file/wn9grDi9mM29Wt7LmQjol7/%E2%9C%85-Yoga-%5BMAIN%5D?node-id=15651%3A44123)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->
https://user-images.githubusercontent.com/39800209/172072157-8fb7a45f-d2e5-481d-99b1-6f09e71a7ac9.mov

| Before | After |
| ------ | ----- |
|    <img width="325" alt="Captura de Tela 2022-06-05 às 18 55 08" src="https://user-images.githubusercontent.com/39800209/172072230-3747b51e-8b61-4665-94c7-3ac514e51858.png">  |    <img width="325" alt="Captura de Tela 2022-06-05 às 18 55 17" src="https://user-images.githubusercontent.com/39800209/172072237-af051b91-9e49-42cf-bc67-3398f642fbb0.png"> |


| success | informative | attention |
| ------ | ----- | ----- |
| <img width="325" alt="Captura de Tela 2022-06-05 às 18 55 17" src="https://user-images.githubusercontent.com/39800209/172072237-af051b91-9e49-42cf-bc67-3398f642fbb0.png">  |  <img width="325" alt="Captura de Tela 2022-06-05 às 19 02 59" src="https://user-images.githubusercontent.com/39800209/172072536-9d0d8f2b-63dd-4c80-a083-d43cf9ffd77b.png"> |  <img width="325" alt="Captura de Tela 2022-06-05 às 19 03 11" src="https://user-images.githubusercontent.com/39800209/172072546-3d942d0e-0d42-4fed-b8ff-65877e6a969c.png"> |