### PR TITLE
fix(dropdown): fix dropdown button click

### DIFF
--- a/packages/yoga/src/Dropdown/Dropdown.theme.js
+++ b/packages/yoga/src/Dropdown/Dropdown.theme.js
@@ -44,6 +44,7 @@ const Dropdown = ({
     padding: {
       right: spacing.small,
       top: spacing.small,
+      bottom: spacing.small,
     },
   },
   optionsList: {

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -141,7 +141,7 @@ const Button = styled.button`
     width: 100%;
     padding-right: ${dropdown.button.padding.right}px;
     padding-top: ${dropdown.button.padding.top}px;
-    padding-bottom: ${dropdown.button.padding.top}px;
+    padding-bottom: ${dropdown.button.padding.bottom}px;
 
     border: none;
     outline: none;

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -141,6 +141,7 @@ const Button = styled.button`
     width: 100%;
     padding-right: ${dropdown.button.padding.right}px;
     padding-top: ${dropdown.button.padding.top}px;
+    padding-bottom: ${dropdown.button.padding.top}px;
 
     border: none;
     outline: none;

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -212,6 +212,7 @@ exports[`<Dropdown /> should match snapshot 1`] = `
   width: 100%;
   padding-right: 16px;
   padding-top: 16px;
+  padding-bottom: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -499,6 +500,7 @@ exports[`<Dropdown /> should match snapshot when disabled 1`] = `
   width: 100%;
   padding-right: 16px;
   padding-top: 16px;
+  padding-bottom: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -795,6 +797,7 @@ exports[`<Dropdown /> should match snapshot when full 1`] = `
   width: 100%;
   padding-right: 16px;
   padding-top: 16px;
+  padding-bottom: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -1103,6 +1106,7 @@ exports[`<Dropdown /> should match snapshot when has a selected value 1`] = `
   width: 100%;
   padding-right: 16px;
   padding-top: 16px;
+  padding-bottom: 16px;
   border: none;
   outline: none;
   background-color: transparent;
@@ -1465,6 +1469,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
   width: 100%;
   padding-right: 16px;
   padding-top: 16px;
+  padding-bottom: 16px;
   border: none;
   outline: none;
   background-color: transparent;


### PR DESCRIPTION
[![#595 Issue](https://img.shields.io/badge/issue-%23595-blue.svg)](https://github.com/gympass/yoga/issues/595)

## Description 📄

Hello guys! 

To solve the problem with the `dropdown` `button` click, it was necessary to assign a `padding bottom` of sixteen pixels to the `button` component, so that the user can execute its functionality when clicking on the bottom part of the `button`

**For more details access the issue [#595](https://github.com/gympass/yoga/issues/595)**

## Platforms 📲

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸


| Before | After |
| ------ | ----- |
|    ![image](https://user-images.githubusercontent.com/58890915/211159995-1315ff0c-d0e2-4a61-acde-771894c889c2.png)    |   ![image](https://user-images.githubusercontent.com/58890915/211160130-d73c8d7c-ace2-419f-97eb-626a66d8e982.png)    |
