### PR TITLE
🚀 feat(Input): add a11y attributes to Input

### DIFF
--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -273,6 +273,7 @@ const AutoComplete = React.forwardRef(
                   )
                 }
                 ref={inputRef}
+                includeAriaAttributes={false}
               />
               {isSuggestionsOpen && (
                 <List {...getMenuProps()} full={full} error={!!error}>

--- a/packages/yoga/src/Dropdown/web/Dropdown.jsx
+++ b/packages/yoga/src/Dropdown/web/Dropdown.jsx
@@ -305,6 +305,7 @@ const Dropdown = React.forwardRef(
                 label={label}
                 full={full}
                 ref={inputRef}
+                includeAriaAttributes={false}
                 {...getInputProps()}
               />
               <Button

--- a/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/yoga/src/Dropdown/web/__snapshots__/Dropdown.test.jsx.snap
@@ -1548,6 +1548,7 @@ exports[`<Dropdown /> should match snapshot with error 1`] = `
       class="c11"
     >
       <span
+        aria-live="polite"
         class="c12"
       >
         Please, select one activity

--- a/packages/yoga/src/Input/web/Helper.jsx
+++ b/packages/yoga/src/Input/web/Helper.jsx
@@ -47,9 +47,14 @@ const Helper = ({
   maxLength,
   length,
   hideMaxLength,
+  a11yId,
 }) => (
   <Wrapper disabled={disabled} error={error}>
-    {(error || helper) && <Info as="span">{error || helper}</Info>}
+    {(error || helper) && (
+      <Info as="span" aria-live="polite" {...(a11yId && { id: a11yId })}>
+        {error || helper}
+      </Info>
+    )}
     {maxLength && !hideMaxLength && (
       <Info as="span">
         {length}/{maxLength}
@@ -65,6 +70,7 @@ Helper.propTypes = {
   maxLength: number,
   length: number,
   hideMaxLength: bool,
+  a11yId: string,
 };
 
 Helper.defaultProps = {
@@ -74,6 +80,7 @@ Helper.defaultProps = {
   maxLength: undefined,
   length: undefined,
   hideMaxLength: undefined,
+  a11yId: undefined,
 };
 
 export default Helper;

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -96,6 +96,8 @@ const Input = React.forwardRef(
       onClean,
       hideMaxLength,
       rightIcon,
+      a11yId,
+      includeAriaAttributes,
       ...props
     },
     ref,
@@ -111,6 +113,26 @@ const Input = React.forwardRef(
         inputRef.current.focus();
       }
     };
+
+    const hasHelper = helper || maxLength || error;
+
+    const helperA11yId = includeAriaAttributes && a11yId && `${a11yId}-helper`;
+    const labelA11yId = includeAriaAttributes && a11yId && `${a11yId}-label`;
+    let a11yFieldProps;
+
+    if (includeAriaAttributes) {
+      a11yFieldProps = a11yId
+        ? {
+            ...(hasHelper && { 'aria-describedby': helperA11yId }),
+            ...(label && { 'aria-labelledby': labelA11yId }),
+          }
+        : {
+            ...(label && { 'aria-label': label }),
+          };
+      a11yFieldProps['aria-invalid'] = !!error;
+    } else {
+      a11yFieldProps = {};
+    }
 
     return (
       <Control full={full}>
@@ -137,12 +159,17 @@ const Input = React.forwardRef(
               ref={inputRef}
               value={value}
               onChange={onChange}
+              {...a11yFieldProps}
             />
           ) : (
             children
           )}
 
-          <Label error={error} disabled={disabled}>
+          <Label
+            error={error}
+            disabled={disabled}
+            {...(labelA11yId && { id: labelA11yId })}
+          >
             {label}
           </Label>
 
@@ -174,7 +201,7 @@ const Input = React.forwardRef(
             </IconWrapper>
           )}
         </Fieldset>
-        {(helper || maxLength || error) && (
+        {hasHelper && (
           <Helper
             error={error}
             helper={helper}
@@ -182,6 +209,7 @@ const Input = React.forwardRef(
             length={value.length}
             disabled={disabled}
             hideMaxLength={hideMaxLength}
+            a11yId={helperA11yId}
           />
         )}
       </Control>
@@ -213,6 +241,10 @@ Input.propTypes = {
   hideMaxLength: bool,
   placeholder: string,
   rightIcon: node,
+  /** a unique prefix to generate HTML IDs to be used for aria-labelledby and aria-describedby */
+  a11yId: string,
+  /** useful for components that extend the Input component and have their own ARIA attributes implementation (e.g. Dropdown) */
+  includeAriaAttributes: bool,
 };
 
 Input.defaultProps = {
@@ -233,6 +265,8 @@ Input.defaultProps = {
   hideMaxLength: false,
   placeholder: undefined,
   rightIcon: undefined,
+  a11yId: undefined,
+  includeAriaAttributes: true,
 };
 
 export default Input;

--- a/packages/yoga/src/Input/web/Input.test.jsx
+++ b/packages/yoga/src/Input/web/Input.test.jsx
@@ -74,6 +74,36 @@ describe('<Input />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match with a11yId', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Input label="Label" a11yId="id" />
+        </ThemeProvider>,
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match with a11yId and error', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Input label="Label" a11yId="id" error="Error message" />
+        </ThemeProvider>,
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match with includeAriaAttributes set to false', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Input label="Label" includeAriaAttributes={false} />
+        </ThemeProvider>,
+      );
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('Events', () => {

--- a/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Email.test.jsx.snap
@@ -185,6 +185,8 @@ exports[`<Input.Email /> Snapshots should match with default input 1`] = `
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         label="Label"
         type="email"

--- a/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Input.test.jsx.snap
@@ -1,5 +1,466 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Input /> Snapshots should match with a11yId 1`] = `
+.c2 {
+  width: 100%;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  outline: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  border: none;
+  box-sizing: border-box;
+  height: 52px;
+  padding-top: 16px;
+  padding-right: 52px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  color: #231B22;
+  font-family: Rubik,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2:focus {
+  color: #231B22;
+}
+
+.c2:focus ~ legend {
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
+  -webkit-transition-property: max-width;
+  transition-property: max-width;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+}
+
+.c2:focus ~ label {
+  -webkit-transform: translateY(-24px);
+  -ms-transform: translateY(-24px);
+  transform: translateY(-24px);
+  -webkit-transition-property: -webkit-transform,font-size,color;
+  -webkit-transition-property: transform,font-size,color;
+  transition-property: transform,font-size,color;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  font-size: 12px;
+  font-weight: 400;
+  color: #231B22;
+}
+
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2::placeholder {
+  color: #6B6B78;
+}
+
+.c2[type="number"]::-webkit-outer-spin-button,
+.c2[type="number"]::-webkit-inner-spin-button {
+  display: none;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c1 {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  width: 320px;
+  height: 52px;
+  padding-left: 12px;
+  border-radius: 8px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #D7D7E0;
+}
+
+.c1:hover:not(:disabled),
+.c1:focus-within:not(:disabled) {
+  border-color: #231B22;
+}
+
+.c4 {
+  position: relative;
+  padding: 0;
+  max-width: 0;
+  width: auto;
+  height: 0;
+  font-weight: normal;
+  visibility: hidden;
+  -webkit-transition-property: max-width,padding;
+  transition-property: max-width,padding;
+  font-size: 12px;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+}
+
+.c5 {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.c3 {
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  pointer-events: none;
+  position: absolute;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  top: 16px;
+  left: 16px;
+  font-size: 14px;
+  font-weight: 400;
+  color: #6B6B78;
+  -webkit-transition-property: -webkit-transform,font-size;
+  -webkit-transition-property: transform,font-size;
+  transition-property: transform,font-size;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+}
+
+.c0 {
+  box-sizing: border-box;
+  width: 320px;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <fieldset
+      class="c1"
+      label="Label"
+      value=""
+    >
+      <input
+        aria-invalid="false"
+        aria-labelledby="id-label"
+        class="c2"
+        label="Label"
+        value=""
+      />
+      <label
+        class="c3"
+        id="id-label"
+      >
+        Label
+      </label>
+      <legend
+        class="c4"
+      >
+        <span
+          class="c5"
+        >
+          Label
+        </span>
+      </legend>
+      
+    </fieldset>
+  </div>
+</div>
+`;
+
+exports[`<Input /> Snapshots should match with a11yId and error 1`] = `
+.c2 {
+  width: 100%;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  outline: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  border: none;
+  box-sizing: border-box;
+  height: 52px;
+  padding-top: 16px;
+  padding-right: 52px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  color: #231B22;
+  font-family: Rubik,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2:focus {
+  color: #231B22;
+}
+
+.c2:focus ~ legend {
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
+  -webkit-transition-property: max-width;
+  transition-property: max-width;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+}
+
+.c2:focus ~ label {
+  -webkit-transform: translateY(-24px);
+  -ms-transform: translateY(-24px);
+  transform: translateY(-24px);
+  -webkit-transition-property: -webkit-transform,font-size,color;
+  -webkit-transition-property: transform,font-size,color;
+  transition-property: transform,font-size,color;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  font-size: 12px;
+  font-weight: 400;
+  color: #CA4808;
+}
+
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2::placeholder {
+  color: #6B6B78;
+}
+
+.c2[type="number"]::-webkit-outer-spin-button,
+.c2[type="number"]::-webkit-inner-spin-button {
+  display: none;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-top: 4px;
+  color: #CA4808;
+}
+
+.c7 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: currentColor;
+  font-size: 12px;
+}
+
+.c1 {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  width: 320px;
+  height: 52px;
+  padding-left: 12px;
+  border-radius: 8px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #CA4808;
+}
+
+.c1:hover:not(:disabled),
+.c1:focus-within:not(:disabled) {
+  border-color: #CA4808;
+}
+
+.c4 {
+  position: relative;
+  padding: 0;
+  max-width: 0;
+  width: auto;
+  height: 0;
+  font-weight: normal;
+  visibility: hidden;
+  -webkit-transition-property: max-width,padding;
+  transition-property: max-width,padding;
+  font-size: 12px;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+}
+
+.c5 {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.c3 {
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  pointer-events: none;
+  position: absolute;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  top: 16px;
+  left: 16px;
+  font-size: 14px;
+  font-weight: 400;
+  color: #6B6B78;
+  -webkit-transition-property: -webkit-transform,font-size;
+  -webkit-transition-property: transform,font-size;
+  transition-property: transform,font-size;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+}
+
+.c0 {
+  box-sizing: border-box;
+  width: 320px;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <fieldset
+      class="c1"
+      label="Label"
+      value=""
+    >
+      <input
+        aria-describedby="id-helper"
+        aria-invalid="true"
+        aria-labelledby="id-label"
+        class="c2"
+        label="Label"
+        value=""
+      />
+      <label
+        class="c3"
+        id="id-label"
+      >
+        Label
+      </label>
+      <legend
+        class="c4"
+      >
+        <span
+          class="c5"
+        >
+          Label
+        </span>
+      </legend>
+      
+    </fieldset>
+    <div
+      class="c6"
+    >
+      <span
+        aria-live="polite"
+        class="c7"
+        id="id-helper"
+      >
+        Error message
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Input /> Snapshots should match with default input 1`] = `
 .c2 {
   width: 100%;
@@ -185,6 +646,8 @@ exports[`<Input /> Snapshots should match with default input 1`] = `
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         label="Label"
         value=""
@@ -397,6 +860,8 @@ exports[`<Input /> Snapshots should match with disabled input 1`] = `
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         disabled=""
         label="Label"
@@ -633,6 +1098,8 @@ exports[`<Input /> Snapshots should match with error 1`] = `
       value=""
     >
       <input
+        aria-invalid="true"
+        aria-label="Label"
         class="c2"
         label="Label"
         value=""
@@ -657,6 +1124,7 @@ exports[`<Input /> Snapshots should match with error 1`] = `
       class="c6"
     >
       <span
+        aria-live="polite"
         class="c7"
       >
         Error message
@@ -851,6 +1319,8 @@ exports[`<Input /> Snapshots should match with full width 1`] = `
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         label="Label"
         value=""
@@ -1085,6 +1555,8 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         label="Label"
         maxlength="20"
@@ -1110,6 +1582,7 @@ exports[`<Input /> Snapshots should match with helper text and max length 1`] = 
       class="c6"
     >
       <span
+        aria-live="polite"
         class="c7"
       >
         Helper text
@@ -1336,6 +1809,8 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         label="Label"
         maxlength="20"
@@ -1361,11 +1836,221 @@ exports[`<Input /> Snapshots should match with helper text, max length and hideM
       class="c6"
     >
       <span
+        aria-live="polite"
         class="c7"
       >
         Helper text
       </span>
     </div>
+  </div>
+</div>
+`;
+
+exports[`<Input /> Snapshots should match with includeAriaAttributes set to false 1`] = `
+.c2 {
+  width: 100%;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  outline: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  border: none;
+  box-sizing: border-box;
+  height: 52px;
+  padding-top: 16px;
+  padding-right: 52px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  color: #231B22;
+  font-family: Rubik,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2:focus {
+  color: #231B22;
+}
+
+.c2:focus ~ legend {
+  max-width: -webkit-max-content;
+  max-width: -moz-max-content;
+  max-width: max-content;
+  -webkit-transition-property: max-width;
+  transition-property: max-width;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+}
+
+.c2:focus ~ label {
+  -webkit-transform: translateY(-24px);
+  -ms-transform: translateY(-24px);
+  transform: translateY(-24px);
+  -webkit-transition-property: -webkit-transform,font-size,color;
+  -webkit-transition-property: transform,font-size,color;
+  transition-property: transform,font-size,color;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  font-size: 12px;
+  font-weight: 400;
+  color: #231B22;
+}
+
+.c2:focus::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2:focus::placeholder {
+  color: #6B6B78;
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+  color: #D7D7E0;
+  -webkit-text-fill-color: #D7D7E0;
+  opacity: 1;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2::-moz-placeholder {
+  color: #6B6B78;
+}
+
+.c2:-ms-input-placeholder {
+  color: #6B6B78;
+}
+
+.c2::placeholder {
+  color: #6B6B78;
+}
+
+.c2[type="number"]::-webkit-outer-spin-button,
+.c2[type="number"]::-webkit-inner-spin-button {
+  display: none;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c1 {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  width: 320px;
+  height: 52px;
+  padding-left: 12px;
+  border-radius: 8px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #D7D7E0;
+}
+
+.c1:hover:not(:disabled),
+.c1:focus-within:not(:disabled) {
+  border-color: #231B22;
+}
+
+.c4 {
+  position: relative;
+  padding: 0;
+  max-width: 0;
+  width: auto;
+  height: 0;
+  font-weight: normal;
+  visibility: hidden;
+  -webkit-transition-property: max-width,padding;
+  transition-property: max-width,padding;
+  font-size: 12px;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  -webkit-transition-duration: 100ms;
+  transition-duration: 100ms;
+}
+
+.c5 {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.c3 {
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  pointer-events: none;
+  position: absolute;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  top: 16px;
+  left: 16px;
+  font-size: 14px;
+  font-weight: 400;
+  color: #6B6B78;
+  -webkit-transition-property: -webkit-transform,font-size;
+  -webkit-transition-property: transform,font-size;
+  transition-property: transform,font-size;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+  -webkit-transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+  transition-timing-function: cubic-bezier(0,0.75,0.1,1);
+}
+
+.c0 {
+  box-sizing: border-box;
+  width: 320px;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <fieldset
+      class="c1"
+      label="Label"
+      value=""
+    >
+      <input
+        class="c2"
+        label="Label"
+        value=""
+      />
+      <label
+        class="c3"
+      >
+        Label
+      </label>
+      <legend
+        class="c4"
+      >
+        <span
+          class="c5"
+        >
+          Label
+        </span>
+      </legend>
+      
+    </fieldset>
   </div>
 </div>
 `;
@@ -1555,6 +2240,8 @@ exports[`<Input /> Snapshots should match with label 1`] = `
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Input"
         class="c2"
         label="Input"
         value=""

--- a/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Number.test.jsx.snap
@@ -185,6 +185,8 @@ exports[`<Input.Number /> Snapshots should match with default input 1`] = `
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         label="Label"
         type="number"

--- a/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Password.test.jsx.snap
@@ -219,6 +219,8 @@ exports[`<Input.Password /> Snapshots should match with default input 1`] = `
         value=""
       >
         <input
+          aria-invalid="false"
+          aria-label="Label"
           class="c3 c4"
           label="Label"
           type="password"
@@ -480,6 +482,8 @@ exports[`<Input.Password /> Snapshots should match with disabled input 1`] = `
         value=""
       >
         <input
+          aria-invalid="false"
+          aria-label="Label"
           class="c3 c4"
           disabled=""
           label="Label"
@@ -737,6 +741,8 @@ exports[`<Input.Password /> Snapshots should match with full width 1`] = `
         value=""
       >
         <input
+          aria-invalid="false"
+          aria-label="Label"
           class="c3 c4"
           label="Label"
           type="password"

--- a/packages/yoga/src/Input/web/__snapshots__/Phone.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Phone.test.jsx.snap
@@ -634,6 +634,8 @@ exports[`<Input.Phone /> Snapshots should match with disabled input 1`] = `
         value=""
       >
         <input
+          aria-invalid="false"
+          aria-label="Label"
           class="c3 c4"
           disabled=""
           label="Label"
@@ -881,6 +883,8 @@ exports[`<Input.Phone /> Snapshots should match with error 1`] = `
       value=""
     >
       <input
+        aria-invalid="true"
+        aria-label="Label"
         class="c2"
         label="Label"
         value=""
@@ -905,6 +909,7 @@ exports[`<Input.Phone /> Snapshots should match with error 1`] = `
       class="c6"
     >
       <span
+        aria-live="polite"
         class="c7"
       >
         Error message
@@ -1134,6 +1139,8 @@ exports[`<Input.Phone /> Snapshots should match with full width 1`] = `
         value=""
       >
         <input
+          aria-invalid="false"
+          aria-label="Label"
           class="c3 c4"
           label="Label"
           type="password"

--- a/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Tel.test.jsx.snap
@@ -185,6 +185,8 @@ exports[`<Input.Tel /> Snapshots should match with default input 1`] = `
       value=""
     >
       <input
+        aria-invalid="false"
+        aria-label="Label"
         class="c2"
         label="Label"
         type="tel"


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/ITK-469)

## Description 📄

This PR adds some accessibility improvements to the Input component, focusing mainly in improving the usability with screen readers:

- Adds two new props to the Input component: `a11yId` and `includeAriaAttributes` (more details about these below);
- Adds `aria-labelledby` to the input element, so that screen readers can announce the label of the input. If no `a11yId` is provided, `aria-label` is added instead (`aria-labelledby` is preferable when there is a visible text that labels an element according to [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label));
- Adds `aria-describedby` to the input element, referencing the helper as it's description element. This allows the screen reader to announce helper and error messages associated with the input when the user focuses the input (works only if the `a11yId` prop is provided).
- Adds `aria-live="polite"` to the Helper component, so that error messages can be announced by the screen reader as soon as they appear;
- Adds `aria-invalid` to the input element, setting it's value to `true` when the `error` prop has a truthy value. This allows the screen reader to announce that the input has invalid data.

#### Generating HTML IDs for a11y
In order to use `aria-labelledby` and `aria-describedby` on the input element, HTML IDs had to be added to the label and helper elements. Some approaches were considered in order to do this (thanks @caiotracera for giving some ideas here):

1. The optimal solution would be using React's [useId hook](https://beta.reactjs.org/reference/react/useId), made specifically to solve this problem. Unfortunately, it is only available on React 18 (Yoga is currently on React 17.0.2).
2. Generate a UUID for the input, store it with `useRef` or `useState`, and use it as a prefix for the HTML IDs. The pro of this approach is that `aria-labelledby` and `aria-describedby` would automatically work on all inputs without the need of passing a prop for that. The con is that some inconsistencies might happen with server side rendering (I honestly don't have experience with SSR and would like to know your opinions on this).
3. Manually pass an ID as a prop to the Input component, which seemed to be the safest approach to start with. Although this approach is not scalable, since devs need to manually pass an ID to each input that they want to have `aria-labelledby` and `aria-describedby` working, it at least makes it possible to do it somehow. Another downside of this approach is that making the ID prop (`a11yId`) optional made the code a bit hard to read due to, for example, conditional props passing.

More about this can be found in this [SO question](https://stackoverflow.com/questions/29420835/how-to-generate-unique-ids-for-form-labels-in-react) and in this [React issue](https://github.com/facebook/react/issues/5867).


#### New `includeAriaAttributes` prop
Besides the new `a11yId` prop, this PR also adds another prop to the Input component: `includeAriaAttributes`. This prop has a `true` value by default and was added to give the possibility of including or not ARIA attributes on the Input, depending on the situation.

The need for this prop arose from components that extend the Input component and have their own ARIA implementations, like Dropdown and AutoComplete (by the way, the usability of these two components with screen readers also need to be revisited in the future, even though they have the ARIA attributes added by downshift).

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Open the Input page in the documentation app;
- Start running a screen reader (on mac, press cmd+F5 to start VoiceOver);
- Focus the input element:
  - it should announce something like "Find an activity, edit text" (the label is announced due to `aria-label`, since no `a11yId` has being passed yet);
- Press the `< >` button in order to edit the code;
- Edit the code adding `error={value == "error" && "Error message"}` to the list of props being passed to the `Input` component;
- Focus the input and type the word "error":
  - it should announce "Error message" as soon as the input enters in error state (due to `aria-live`);
- Focus any other element and then focus the input element again (still in the error state):
  - it should mention "invalid data" during the announcement (due to `aria-invalid`). Although, in this case it's not expected to have the error description announced, since there's no link between the helper and the input yet;
- Edit the code once again, now adding `a11yId="id"` to the list of props being passed to the `Input` component;
- Focus the input element:
  - it should now announce the content of the helper component too (i.e. the error message if the the input has errors or the helper text otherwise). That works now due to `aria-describedby`, that could be added because of the `a11yId`;
- Edit the code one last time, adding now `includeAriaAttributes={false}` to the list of props being passed to the `Input` component (feel free to keep the other added props or remove them);
- Focus the input element:
  - it should announce "edit text, blank". The label of the input is not expected to be announced due to the removal of `aria-label`/`aria-labelledby`.

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

The videos below do not have audio, but the announcements of VoiceOver are shown as text in the gray box.

Before:

https://user-images.githubusercontent.com/10004004/226908572-03c37f7d-79d3-419e-aacf-3ff60558c58a.mov


- The label of the input is not announced
- The screen reader is not aware whether the input has invalid data or not
- The helper text and the error description are not announced

After:

https://user-images.githubusercontent.com/10004004/226908725-d87f0b9f-e846-4b90-a929-0a2facfa709e.mov


- The label of the input is announced (even when no `a11yId` is passed)
- The screen reader announces if the input has invalid data
- The error description is announced at least once due to `aria-live`, or everytime the input is focused when an `a11yId` is provided