### PR TITLE
🐞 Fix `Accordion` warning - styled components called inside render

### DIFF
--- a/packages/yoga/src/Accordion/web/Accordion.jsx
+++ b/packages/yoga/src/Accordion/web/Accordion.jsx
@@ -5,6 +5,198 @@ import { ChevronDown } from '@gympass/yoga-icons';
 import { Text, Divider } from '@gympass/yoga';
 import Content from './Content';
 
+const AccordionWrapper = styled.div`
+  border: none;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+
+  ${({
+    theme: {
+      yoga: {
+        colors: { white, elements },
+      },
+    },
+    disabled,
+  }) => {
+    return `
+  background: ${disabled ? elements.backgroundAndDisabled : white}
+`;
+  }}
+
+  hr {
+    bottom: 0;
+    left: 0;
+    margin: 0;
+    position: absolute;
+    z-index: -1;
+  }
+`;
+
+const getVerticalPadding = (accordion, small) => {
+  if (small) return accordion.padding.small;
+  return accordion.padding.large;
+};
+
+const getHorizontalPadding = (accordion, hasHorizontalPadding) => {
+  if (hasHorizontalPadding) return accordion.padding.standard;
+  return accordion.padding.zero;
+};
+
+const Header = styled.button`
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+
+  ${({
+    theme: {
+      yoga: {
+        components: { accordion },
+      },
+    },
+    small,
+    hasHorizontalPadding,
+  }) => {
+    return `
+  padding:${getVerticalPadding(accordion, small)}px ${getHorizontalPadding(
+      accordion,
+      hasHorizontalPadding,
+    )}px;
+`;
+  }}
+
+  &:focus-visible {
+    ${({
+      theme: {
+        yoga: {
+          colors: { elements },
+        },
+      },
+    }) => {
+      return `
+    background: ${elements.backgroundAndDisabled};
+
+  `;
+    }}
+  }
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      cursor: not-allowed;
+    `}
+`;
+
+const Title = styled.div`
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  text-align: start;
+
+  ${({
+    theme: {
+      yoga: {
+        components: { accordion },
+      },
+    },
+    subtitle,
+  }) => {
+    return `
+  gap: ${subtitle ? accordion.gap.header : 0}px;
+  margin: ${subtitle ? 0 : `${accordion.paddingArrow.total}px 0`};
+`;
+  }}
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      ${({
+        theme: {
+          yoga: {
+            colors: { text },
+          },
+        },
+      }) => {
+        return `
+      color: ${text.secundary};
+    `;
+      }}
+    `}
+`;
+
+const AccordionContent = styled.div`
+  height: auto;
+  max-height: ${({ isOpen }) => (isOpen ? '9999px' : '0')};
+  overflow: hidden;
+  transition: max-height 200ms ease-in-out;
+
+  ${({
+    theme: {
+      yoga: {
+        components: { accordion },
+      },
+    },
+    small,
+  }) =>
+    small &&
+    css`
+      ${Content} {
+        padding-bottom: ${accordion.padding.small}px;
+      }
+    `}
+
+  ${({ hasHorizontalPadding }) =>
+    !hasHorizontalPadding &&
+    css`
+      ${Content} {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    `}
+`;
+
+const ArrowWrapper = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+
+  svg {
+    transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+    transition: all 200ms ease-out 0s;
+
+    ${({
+      theme: {
+        yoga: {
+          colors: { primary, text },
+        },
+      },
+      disabled,
+    }) => {
+      return `
+      fill: ${disabled ? text.secondary : primary};
+    `;
+    }}
+  }
+
+  ${({
+    theme: {
+      yoga: {
+        components: { accordion },
+      },
+    },
+  }) => {
+    return `
+  padding: ${accordion.paddingArrow.total}px;
+`;
+  }}
+`;
+
 const Accordion = ({
   title,
   subtitle,
@@ -17,198 +209,17 @@ const Accordion = ({
 }) => {
   const [open, setOpen] = useState(expanded);
 
-  const getVerticalPadding = accordion => {
-    if (small) return accordion.padding.small;
-    return accordion.padding.large;
-  };
-
-  const getHorizontalPadding = accordion => {
-    if (hasHorizontalPadding) return accordion.padding.standard;
-    return accordion.padding.zero;
-  };
-
-  const AccordionWrapper = styled.div`
-    border: none;
-    display: flex;
-    flex-direction: column;
-    position: relative;
-    width: 100%;
-    z-index: 1;
-
-    ${({
-      theme: {
-        yoga: {
-          colors: { white, elements },
-        },
-      },
-    }) => {
-      return `
-      background: ${disabled ? elements.backgroundAndDisabled : white}
-    `;
-    }}
-
-    hr {
-      bottom: 0;
-      left: 0;
-      margin: 0;
-      position: absolute;
-      z-index: -1;
-    }
-  `;
-
-  const Header = styled.button`
-    align-items: center;
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-
-    ${({
-      theme: {
-        yoga: {
-          components: { accordion },
-        },
-      },
-    }) => {
-      return `
-      padding:${getVerticalPadding(accordion)}px ${getHorizontalPadding(
-        accordion,
-      )}px;
-    `;
-    }}
-
-    &:focus-visible {
-      ${({
-        theme: {
-          yoga: {
-            colors: { elements },
-          },
-        },
-      }) => {
-        return `
-        background: ${elements.backgroundAndDisabled};
-
-      `;
-      }}
-    }
-
-    ${disabled &&
-    css`
-      cursor: not-allowed;
-    `}
-  `;
-
-  const Title = styled.div`
-    align-items: flex-start;
-    display: flex;
-    flex-direction: column;
-    text-align: start;
-
-    ${({
-      theme: {
-        yoga: {
-          components: { accordion },
-        },
-      },
-    }) => {
-      return `
-      gap: ${subtitle ? accordion.gap.header : 0}px;
-      margin: ${subtitle ? 0 : `${accordion.paddingArrow.total}px 0`};
-    `;
-    }}
-
-    ${disabled &&
-    css`
-      ${({
-        theme: {
-          yoga: {
-            colors: { text },
-          },
-        },
-      }) => {
-        return `
-          color: ${text.secundary};
-        `;
-      }}
-    `}
-  `;
-
-  const AccordionContent = styled.div`
-    height: auto;
-    max-height: ${({ isOpen }) => (isOpen ? '9999px' : '0')};
-    overflow: hidden;
-    transition: max-height 200ms ease-in-out;
-
-    ${({
-      theme: {
-        yoga: {
-          components: { accordion },
-        },
-      },
-    }) =>
-      small &&
-      css`
-        ${Content} {
-          padding-bottom: ${accordion.padding.small}px;
-        }
-      `}
-
-    ${!hasHorizontalPadding &&
-    css`
-      ${Content} {
-        padding-left: 0;
-        padding-right: 0;
-      }
-    `}
-  `;
-
-  const ArrowWrapper = styled.div`
-    align-items: center;
-    display: flex;
-    justify-content: center;
-
-    svg {
-      transform: ${({ isOpen }) =>
-        isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
-      transition: all 200ms ease-out 0s;
-
-      ${({
-        theme: {
-          yoga: {
-            colors: { primary, text },
-          },
-        },
-      }) => {
-        return `
-          fill: ${disabled ? text.secondary : primary};
-        `;
-      }}
-    }
-
-    ${({
-      theme: {
-        yoga: {
-          components: { accordion },
-        },
-      },
-    }) => {
-      return `
-      padding: ${accordion.paddingArrow.total}px;
-    `;
-    }}
-  `;
-
   return (
-    <AccordionWrapper {...props}>
+    <AccordionWrapper disabled={disabled} {...props}>
       <Header
         disabled={disabled}
         onClick={() => {
           setOpen(!open);
         }}
+        small={small}
+        hasHorizontalPadding={hasHorizontalPadding}
       >
-        <Title>
+        <Title subtitle={subtitle}>
           {small ? (
             <Text.Small color={disabled ? 'deep' : undefined}>
               {title}
@@ -225,12 +236,18 @@ const Accordion = ({
           <Text.Small color="deep">{subtitle}</Text.Small>
         </Title>
 
-        <ArrowWrapper isOpen={open}>
+        <ArrowWrapper isOpen={open} disabled={disabled}>
           <ChevronDown width={24} height={24} />
         </ArrowWrapper>
       </Header>
 
-      <AccordionContent isOpen={open}>{children}</AccordionContent>
+      <AccordionContent
+        isOpen={open}
+        small={small}
+        hasHorizontalPadding={hasHorizontalPadding}
+      >
+        {children}
+      </AccordionContent>
       <Divider />
     </AccordionWrapper>
   );

--- a/packages/yoga/src/Accordion/web/Accordion.jsx
+++ b/packages/yoga/src/Accordion/web/Accordion.jsx
@@ -214,7 +214,7 @@ const Accordion = ({
       <Header
         disabled={disabled}
         onClick={() => {
-          setOpen(!open);
+          setOpen(o => !o);
         }}
         small={small}
         hasHorizontalPadding={hasHorizontalPadding}

--- a/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
+++ b/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
@@ -5,46 +5,6 @@ exports[`<Accordion /> should correctly render the default version 1`] = `
   padding: 0 20px 20px;
 }
 
-.c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  color: #6B6B78;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  font-weight: 500;
-  font-family: Rubik;
-  color: #231B22;
-  line-height: 24px;
-}
-
-.c8 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  font-size: 16px;
-}
-
-.c9 {
-  width: 100%;
-  border-width: 0px;
-  border-left-width: 0px;
-  border-bottom-width: 1px;
-  border-color: #D7D7E0;
-}
-
 .c0 {
   border: none;
   display: -webkit-box;
@@ -142,6 +102,46 @@ exports[`<Accordion /> should correctly render the default version 1`] = `
   fill: #D8385E;
 }
 
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: Rubik;
+  color: #231B22;
+  line-height: 24px;
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  font-size: 16px;
+}
+
+.c9 {
+  width: 100%;
+  border-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 1px;
+  border-color: #D7D7E0;
+}
+
 <div
   class="c0"
 >
@@ -193,50 +193,6 @@ exports[`<Accordion /> should correctly render the default version 1`] = `
 exports[`<Accordion /> should correctly render the default version with subtitle 1`] = `
 .c8 {
   padding: 0 20px 20px;
-}
-
-.c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  color: #6B6B78;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  font-weight: 500;
-  font-family: Rubik;
-  color: #231B22;
-  line-height: 24px;
-}
-
-.c9 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  font-size: 16px;
-}
-
-.c10 {
-  width: 100%;
-  border-width: 0px;
-  border-left-width: 0px;
-  border-bottom-width: 1px;
-  border-color: #D7D7E0;
-}
-
-.c11 .c7 {
-  padding-bottom: 16px;
 }
 
 .c0 {
@@ -303,6 +259,10 @@ exports[`<Accordion /> should correctly render the default version with subtitle
   margin: 0;
 }
 
+.c11 .c7 {
+  padding-bottom: 16px;
+}
+
 .c6 {
   height: auto;
   max-height: 0;
@@ -334,6 +294,46 @@ exports[`<Accordion /> should correctly render the default version with subtitle
   -webkit-transition: all 200ms ease-out 0s;
   transition: all 200ms ease-out 0s;
   fill: #D8385E;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: Rubik;
+  color: #231B22;
+  line-height: 24px;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  font-size: 16px;
+}
+
+.c10 {
+  width: 100%;
+  border-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 1px;
+  border-color: #D7D7E0;
 }
 
 <div
@@ -389,54 +389,6 @@ exports[`<Accordion /> should correctly render the default version with subtitle
 exports[`<Accordion /> should correctly render the default version without side padding 1`] = `
 .c8 {
   padding: 0 20px 20px;
-}
-
-.c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  color: #6B6B78;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  font-weight: 500;
-  font-family: Rubik;
-  color: #231B22;
-  line-height: 24px;
-}
-
-.c9 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  font-size: 16px;
-}
-
-.c10 {
-  width: 100%;
-  border-width: 0px;
-  border-left-width: 0px;
-  border-bottom-width: 1px;
-  border-color: #D7D7E0;
-}
-
-.c11 .c7 {
-  padding-bottom: 16px;
-}
-
-.c12 .c7 {
-  padding-bottom: 16px;
 }
 
 .c0 {
@@ -503,6 +455,10 @@ exports[`<Accordion /> should correctly render the default version without side 
   margin: 8px 0;
 }
 
+.c11 .c7 {
+  padding-bottom: 16px;
+}
+
 .c6 {
   height: auto;
   max-height: 9999px;
@@ -539,6 +495,46 @@ exports[`<Accordion /> should correctly render the default version without side 
   -webkit-transition: all 200ms ease-out 0s;
   transition: all 200ms ease-out 0s;
   fill: #D8385E;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: Rubik;
+  color: #231B22;
+  line-height: 24px;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  font-size: 16px;
+}
+
+.c10 {
+  width: 100%;
+  border-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 1px;
+  border-color: #D7D7E0;
 }
 
 <div
@@ -592,46 +588,6 @@ exports[`<Accordion /> should correctly render the default version without side 
 exports[`<Accordion /> should correctly render the small version 1`] = `
 .c8 {
   padding: 0 20px 20px;
-}
-
-.c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  color: #6B6B78;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-}
-
-.c9 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  font-size: 16px;
-}
-
-.c10 {
-  width: 100%;
-  border-width: 0px;
-  border-left-width: 0px;
-  border-bottom-width: 1px;
-  border-color: #D7D7E0;
 }
 
 .c0 {
@@ -735,6 +691,46 @@ exports[`<Accordion /> should correctly render the small version 1`] = `
   fill: #D8385E;
 }
 
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  font-size: 16px;
+}
+
+.c10 {
+  width: 100%;
+  border-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 1px;
+  border-color: #D7D7E0;
+}
+
 <div
   class="c0"
 >
@@ -786,50 +782,6 @@ exports[`<Accordion /> should correctly render the small version 1`] = `
 exports[`<Accordion /> should correctly render the small version with subtitle 1`] = `
 .c8 {
   padding: 0 20px 20px;
-}
-
-.c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  color: #6B6B78;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-}
-
-.c9 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  font-size: 16px;
-}
-
-.c10 {
-  width: 100%;
-  border-width: 0px;
-  border-left-width: 0px;
-  border-bottom-width: 1px;
-  border-color: #D7D7E0;
-}
-
-.c11 .c7 {
-  padding-bottom: 16px;
 }
 
 .c0 {
@@ -933,6 +885,46 @@ exports[`<Accordion /> should correctly render the small version with subtitle 1
   fill: #D8385E;
 }
 
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  font-size: 16px;
+}
+
+.c10 {
+  width: 100%;
+  border-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 1px;
+  border-color: #D7D7E0;
+}
+
 <div
   class="c0"
 >
@@ -986,59 +978,6 @@ exports[`<Accordion /> should correctly render the small version with subtitle 1
 exports[`<Accordion /> should correctly render the small version without side padding 1`] = `
 .c8 {
   padding: 0 20px 20px;
-}
-
-.c4 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  color: #6B6B78;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-}
-
-.c9 {
-  margin: 0;
-  padding: 0;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  font-family: Rubik;
-  color: #231B22;
-  font-size: 16px;
-}
-
-.c10 {
-  width: 100%;
-  border-width: 0px;
-  border-left-width: 0px;
-  border-bottom-width: 1px;
-  border-color: #D7D7E0;
-}
-
-.c11 .c7 {
-  padding-bottom: 16px;
-}
-
-.c12 .c7 {
-  padding-bottom: 16px;
-}
-
-.c13 .c7 {
-  padding-left: 0;
-  padding-right: 0;
 }
 
 .c0 {
@@ -1105,6 +1044,15 @@ exports[`<Accordion /> should correctly render the small version without side pa
   margin: 8px 0;
 }
 
+.c11 .c7 {
+  padding-bottom: 16px;
+}
+
+.c12 .c7 {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .c6 {
   height: auto;
   max-height: 0;
@@ -1145,6 +1093,46 @@ exports[`<Accordion /> should correctly render the small version without side pa
   -webkit-transition: all 200ms ease-out 0s;
   transition: all 200ms ease-out 0s;
   fill: #D8385E;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  color: #6B6B78;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  font-size: 16px;
+}
+
+.c10 {
+  width: 100%;
+  border-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 1px;
+  border-color: #D7D7E0;
 }
 
 <div


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/TVM-994)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fix the following `Accordion` warning:
```
The component styled.div with the id of "..." has been created dynamically.
You may see this warning because you've called styled inside another component.
To resolve this only create new StyledComponents outside of any render method and function component.
```
![image](https://user-images.githubusercontent.com/47691990/229440138-8ce4188f-66da-4553-9e5b-296d6f06ce64.png)

- The animations on style components `AccordionContent` and `ArrowWrapper` were not being triggered. 
This PR also fixes that.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

- After making the necessary changes, the `Accordion` was tested manually - the behaviour stayed the same, with the addition of the animations now being triggered (as mentioned in the 2nd point of the description of this PR).
- Snapshots were updated.

[Enter the tips to test this PR]

- [ ] Unit Test
- [X] Snapshot Test

## Checklist: 🔍

- [X] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [X] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

N/A since the UI does not change.
