### PR TITLE
  🚀  feat(accordion): added className to enable edit styles

### DIFF
--- a/packages/yoga/src/Accordion/web/Accordion.test.jsx
+++ b/packages/yoga/src/Accordion/web/Accordion.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, screen } from '@testing-library/react';
 import { Text, Button } from '@gympass/yoga';
 import { ThemeProvider } from '../..';
 
@@ -24,5 +24,28 @@ describe('<Accordion />', () => {
     );
 
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should have className when passed as props', () => {
+    render(
+      <ThemeProvider>
+        <Accordion title="Title">
+          <Accordion.Content
+            className="className-as-props"
+            data-testid="accordion-content"
+          >
+            <Text>Content</Text>
+
+            <Button small inverted>
+              Small button
+            </Button>
+          </Accordion.Content>
+        </Accordion>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('accordion-content')).toHaveClass(
+      'className-as-props',
+    );
   });
 });

--- a/packages/yoga/src/Accordion/web/Content.jsx
+++ b/packages/yoga/src/Accordion/web/Content.jsx
@@ -1,33 +1,17 @@
-import { node, string } from 'prop-types';
-import React from 'react';
-
 import styled from 'styled-components';
 
-const Content = ({ children, className }) => {
-  const ContentWrapper = styled.div`
-    ${({
-      theme: {
-        yoga: {
-          components: { accordion },
-        },
+const Content = styled.div`
+  ${({
+    theme: {
+      yoga: {
+        components: { accordion },
       },
-    }) => {
-      return `
+    },
+  }) => {
+    return `
       padding: 0 ${accordion.padding.standard}px ${accordion.padding.standard}px;
     `;
-    }}
-  `;
-
-  return <ContentWrapper className={className}>{children}</ContentWrapper>;
-};
-
-Content.propTypes = {
-  children: node.isRequired,
-  className: string,
-};
-
-Content.defaultProps = {
-  className: '',
-};
+  }}
+`;
 
 export default Content;

--- a/packages/yoga/src/Accordion/web/Content.jsx
+++ b/packages/yoga/src/Accordion/web/Content.jsx
@@ -1,9 +1,9 @@
-import { node } from 'prop-types';
+import { node, string } from 'prop-types';
 import React from 'react';
 
 import styled from 'styled-components';
 
-const Content = ({ children }) => {
+const Content = ({ children, className }) => {
   const ContentWrapper = styled.div`
     ${({
       theme: {
@@ -18,11 +18,16 @@ const Content = ({ children }) => {
     }}
   `;
 
-  return <ContentWrapper>{children}</ContentWrapper>;
+  return <ContentWrapper className={className}>{children}</ContentWrapper>;
 };
 
 Content.propTypes = {
   children: node.isRequired,
+  className: string,
+};
+
+Content.defaultProps = {
+  className: '',
 };
 
 export default Content;

--- a/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
+++ b/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Accordion /> should match snapshot 1`] = `
+.c7 {
+  padding: 0 20px 20px;
+}
+
 .c8 {
   box-sizing: border-box;
   text-align: center;
@@ -211,10 +215,6 @@ exports[`<Accordion /> should match snapshot 1`] = `
   -webkit-transition: all 200ms ease-out 0s;
   transition: all 200ms ease-out 0s;
   fill: #D8385E;
-}
-
-.c7 {
-  padding: 0 20px 20px;
 }
 
 <body>


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We work at Darwin and have a scenario in which we want to use the accordion without existing padding. We can use change the style in Accordion component but we can't do the same in Accordion.Content. 

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->


- [x] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [X] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
