### PR TITLE
🐞 Fix labnative error on init

### DIFF
--- a/packages/labnative/babel.config.js
+++ b/packages/labnative/babel.config.js
@@ -4,6 +4,7 @@ module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   plugins: [
     'import-glob',
+    '@babel/plugin-proposal-export-namespace-from',
     [
       'module-resolver',
       {


### PR DESCRIPTION
## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `labnative` package was throwing errors when running `yarn dev:native:android` and `yarn dev:native:ios` because of this named exports: https://github.com/gympass/yoga/blob/c33949c0b93ecc10be19ee73132cc9778a6a595e/packages/icons/src/index.js#L3-L4

This PR, basically, adds a missing babel plugin to handle these exports.
## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [ ] Web
- [x] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

| Before | After |
| ------ | ----- |
| ![simulator_screenshot_B3C1B8B3-E3B9-49EA-93E6-3696D50E6FE9](https://user-images.githubusercontent.com/25802240/211375668-65e1947b-52ea-4965-88db-0c707986223d.png) | ![simulator_screenshot_2BC673EF-B42D-47F5-BF7D-F26598BD7DA4](https://user-images.githubusercontent.com/25802240/211375544-2dadebc1-3782-49ad-91c1-cd44b4d366ca.png) |
