### PR TITLE
✨ Add "neutral" variant color for Tag.Informative

### DIFF
--- a/packages/doc/content/components/components/tag/informative-web.mdx
+++ b/packages/doc/content/components/components/tag/informative-web.mdx
@@ -1,72 +1,61 @@
 import { Link as GatsbyLink } from 'gatsby';
 
-### Usage
+### Basic Tag
 
-```javascript state
-const Wrapper = props => (
-  <Box
-    display="inline-flex"
-    alignItems="center"
-    flexDirection="column"
-    {...props}
-  />
-);
+```
+<Tag.Informative>tag</Tag.Informative>
 
-render(
-  <>
-    <Wrapper>
-      <Tag.Informative mb="xxxsmall" mr="medium" variant="success">
-        success
-      </Tag.Informative>
-      <Tag.Informative mr="medium" variant="success" icon={Building}>
-        success with custom icon
-      </Tag.Informative>
-      <Tag.Informative
-        mt="xxxsmall"
-        mr="medium"
-        variant="success"
-        icon={Building}
-        small
-      >
-        success small with custom icon
-      </Tag.Informative>
-    </Wrapper>
-    <Wrapper>
-      <Tag.Informative variant="informative">informative</Tag.Informative>
-      <Tag.Informative mv="medium" variant="informative" icon={Building}>
-        informative with custom icon
-      </Tag.Informative>
-      <Tag.Informative variant="informative" icon={Building} small>
-        informative small with custom icon
-      </Tag.Informative>
-    </Wrapper>
-    <Wrapper>
-      <Tag.Informative marginLeft="medium" variant="attention">
-        attention
-      </Tag.Informative>
-      <Tag.Informative
-        marginLeft="medium"
-        marginVertical="xxxsmall"
-        variant="attention"
-        icon={Building}
-      >
-        attention with custom icon
-      </Tag.Informative>
-      <Tag.Informative
-        marginLeft="medium"
-        variant="attention"
-        icon={Building}
-        small
-      >
-        attention small with custom icon
-      </Tag.Informative>
-    </Wrapper>
-  </>,
-);
+```
+
+### Colors
+The tag component has following variants: `neutral`, `success`, `informative` and `attention`
+
+```
+<Box d="flex">
+  <Tag.Informative variant="neutral" mr="small">
+    neutral
+  </Tag.Informative>
+
+  <Tag.Informative variant="success" mr="small">
+    success
+  </Tag.Informative>
+
+  <Tag.Informative variant="informative" mr="small">
+    informative
+  </Tag.Informative>
+
+  <Tag.Informative variant="attention">
+    attention
+  </Tag.Informative>
+</Box>
+```
+
+### Sizes
+Use the prop `small` to control its size
+
+```
+<Box d="flex" flexDirection="column" alignItems="center">
+  <Tag.Informative variant="informative" small mb="small">
+    I'm a small tag
+  </Tag.Informative>
+
+  <Tag.Informative variant="informative">
+    I'm a regular tag
+  </Tag.Informative>
+</Box>
+```
+
+### Adornments
+Use the prop `icon` to add an icon. Refer to <GatsbyLink to="/components/icons">icons</GatsbyLink> to check the library.
+
+```
+<Tag.Informative variant="attention" icon={AlertTriangle}>
+  You have pending actions
+</Tag.Informative>
 ```
 
 ### Props
 
-The Tag component also has support for margins props as you can see more details <GatsbyLink to="/system/spacing">our system</GatsbyLink>
-
 <PropsTable component="Tag.Informative" platform="web" />
+
+The Tag component also has support for margins props as you can see more details <GatsbyLink to="/system/spacing">our system</GatsbyLink>

--- a/packages/yoga/src/Tag/web/Informative.jsx
+++ b/packages/yoga/src/Tag/web/Informative.jsx
@@ -61,17 +61,20 @@ const TagInformative = ({
 );
 
 TagInformative.propTypes = {
-  /** style the tag following the theme (success, informative, attention) */
-  variant: oneOf(['success', 'informative', 'attention']).isRequired,
+  /** Values: neutral, success, informative, attention */
+  variant: oneOf(['neutral', 'success', 'informative', 'attention']),
+  /** Icon reference from our library */
   icon: func,
+  /** The tag's content */
   children: node.isRequired,
-  /** Can send small to use this variant */
+  /** The tag's size */
   small: bool,
 };
 
 TagInformative.defaultProps = {
   icon: undefined,
   small: false,
+  variant: 'neutral'
 };
 
 TagInformative.displayName = 'Tag.Informative';

--- a/packages/yoga/src/Tag/web/Informative.jsx
+++ b/packages/yoga/src/Tag/web/Informative.jsx
@@ -74,7 +74,7 @@ TagInformative.propTypes = {
 TagInformative.defaultProps = {
   icon: undefined,
   small: false,
-  variant: 'neutral'
+  variant: 'neutral',
 };
 
 TagInformative.displayName = 'Tag.Informative';

--- a/packages/yoga/src/Theme/theme/theme.js
+++ b/packages/yoga/src/Theme/theme/theme.js
@@ -36,6 +36,7 @@ const theme = tokens => {
       success: [tokens.colors.success, tokens.colors.hope],
       informative: [tokens.colors.neutral, tokens.colors.relax],
       attention: [tokens.colors.attention, tokens.colors.verve],
+      neutral: [tokens.colors.light, tokens.colors.medium],
     },
     text: {
       primary: tokens.colors.stamina,
@@ -51,10 +52,15 @@ const theme = tokens => {
 
   [colors.feedback.success.light, colors.feedback.success.dark] =
     colors.feedback.success;
+
   [colors.feedback.informative.light, colors.feedback.informative.dark] =
     colors.feedback.informative;
+
   [colors.feedback.attention.light, colors.feedback.attention.dark] =
     colors.feedback.attention;
+
+  [colors.feedback.neutral.light, colors.feedback.neutral.dark] =
+    colors.feedback.neutral;
 
   return {
     ...tokens,


### PR DESCRIPTION
# ✨ Add "neutral" variant color for Tag.Informative

## Description 📄
For **Clients Engagement** team we notice that we need a new color to express a neutral status on the invitation to sign up feature. 

To complete that, we used the <Tag.Informative> component, but that color wasn't there.

## Platforms 📲

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

|Before|After|
|---|---|
|<img src="https://user-images.githubusercontent.com/6570553/178285521-10536e79-cb33-476e-b969-b177ed951d35.png" width="400"/>|<img src="https://user-images.githubusercontent.com/6570553/178285996-10f67b98-4741-42c9-b287-ce98f8510a72.gif" />|
