### PR TITLE
ActionRequirement - Illustration should occupy all the upper space

### DIFF
--- a/packages/yoga/src/ActionRequirement/web/ActionRequirement.jsx
+++ b/packages/yoga/src/ActionRequirement/web/ActionRequirement.jsx
@@ -13,6 +13,7 @@ import Box from '../../Box';
 
 const StyledActionRequirement = styled.div`
   display: flex;
+  height: 100%;
   ${media.xxs`
     flex-direction: column;
   `}
@@ -38,7 +39,10 @@ const Content = styled.div`
 `;
 
 const BoxIllustration = styled(Box)`
-  text-align: center;
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 function isChildFromComponent(child, component) {


### PR DESCRIPTION
## Description 📄

The illustration should take up all the top space if it doesn't have a lot of content

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings


## Screenshots 📸

| Before | After |
| ------ | ----- |
|  <img width="322" src="https://user-images.githubusercontent.com/27781419/194661415-c07dc1d6-ad36-4bdc-95de-847ff2b3b7cb.png">  |  <img width="322" alt="Screen Shot 2022-10-07 at 18 21 16" src="https://user-images.githubusercontent.com/27781419/194660080-614f973b-d18e-45f4-b722-ca39e659973e.png">     |
