### PR TITLE
[EUEG-1725] - Update width plan card 🚀

### DIFF
--- a/packages/yoga/src/Card/native/PlanCard/PlanCard.jsx
+++ b/packages/yoga/src/Card/native/PlanCard/PlanCard.jsx
@@ -9,7 +9,7 @@ import Card from '../Card';
 export const PLAN_LINE_HEIGHT = 8;
 
 const Plan = styled(Card)`
-  max-width: 288px;
+  max-width: 312px;
   width: 100%;
   position: relative;
 

--- a/packages/yoga/src/Card/native/PlanCard/__snapshots__/PlanCard.test.jsx.snap
+++ b/packages/yoga/src/Card/native/PlanCard/__snapshots__/PlanCard.test.jsx.snap
@@ -56,7 +56,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
           Object {
             "backgroundColor": "#FFFFFF",
             "borderRadius": 16,
-            "maxWidth": 288,
+            "maxWidth": 312,
             "paddingBottom": 32,
             "paddingLeft": 20,
             "paddingRight": 20,
@@ -690,7 +690,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with suffix 1`] = `
           Object {
             "backgroundColor": "#FFFFFF",
             "borderRadius": 16,
-            "maxWidth": 288,
+            "maxWidth": 312,
             "paddingBottom": 32,
             "paddingLeft": 20,
             "paddingRight": 20,
@@ -911,7 +911,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with variant 1`] = `
           Object {
             "backgroundColor": "#FFFFFF",
             "borderRadius": 16,
-            "maxWidth": 288,
+            "maxWidth": 312,
             "paddingBottom": 32,
             "paddingLeft": 20,
             "paddingRight": 20,

--- a/packages/yoga/src/Card/web/PlanCard/PlanCard.jsx
+++ b/packages/yoga/src/Card/web/PlanCard/PlanCard.jsx
@@ -10,7 +10,7 @@ const Plan = styled.article`
   width: 100%;
   display: inline-block;
   position: relative;
-  max-width: 288px;
+  max-width: 312px;
 
   overflow: hidden;
 

--- a/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
+++ b/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   width: 100%;
   display: inline-block;
   position: relative;
-  max-width: 288px;
+  max-width: 312px;
   overflow: hidden;
   padding: 64px 20px 32px 20px;
   border-radius: 16px;
@@ -476,7 +476,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with suffix 1`] = `
   width: 100%;
   display: inline-block;
   position: relative;
-  max-width: 288px;
+  max-width: 312px;
   overflow: hidden;
   padding: 64px 20px 32px 20px;
   border-radius: 16px;
@@ -615,7 +615,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with variant 1`] = `
   width: 100%;
   display: inline-block;
   position: relative;
-  max-width: 288px;
+  max-width: 312px;
   overflow: hidden;
   padding: 64px 20px 32px 20px;
   border-radius: 16px;


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/EUEG-1725)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changing the plan card width.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [X] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit Test
- [X] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://www.figma.com/file/wn9grDi9mM29Wt7LmQjol7/branch/IGniQw5A9xz5XSd2xMrSi9/%E2%9C%85-Yoga-%5BMAIN%5D?node-id=7634%3A0)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

![Captura de Tela 2022-06-15 às 14 00 51](https://user-images.githubusercontent.com/98053923/173885524-7b015f52-2720-41c2-8423-8889a369b5e5.png)

<img width="326" alt="Captura de Tela 2022-06-15 às 14 00 36" src="https://user-images.githubusercontent.com/98053923/173885592-5bae1501-b4ce-4847-a302-c79ea9b16c1e.png">