### PR TITLE
:adhesive_bandage: add -webkit- prop on text fill color on input

### DIFF
--- a/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
+++ b/packages/yoga/src/AutoComplete/web/__snapshots__/AutoComplete.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<AutoComplete /> Snapshots should match with a full width component 1`]
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -299,7 +299,7 @@ exports[`<AutoComplete /> Snapshots should match with default component 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -525,7 +525,7 @@ exports[`<AutoComplete /> Snapshots should match with full width options list 1`
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -903,7 +903,7 @@ exports[`<AutoComplete /> Snapshots should match with options list 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Dropdown /> should match snapshot 1`] = `
 .c4:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -362,7 +362,7 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -656,7 +656,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
 .c4:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -945,7 +945,7 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -1260,7 +1260,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
 .c4:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/Field.jsx
+++ b/packages/yoga/src/Input/web/Field.jsx
@@ -88,7 +88,7 @@ const Field = styled.input`
     &:disabled {
       cursor: not-allowed;
       color: ${colors.text.disabled};
-      text-fill-color: ${colors.text.disabled};
+      -webkit-text-fill-color: ${colors.text.disabled};
       opacity: 1;
     }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -282,7 +282,7 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -496,7 +496,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -739,7 +739,7 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -948,7 +948,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -1199,7 +1199,7 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -1443,7 +1443,7 @@ exports[`<Input /> Snapshots should match with label 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -327,7 +327,7 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 
@@ -590,7 +590,7 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
 .c3:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 

--- a/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
+++ b/packages/yoga/src/TextArea/web/__snapshots__/TextArea.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`<TextArea /> should match snapshot 1`] = `
 .c2:disabled {
   cursor: not-allowed;
   color: #D7D7E0;
-  text-fill-color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
   opacity: 1;
 }
 


### PR DESCRIPTION
## Description 📄

After add a prop on Field when is disabled to iOS the text is showing very light, local was working, the text is showing great, but when update yoga lib the text continue showing very light. This happened because the prop was ignored.
Add webkit this prop. 

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [x] Unit Test
- [x] Snapshot Test

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone 12 - 2022-06-28 at 11 54 21](https://user-images.githubusercontent.com/16164937/176211209-43b598ed-ad8a-4cb8-bd92-de984329bdde.png) | ![Simulator Screen Shot - iPhone 12 - 2022-06-28 at 11 51 33](https://user-images.githubusercontent.com/16164937/176211264-ece70c35-fa3d-4b1c-b1b3-c3c757d85b16.png) |
