### PR TITLE
🚀 feat(AutoComplete): flag to bypass options filtering

### DIFF
--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -162,6 +162,7 @@ const AutoComplete = React.forwardRef(
       error,
       openSuggestionsAriaLabel,
       closeSuggestionsAriaLabel,
+      shouldfilterOptions,
       ...props
     },
     ref,
@@ -224,14 +225,16 @@ const AutoComplete = React.forwardRef(
             'gi',
           );
 
-          const suggestionList = options
-            .filter(option => option.match(reg))
-            .sort((first, second) =>
-              first.toLowerCase().indexOf(inputValue) <
-              second.toLowerCase().indexOf(inputValue)
-                ? -1
-                : 1,
-            );
+          const suggestionList = shouldfilterOptions
+            ? options
+                .filter(option => option.match(reg))
+                .sort((first, second) =>
+                  first.toLowerCase().indexOf(inputValue) <
+                  second.toLowerCase().indexOf(inputValue)
+                    ? -1
+                    : 1,
+                )
+            : options;
 
           if (!!inputValue && isOpen) {
             setIsSuggestionsOpen(true);
@@ -325,6 +328,8 @@ AutoComplete.propTypes = {
   openSuggestionsAriaLabel: string,
   /** an aria label for the close suggestions icon */
   closeSuggestionsAriaLabel: string,
+  /** flag to enable options filtering */
+  shouldfilterOptions: bool,
 };
 
 AutoComplete.defaultProps = {
@@ -339,6 +344,7 @@ AutoComplete.defaultProps = {
   error: undefined,
   openSuggestionsAriaLabel: 'Open suggestions',
   closeSuggestionsAriaLabel: 'Close suggestions',
+  shouldfilterOptions: true,
 };
 
 export default AutoComplete;

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
@@ -65,6 +65,25 @@ describe('<AutoComplete />', () => {
       );
     });
 
+    it('should not filter the options', () => {
+      const { container, getByDisplayValue } = render(
+        <ThemeProvider>
+          <AutoComplete
+            value="secon"
+            options={['first', 'second', 'third']}
+            shouldfilterOptions={false}
+          />
+        </ThemeProvider>,
+      );
+
+      fireEvent.focus(getByDisplayValue('secon'));
+
+      expect(container.querySelector('ul').firstChild.textContent).toBe(
+        'first',
+      );
+      expect(container.querySelector('ul').childNodes.length).toBe(3);
+    });
+
     it('should close options list when clean button is clicked', () => {
       const { container, getByDisplayValue, getByRole } = render(
         <ThemeProvider>


### PR DESCRIPTION
## Description 📄

Added new `shouldFilterOptions` prop to `AutoComplete` to bypass filtering and sorting dropdown options.

_Disclaimer: This prop will have a `true` default value so we can avoid breaking changes_

## Platforms 📲

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested? 🧪

- [x] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

https://user-images.githubusercontent.com/26771441/228029604-9dc4794f-84f2-487d-8eaa-67e11c55744d.mov