### PR TITLE
🐛 fix: add color text and opacity for input web

### DIFF
--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -297,6 +298,7 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -522,6 +524,7 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -899,6 +902,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }

--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -72,7 +72,8 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {
@@ -296,7 +297,8 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {
@@ -520,7 +522,8 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {
@@ -896,7 +899,8 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {

--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -299,7 +299,7 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -525,7 +525,7 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -903,7 +903,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`<Dropdown /> should match snapshot 1`] = `
 
 .c4:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -360,6 +361,7 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -653,6 +655,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
 
 .c4:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -941,6 +944,7 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -1255,6 +1259,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
 
 .c4:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -72,7 +72,8 @@ exports[`<Dropdown /> should match snapshot 1`] = `
 
 .c4:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c4::-webkit-input-placeholder {
@@ -359,7 +360,8 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {
@@ -651,7 +653,8 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
 
 .c4:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c4::-webkit-input-placeholder {
@@ -938,7 +941,8 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {
@@ -1251,7 +1255,8 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
 
 .c4:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c4::-webkit-input-placeholder {

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Dropdown /> should match snapshot 1`] = `
 .c4:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -362,7 +362,7 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -656,7 +656,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
 .c4:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -945,7 +945,7 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -1260,7 +1260,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
 .c4:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -89,7 +89,7 @@ const Field = styled.input`
       cursor: not-allowed;
       color: ${colors.text.disabled};
       -webkit-text-fill-color: ${colors.text.disabled};
-      opacity: 1; 
+      opacity: 1;
     }
 
     ${placeholder && label

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -88,7 +88,7 @@ const Field = styled.input`
     &:disabled {
       cursor: not-allowed;
       color: ${colors.text.disabled};
-      -webkit-text-fill-color: ${colors.text.disabled};
+      text-fill-color: ${colors.text.disabled};
       opacity: 1;
     }
 

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -88,6 +88,8 @@ const Field = styled.input`
     &:disabled {
       cursor: not-allowed;
       color: ${colors.text.disabled};
+      -webkit-text-fill-color: ${colors.text.disabled};
+      opacity: 1; 
     }
 
     ${placeholder && label

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -72,7 +72,8 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -72,7 +72,8 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {
@@ -279,7 +280,8 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {
@@ -491,7 +493,8 @@ exports[`<Input /> Snapshots should match with error 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {
@@ -732,7 +735,8 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {
@@ -939,7 +943,8 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {
@@ -1188,7 +1193,8 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {
@@ -1430,7 +1436,8 @@ exports[`<Input /> Snapshots should match with label 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -282,7 +282,7 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -496,7 +496,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -739,7 +739,7 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -948,7 +948,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -1199,7 +1199,7 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -1443,7 +1443,7 @@ exports[`<Input /> Snapshots should match with label 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -280,6 +281,7 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -493,6 +495,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -735,6 +738,7 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -943,6 +947,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -1193,6 +1198,7 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -1436,6 +1442,7 @@ exports[`<Input /> Snapshots should match with label 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -72,7 +72,8 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -325,6 +326,7 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
@@ -587,6 +589,7 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -72,7 +72,8 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {
@@ -324,7 +325,8 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {
@@ -585,7 +587,8 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
 
 .c3:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c3::-webkit-input-placeholder {

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -327,7 +327,7 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -590,7 +590,7 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -72,7 +72,8 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -139,7 +139,8 @@ exports[`<TextArea /> should match snapshot 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
-  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
 }
 
 .c2::-webkit-input-placeholder {

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`<TextArea /> should match snapshot 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  -webkit-text-fill-color: #D7D7E0;
+  text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -139,6 +139,7 @@ exports[`<TextArea /> should match snapshot 1`] = `
 
 .c2:disabled {
   cursor: not-allowed;
+  color: #D7D7E0;
   -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }


### PR DESCRIPTION

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

- Add text color and opacity to fix bug on iOS (Safari)
- Update tests snapshots

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots 📸

### Before 
![image](https://user-images.githubusercontent.com/14081572/175660266-4554fcaf-cb24-4ff0-96af-5286871175e9.png)


### After 
![image](https://user-images.githubusercontent.com/14081572/175660180-3076022d-fffb-4115-9515-c71647345952.png)





