### PR TITLE
🚀 refactor(drawer): adjust drawer styles and structure

### DIFF
--- a/packages/doc/content/components/components/dialog/index.mdx
+++ b/packages/doc/content/components/components/dialog/index.mdx
@@ -114,7 +114,7 @@ render(() => {
         isOpen={isOpen}
         onClose={handleOnClose}
       >
-       <Dialog.Header>
+       <Dialog.Header onClose={handleOnClose}>
         Are you sure you want to downgrade to a Platinum plan?
        </Dialog.Header>
        <Dialog.Content>

--- a/packages/doc/content/components/components/dialog/index.mdx
+++ b/packages/doc/content/components/components/dialog/index.mdx
@@ -257,4 +257,11 @@ render(() => {
 
 ### Props
 
+### Dialog
+
 <PropsTable component="Dialog" platform="web" />
+
+
+### Dialog.Header
+
+<PropsTable component="Dialog.Header" platform="web" />

--- a/packages/doc/content/components/components/drawer/index.mdx
+++ b/packages/doc/content/components/components/drawer/index.mdx
@@ -41,29 +41,31 @@ render(() => {
   return (
     <>
       <Button onClick={handleOpen}>Open Drawer</Button>
-        <Drawer isOpen={isOpen} onClose={handleOnClose} title="section title">
-          <Drawer.Content>
-            <BoxContent>
-              <Video width="40" height="40" fill="#D8385E" />
-              <Text.Medium marginTop="medium" size="xxlarge">Learn how to edit this area</Text.Medium>
-              <Text marginTop="xxsmall" color="deep">This section is dinamic and can be edit.</Text>
-              <Text marginTop="large" color="vibin">Watch de video</Text>
-            </BoxContent>
-          </Drawer.Content>
+      <Drawer isOpen={isOpen} onClose={handleOnClose}>
+        <Drawer.Header onClose={handleOnClose} title="section title" />
 
-          <Drawer.Footer>
-            <Box display="flex" width="100%" gap="large">
-              <Button onClick={handleOnAction}>Large button</Button>
-              <Button.Text onClick={handleOnClose}>Large button</Button.Text>
-            </Box>
-          </Drawer.Footer>
-        </Drawer>
+        <Drawer.Content>
+          <BoxContent>
+            <Video width="40" height="40" fill="#D8385E" />
+            <Text.Medium marginTop="medium" size="xxlarge">Learn how to edit this area</Text.Medium>
+            <Text marginTop="xxsmall" color="deep">This section is dinamic and can be edit.</Text>
+            <Text marginTop="large" color="vibin">Watch de video</Text>
+          </BoxContent>
+        </Drawer.Content>
+
+        <Drawer.Footer>
+          <Box display="flex" width="100%" gap="large">
+            <Button onClick={handleOnAction}>Large button</Button>
+            <Button.Text onClick={handleOnClose}>Large button</Button.Text>
+          </Box>
+        </Drawer.Footer>
+      </Drawer>
     </>
   );
 });
 ```
 
-### Drawer with back button usage
+### Drawer with back button
 
 ```javascript state
 render(() => {
@@ -94,18 +96,172 @@ render(() => {
   return (
     <>
       <Button onClick={handleOpen}>Open Drawer</Button>
-      <Drawer isOpen={isOpen} onClose={handleOnClose} onBack={handleOnClose} title="section title">
-        <Drawer.Header>
-          <Box display="flex" justifyContent="flex-end" alignItems="center" width="100%">
-            <Box
-              style={{
-                textAlign: 'center'
-              }}
-              width="100%"
-            >Drawer title</Box>
-          </Box>
-        </Drawer.Header>
+      <Drawer isOpen={isOpen} onClose={handleOnClose}>
+        <Drawer.Header onClose={handleOnClose} onBack={handleOnClose} title="section title" />
 
+        <Drawer.Content>
+          <BoxContent>
+            <Video width="40" height="40" fill="#D8385E" />
+            <Text.Medium marginTop="medium" size="xxlarge">Learn how to edit this area</Text.Medium>
+            <Text marginTop="xxsmall" color="deep">This section is dinamic and can be edit.</Text>
+            <Text marginTop="large" color="vibin">Watch de video</Text>
+          </BoxContent>
+        </Drawer.Content>
+
+        <Drawer.Footer>
+          <Box display="flex" width="100%" gap="large">
+            <Button onClick={handleOnAction}>Large button</Button>
+            <Button.Text onClick={handleOnClose}>Large button</Button.Text>
+          </Box>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+});
+```
+
+### Drawer with divider on header
+
+```javascript state
+render(() => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleOnClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleOnAction = () => {
+    alert('This is your custom action');
+  };
+
+  const BoxContent = styled(Box)`
+    height: 100%;
+    max-width: 340px;
+
+    display: flex;
+    flex-direction: column;
+
+    margin-top: 100px;
+  `;
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open Drawer</Button>
+      <Drawer isOpen={isOpen} onClose={handleOnClose}>
+        <Drawer.Header onClose={handleOnClose} onBack={handleOnClose} title="section title" divider />
+
+        <Drawer.Content>
+          <BoxContent>
+            <Video width="40" height="40" fill="#D8385E" />
+            <Text.Medium marginTop="medium" size="xxlarge">Learn how to edit this area</Text.Medium>
+            <Text marginTop="xxsmall" color="deep">This section is dinamic and can be edit.</Text>
+            <Text marginTop="large" color="vibin">Watch de video</Text>
+          </BoxContent>
+        </Drawer.Content>
+
+        <Drawer.Footer>
+          <Box display="flex" width="100%" gap="large">
+            <Button onClick={handleOnAction}>Large button</Button>
+            <Button.Text onClick={handleOnClose}>Large button</Button.Text>
+          </Box>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+});
+```
+
+### Drawer with no close button
+
+```javascript state
+render(() => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleOnClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleOnAction = () => {
+    alert('This is your custom action');
+  };
+
+  const BoxContent = styled(Box)`
+    height: 100%;
+    max-width: 340px;
+
+    display: flex;
+    flex-direction: column;
+
+    margin-top: 100px;
+  `;
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open Drawer</Button>
+      <Drawer isOpen={isOpen} onClose={handleOnClose}>
+        <Drawer.Header onClose={handleOnClose} onBack={handleOnClose} title="section title" hideCloseButton />
+
+        <Drawer.Content>
+          <BoxContent>
+            <Video width="40" height="40" fill="#D8385E" />
+            <Text.Medium marginTop="medium" size="xxlarge">Learn how to edit this area</Text.Medium>
+            <Text marginTop="xxsmall" color="deep">This section is dinamic and can be edit.</Text>
+            <Text marginTop="large" color="vibin">Watch de video</Text>
+          </BoxContent>
+        </Drawer.Content>
+
+        <Drawer.Footer>
+          <Box display="flex" width="100%" gap="large">
+            <Button onClick={handleOnAction}>Large button</Button>
+            <Button.Text onClick={handleOnClose}>Large button</Button.Text>
+          </Box>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+});
+```
+
+### Drawer with no header
+
+```javascript state
+render(() => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleOnClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleOnAction = () => {
+    alert('This is your custom action');
+  };
+
+  const BoxContent = styled(Box)`
+    height: 100%;
+    max-width: 340px;
+
+    display: flex;
+    flex-direction: column;
+
+    margin-top: 100px;
+  `;
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open Drawer</Button>
+      <Drawer isOpen={isOpen} onClose={handleOnClose}>
         <Drawer.Content>
           <BoxContent>
             <Video width="40" height="40" fill="#D8385E" />

--- a/packages/doc/content/components/components/drawer/index.mdx
+++ b/packages/doc/content/components/components/drawer/index.mdx
@@ -285,4 +285,8 @@ render(() => {
 
 ### Props
 
+#### Drawer
 <PropsTable component="Drawer" platform="web" />
+
+#### Drawer.Header
+<PropsTable component="Drawer.Header" platform="web" />

--- a/packages/doc/content/components/components/drawer/index.mdx
+++ b/packages/doc/content/components/components/drawer/index.mdx
@@ -28,41 +28,100 @@ render(() => {
     alert('This is your custom action');
   };
 
+  const BoxContent = styled(Box)`
+    height: 100%;
+    max-width: 340px;
+
+    display: flex;
+    flex-direction: column;
+
+    margin-top: 100px;
+  `;
+
   return (
     <>
       <Button onClick={handleOpen}>Open Drawer</Button>
-        <Drawer isOpen={isOpen} onClose={handleOnClose}>
-          <Drawer.Header>
-            <Box display="flex" justifyContent="flex-end" alignItems="center" width="100%">
-              <Box
-                style={{
-                  textAlign: 'center'
-                }}
-                width="100%"
-              >Drawer title</Box>
-            </Box>
-          </Drawer.Header>
+        <Drawer isOpen={isOpen} onClose={handleOnClose} title="section title">
           <Drawer.Content>
-            <Box
-              display="flex"
-              flexDirection="column"
-              justifyContent="center"
-              style={{
-                paddingTop: 10,
-                height: '100%'
-              }}
-            >
+            <BoxContent>
               <Video width="40" height="40" fill="#D8385E" />
-              <Text.Medium  mt="large" fontSize="xxlarge">Learn how to edit this area</Text.Medium>
-              <Text mt="xxssmall" color="light">Live the mission</Text>
-              <Text mt="xxsmall" color="uplift">Watch de video</Text>
-            </Box>
+              <Text.Medium marginTop="medium" size="xxlarge">Learn how to edit this area</Text.Medium>
+              <Text marginTop="xxsmall" color="deep">This section is dinamic and can be edit.</Text>
+              <Text marginTop="large" color="vibin">Watch de video</Text>
+            </BoxContent>
           </Drawer.Content>
+
           <Drawer.Footer>
-            <Button onClick={handleOnAction}>large button</Button>
-            <Button.Text onClick={handleOnClose}>Cancel</Button.Text>
+            <Box display="flex" width="100%" gap="large">
+              <Button onClick={handleOnAction}>Large button</Button>
+              <Button.Text onClick={handleOnClose}>Large button</Button.Text>
+            </Box>
           </Drawer.Footer>
         </Drawer>
+    </>
+  );
+});
+```
+
+### Drawer with back button usage
+
+```javascript state
+render(() => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleOnClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleOnAction = () => {
+    alert('This is your custom action');
+  };
+
+  const BoxContent = styled(Box)`
+    height: 100%;
+    max-width: 340px;
+
+    display: flex;
+    flex-direction: column;
+
+    margin-top: 100px;
+  `;
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open Drawer</Button>
+      <Drawer isOpen={isOpen} onClose={handleOnClose} onBack={handleOnClose} title="section title">
+        <Drawer.Header>
+          <Box display="flex" justifyContent="flex-end" alignItems="center" width="100%">
+            <Box
+              style={{
+                textAlign: 'center'
+              }}
+              width="100%"
+            >Drawer title</Box>
+          </Box>
+        </Drawer.Header>
+
+        <Drawer.Content>
+          <BoxContent>
+            <Video width="40" height="40" fill="#D8385E" />
+            <Text.Medium marginTop="medium" size="xxlarge">Learn how to edit this area</Text.Medium>
+            <Text marginTop="xxsmall" color="deep">This section is dinamic and can be edit.</Text>
+            <Text marginTop="large" color="vibin">Watch de video</Text>
+          </BoxContent>
+        </Drawer.Content>
+
+        <Drawer.Footer>
+          <Box display="flex" width="100%" gap="large">
+            <Button onClick={handleOnAction}>Large button</Button>
+            <Button.Text onClick={handleOnClose}>Large button</Button.Text>
+          </Box>
+        </Drawer.Footer>
+      </Drawer>
     </>
   );
 });

--- a/packages/doc/content/components/components/drawer/index.mdx
+++ b/packages/doc/content/components/components/drawer/index.mdx
@@ -97,7 +97,7 @@ render(() => {
     <>
       <Button onClick={handleOpen}>Open Drawer</Button>
       <Drawer isOpen={isOpen} onClose={handleOnClose}>
-        <Drawer.Header onClose={handleOnClose} onBack={handleOnClose} title="section title" />
+        <Drawer.Header onClose={handleOnClose} backHandler={handleOnClose} title="section title" />
 
         <Drawer.Content>
           <BoxContent>
@@ -152,7 +152,7 @@ render(() => {
     <>
       <Button onClick={handleOpen}>Open Drawer</Button>
       <Drawer isOpen={isOpen} onClose={handleOnClose}>
-        <Drawer.Header onClose={handleOnClose} onBack={handleOnClose} title="section title" divider />
+        <Drawer.Header onClose={handleOnClose} backHandler={handleOnClose} title="section title" divider />
 
         <Drawer.Content>
           <BoxContent>
@@ -207,7 +207,7 @@ render(() => {
     <>
       <Button onClick={handleOpen}>Open Drawer</Button>
       <Drawer isOpen={isOpen} onClose={handleOnClose}>
-        <Drawer.Header onClose={handleOnClose} onBack={handleOnClose} title="section title" hideCloseButton />
+        <Drawer.Header onClose={handleOnClose} backHandler={handleOnClose} title="section title" hideCloseButton />
 
         <Drawer.Content>
           <BoxContent>

--- a/packages/yoga/package.json
+++ b/packages/yoga/package.json
@@ -52,8 +52,10 @@
     "react-phone-input-2": "^2.15.1"
   },
   "devDependencies": {
+    "@testing-library/dom": "^9.2.0",
     "@testing-library/react": "^12.0.4",
     "@testing-library/react-native": "^9.1.0",
+    "@testing-library/user-event": "^14.4.3",
     "babel-plugin-inline-react-svg": "^1.1.1",
     "styled-components": "^4.4.0"
   },

--- a/packages/yoga/src/BottomSheet/web/BottomSheet.test.jsx
+++ b/packages/yoga/src/BottomSheet/web/BottomSheet.test.jsx
@@ -66,8 +66,8 @@ describe('<BottomSheet />', () => {
   it('should show the close button', () => {
     render(
       <ThemeProvider>
-        <BottomSheet isOpen hideCloseButton={false} onClose={() => {}}>
-          <BottomSheet.Header>Title</BottomSheet.Header>
+        <BottomSheet isOpen onClose={() => {}}>
+          <BottomSheet.Header onClose={() => {}}>Title</BottomSheet.Header>
         </BottomSheet>
       </ThemeProvider>,
     );

--- a/packages/yoga/src/Dialog/web/Dialog.jsx
+++ b/packages/yoga/src/Dialog/web/Dialog.jsx
@@ -110,7 +110,7 @@ Dialog.propTypes = {
   isOpen: bool,
   /** Function to close the dialog. */
   onClose: func,
-  onBack: func,
+  backHandler: func,
   zIndex: number,
   children: node.isRequired,
 };
@@ -118,7 +118,7 @@ Dialog.propTypes = {
 Dialog.defaultProps = {
   isOpen: false,
   onClose: undefined,
-  onBack: undefined,
+  backHandler: undefined,
   zIndex: 3,
   dialogId: undefined,
 };

--- a/packages/yoga/src/Dialog/web/Dialog.jsx
+++ b/packages/yoga/src/Dialog/web/Dialog.jsx
@@ -3,9 +3,8 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { func, bool, node, number, string } from 'prop-types';
 
-import { Close } from '@gympass/yoga-icons';
 import { usePortal, useCombinedRefs } from '../../hooks';
-import { Button, Card, Box } from '../..';
+import { Card } from '../..';
 
 export const StyledDialog = styled(Card)`
   ${({
@@ -54,13 +53,9 @@ const Overlay = styled.div`
 `;
 
 const Dialog = React.forwardRef(
-  (
-    { isOpen, hideCloseButton, children, dialogId, onClose, zIndex, ...props },
-    forwardedRef,
-  ) => {
+  ({ isOpen, children, dialogId, onClose, zIndex, ...props }, forwardedRef) => {
     const dialogRef = useCombinedRefs(forwardedRef);
     const dialogElement = usePortal(dialogId ?? 'dialog');
-    const isCloseButtonVisible = onClose && !hideCloseButton;
 
     const closeDialog = useCallback(
       e => {
@@ -97,11 +92,6 @@ const Dialog = React.forwardRef(
           zIndex={zIndex}
         >
           <StyledDialog onClose={onClose} {...props}>
-            {isCloseButtonVisible && (
-              <Box d="flex" justifyContent="flex-end" w="100%">
-                <Button.Icon icon={Close} inverted onClick={onClose} />
-              </Box>
-            )}
             {children}
           </StyledDialog>
         </Overlay>,
@@ -118,8 +108,6 @@ Dialog.propTypes = {
   dialogId: string,
   /** Control the dialog visibility. */
   isOpen: bool,
-  /** Hide the close button when onClose prop is defined. */
-  hideCloseButton: bool,
   /** Function to close the dialog. */
   onClose: func,
   onBack: func,
@@ -129,7 +117,6 @@ Dialog.propTypes = {
 
 Dialog.defaultProps = {
   isOpen: false,
-  hideCloseButton: false,
   onClose: undefined,
   onBack: undefined,
   zIndex: 3,

--- a/packages/yoga/src/Dialog/web/Dialog.jsx
+++ b/packages/yoga/src/Dialog/web/Dialog.jsx
@@ -122,6 +122,7 @@ Dialog.propTypes = {
   hideCloseButton: bool,
   /** Function to close the dialog. */
   onClose: func,
+  onBack: func,
   zIndex: number,
   children: node.isRequired,
 };
@@ -130,6 +131,7 @@ Dialog.defaultProps = {
   isOpen: false,
   hideCloseButton: false,
   onClose: undefined,
+  onBack: undefined,
   zIndex: 3,
   dialogId: undefined,
 };

--- a/packages/yoga/src/Dialog/web/Dialog.test.jsx
+++ b/packages/yoga/src/Dialog/web/Dialog.test.jsx
@@ -28,7 +28,7 @@ describe('<Dialog />', () => {
     const { baseElement } = render(
       <ThemeProvider>
         <Dialog isOpen onClose={jest.fn()}>
-          <Dialog.Header>Title</Dialog.Header>
+          <Dialog.Header onClose={jest.fn()}>Title</Dialog.Header>
           <Dialog.Content>Subtitle</Dialog.Content>
           <Dialog.Footer>
             <Button secondary>Ok, got it</Button>
@@ -73,7 +73,7 @@ describe('<Dialog />', () => {
     render(
       <ThemeProvider>
         <Dialog isOpen onClose={onCloseMock}>
-          <Dialog.Header>Title</Dialog.Header>
+          <Dialog.Header onClose={onCloseMock}>Title</Dialog.Header>
         </Dialog>
       </ThemeProvider>,
     );

--- a/packages/yoga/src/Dialog/web/Header.jsx
+++ b/packages/yoga/src/Dialog/web/Header.jsx
@@ -1,17 +1,39 @@
 import React from 'react';
-import Box from '../../Box';
+import { Close } from '@gympass/yoga-icons';
+import { func, node } from 'prop-types';
+import { Box, Button } from '../..';
 
-const Header = props => (
-  <Box
-    as="header"
-    ta="center"
-    color="text.primary"
-    fw="medium"
-    fs="xlarge"
-    mb="large"
-    {...props}
-  />
-);
+function Header({ onClose, children, ...props }) {
+  return (
+    <Box
+      as="header"
+      ta="center"
+      color="text.primary"
+      fw="medium"
+      fs="xlarge"
+      mb="large"
+      {...props}
+    >
+      {onClose && (
+        <Box d="flex" justifyContent="flex-end" w="100%">
+          <Button.Icon icon={Close} inverted onClick={onClose} />
+        </Box>
+      )}
+
+      {children}
+    </Box>
+  );
+}
+
+Header.propTypes = {
+  onClose: func,
+  children: node,
+};
+
+Header.defaultProps = {
+  onClose: undefined,
+  children: null,
+};
 
 Header.displayName = 'Dialog.Header';
 

--- a/packages/yoga/src/Dialog/web/__snapshots__/Dialog.test.jsx.snap
+++ b/packages/yoga/src/Dialog/web/__snapshots__/Dialog.test.jsx.snap
@@ -244,7 +244,7 @@ exports[`<Dialog /> should match snapshot with close button 1`] = `
   fill: #FFFFFF;
 }
 
-.c6 {
+.c3 {
   margin-bottom: 24px;
   color: #231B22;
   font-size: 24px;
@@ -272,7 +272,7 @@ exports[`<Dialog /> should match snapshot with close button 1`] = `
   gap: 24px;
 }
 
-.c3 {
+.c4 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -284,12 +284,12 @@ exports[`<Dialog /> should match snapshot with close button 1`] = `
   justify-content: flex-end;
 }
 
-.c5 {
+.c6 {
   width: 24px;
   height: 24px;
 }
 
-.c4 {
+.c5 {
   box-sizing: border-box;
   text-align: center;
   outline: none;
@@ -332,7 +332,7 @@ exports[`<Dialog /> should match snapshot with close button 1`] = `
   width: 48px;
 }
 
-.c4 svg {
+.c5 svg {
   width: 24px;
   height: 24px;
   fill: #FFFFFF;
@@ -341,39 +341,39 @@ exports[`<Dialog /> should match snapshot with close button 1`] = `
   transition: fill 0.2s;
 }
 
-.c4:not([disabled]):hover,
-.c4:not([disabled]):focus {
+.c5:not([disabled]):hover,
+.c5:not([disabled]):focus {
   box-shadow: 0 4px 8px rgba(216,56,94,0.45);
 }
 
-.c4:active {
+.c5:active {
   background-color: rgba(216,56,94,0.75);
   color: #FFFFFF;
 }
 
-.c4:active svg {
+.c5:active svg {
   fill: #FFFFFF;
 }
 
-.c4 svg {
+.c5 svg {
   fill: #D8385E;
 }
 
-.c4:active {
+.c5:active {
   background-color: rgba(255,255,255,0.75);
   color: rgba(216,56,94,0.75);
 }
 
-.c4:active svg {
+.c5:active svg {
   fill: rgba(216,56,94,0.75);
 }
 
-.c4:not([disabled]):hover,
-.c4:not([disabled]):focus {
+.c5:not([disabled]):hover,
+.c5:not([disabled]):focus {
   box-shadow: 0 4px 8px rgba(255,255,255,0.45);
 }
 
-.c4 svg {
+.c5 svg {
   width: unset;
   height: unset;
   margin-right: unset;
@@ -438,24 +438,24 @@ exports[`<Dialog /> should match snapshot with close button 1`] = `
         <section
           class="c1 c2"
         >
-          <div
-            class="c3"
-            d="flex"
-          >
-            <button
-              class="c4"
-            >
-              <svg
-                class="c5"
-                height="24"
-                width="24"
-              />
-            </button>
-          </div>
           <header
-            class="c6"
+            class="c3"
             color="text.primary"
           >
+            <div
+              class="c4"
+              d="flex"
+            >
+              <button
+                class="c5"
+              >
+                <svg
+                  class="c6"
+                  height="24"
+                  width="24"
+                />
+              </button>
+            </div>
             Title
           </header>
           <div

--- a/packages/yoga/src/Drawer/Drawer.theme.js
+++ b/packages/yoga/src/Drawer/Drawer.theme.js
@@ -1,9 +1,9 @@
 const Drawer = ({ spacing }) => ({
   padding: {
     top: spacing.small,
-    right: spacing.xxxlarge,
+    right: spacing.xxlarge,
     bottom: spacing.xxlarge,
-    left: spacing.xxxlarge,
+    left: spacing.xxlarge,
   },
   width: {
     default: 600,

--- a/packages/yoga/src/Drawer/web/Content.jsx
+++ b/packages/yoga/src/Drawer/web/Content.jsx
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
+import { theme } from '@gympass/yoga';
 import Dialog from '../../Dialog';
 
 const Content = styled(Dialog.Content)`
-  margin: 0;
+  margin: ${theme.spacing.zero};
   height: 100%;
   width: 100%;
   align-self: flex-start;
   text-align: left;
+  padding-left: ${theme.spacing.xxlarge}px;
 `;
 
 Content.displayName = 'Drawer.Content';

--- a/packages/yoga/src/Drawer/web/Content.jsx
+++ b/packages/yoga/src/Drawer/web/Content.jsx
@@ -3,12 +3,15 @@ import { theme } from '@gympass/yoga';
 import Dialog from '../../Dialog';
 
 const Content = styled(Dialog.Content)`
-  margin: ${theme.spacing.zero};
-  height: 100%;
   width: 100%;
+  height: 100%;
+
   align-self: flex-start;
-  text-align: left;
+
+  margin: ${theme.spacing.zero};
   padding-left: ${theme.spacing.xxlarge}px;
+
+  text-align: left;
 `;
 
 Content.displayName = 'Drawer.Content';

--- a/packages/yoga/src/Drawer/web/Drawer.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.jsx
@@ -14,7 +14,7 @@ const StyledDrawer = styled(Dialog)`
   animation-fill-mode: forwards;
   transition: 0.25s ease-in-out;
 
-  padding: 16px 16px 40px 40px;
+  padding: 0 !important;
 
   ${({
     theme: {

--- a/packages/yoga/src/Drawer/web/Drawer.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.jsx
@@ -4,17 +4,7 @@ import { node, number } from 'prop-types';
 import Dialog from '../../Dialog';
 
 const StyledDrawer = styled(Dialog)`
-  ${({
-    theme: {
-      yoga: {
-        components: { drawer },
-      },
-    },
-  }) => `
-  padding: ${drawer.padding.top}px ${drawer.padding.right}px ${drawer.padding.bottom}px ${drawer.padding.left}px;
-  width: min(${drawer.width.default}px, 100%);
-  `}
-  border-radius: 0!important;
+  border-radius: 0 !important;
   height: 100%;
   align-self: flex-end;
   position: absolute;
@@ -23,6 +13,19 @@ const StyledDrawer = styled(Dialog)`
   animation-duration: 400ms;
   animation-fill-mode: forwards;
   transition: 0.25s ease-in-out;
+
+  padding: 16px 16px 40px 40px;
+
+  ${({
+    theme: {
+      yoga: {
+        components: { drawer },
+      },
+    },
+  }) => `
+    width: min(${drawer.width.default}px, 100%);
+  `}
+
   @keyframes content {
     0% {
       transform: translate3d(100%, 0, 0);

--- a/packages/yoga/src/Drawer/web/Drawer.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.jsx
@@ -11,8 +11,8 @@ const StyledDrawer = styled(Dialog)`
   align-self: flex-end;
 
   height: 100%;
-  padding: ${theme.spacing.zero};
-  border-radius: ${theme.borders.zero};
+  padding: ${theme.spacing.zero} !important;
+  border-radius: ${theme.borders.zero} !important;
 
   transition: 0.25s ease-in-out;
 

--- a/packages/yoga/src/Drawer/web/Drawer.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.jsx
@@ -1,20 +1,24 @@
 import React from 'react';
 import styled from 'styled-components';
 import { node, number } from 'prop-types';
+import { theme } from '@gympass/yoga';
 import Dialog from '../../Dialog';
 
 const StyledDrawer = styled(Dialog)`
-  border-radius: 0 !important;
-  height: 100%;
-  align-self: flex-end;
   position: absolute;
   right: 0;
+
+  align-self: flex-end;
+
+  height: 100%;
+  padding: ${theme.spacing.zero};
+  border-radius: ${theme.borders.zero};
+
+  transition: 0.25s ease-in-out;
+
   animation: content;
   animation-duration: 400ms;
   animation-fill-mode: forwards;
-  transition: 0.25s ease-in-out;
-
-  padding: 0 !important;
 
   ${({
     theme: {

--- a/packages/yoga/src/Drawer/web/Drawer.test.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.test.jsx
@@ -8,12 +8,13 @@ import Drawer from '.';
 
 describe('<Drawer />', () => {
   afterEach(cleanup);
+  const onActionMock = jest.fn();
 
   it('should match snapshot', () => {
     const { baseElement } = render(
       <ThemeProvider>
         <Drawer isOpen>
-          <Drawer.Header>Title</Drawer.Header>
+          <Drawer.Header title="Title" />
           <Drawer.Content>Subtitle</Drawer.Content>
           <Drawer.Footer>
             <Button secondary>Ok, got it</Button>
@@ -26,8 +27,6 @@ describe('<Drawer />', () => {
   });
 
   it('should render a minimal drawer', async () => {
-    const onActionMock = jest.fn();
-
     render(
       <ThemeProvider>
         <Drawer isOpen>
@@ -50,5 +49,115 @@ describe('<Drawer />', () => {
       .click(screen.getByRole('button', { name: /Ok, got it/i }));
 
     expect(onActionMock).toHaveBeenCalledTimes(1);
+  });
+
+  describe('<Drawer.Header />', () => {
+    afterEach(cleanup);
+
+    it('should render close bottom', () => {
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Header title="Title" onClose={onActionMock} />
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByTestId('close-button-drawer')).toBeInTheDocument();
+    });
+
+    it('should render back bottom', () => {
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Header title="Title" onBack={onActionMock} />
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByTestId('back-button-drawer')).toBeInTheDocument();
+    });
+
+    it('should render close and back bottons', () => {
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Header
+              title="Title"
+              onClose={onActionMock}
+              onBack={onActionMock}
+            />
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByTestId('back-button-drawer')).toBeInTheDocument();
+    });
+
+    it('should render divider component', () => {
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Header title="Title" divider />
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByTestId('divider-drawer')).toBeInTheDocument();
+    });
+
+    it('should render drawer without drawer.header', async () => {
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Content>Subtitle</Drawer.Content>
+            <Drawer.Footer>
+              <Button onClick={onActionMock} secondary>
+                Ok, got it
+              </Button>
+            </Drawer.Footer>
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      await userEvent
+        .setup()
+        .click(screen.getByRole('button', { name: /Ok, got it/i }));
+
+      expect(screen.getByText('Subtitle')).toBeInTheDocument();
+      expect(onActionMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should render all props', async () => {
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Header
+              title="Title"
+              onClose={onActionMock}
+              onBack={onActionMock}
+              divider
+            />
+            <Drawer.Content>Subtitle</Drawer.Content>
+            <Drawer.Footer>
+              <Button onClick={onActionMock} secondary>
+                Ok, got it
+              </Button>
+            </Drawer.Footer>
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      await userEvent
+        .setup()
+        .click(screen.getByRole('button', { name: /Ok, got it/i }));
+
+      expect(onActionMock).toHaveBeenCalledTimes(3);
+      expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Subtitle')).toBeInTheDocument();
+      expect(screen.getByTestId('close-button-drawer')).toBeInTheDocument();
+      expect(screen.getByTestId('divider-drawer')).toBeInTheDocument();
+      expect(screen.getByTestId('back-button-drawer')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/yoga/src/Drawer/web/Drawer.test.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.test.jsx
@@ -8,7 +8,6 @@ import Drawer from '.';
 
 describe('<Drawer />', () => {
   afterEach(cleanup);
-  const onActionMock = jest.fn();
 
   it('should match snapshot', () => {
     const { baseElement } = render(
@@ -17,7 +16,7 @@ describe('<Drawer />', () => {
           <Drawer.Header title="Title" />
           <Drawer.Content>Subtitle</Drawer.Content>
           <Drawer.Footer>
-            <Button secondary>Ok, got it</Button>
+            <Button secondary>Ok, got it!</Button>
           </Drawer.Footer>
         </Drawer>
       </ThemeProvider>,
@@ -27,6 +26,8 @@ describe('<Drawer />', () => {
   });
 
   it('should render a minimal drawer', async () => {
+    const onActionMock = jest.fn();
+
     render(
       <ThemeProvider>
         <Drawer isOpen>
@@ -34,64 +35,89 @@ describe('<Drawer />', () => {
           <Drawer.Content>Subtitle</Drawer.Content>
           <Drawer.Footer>
             <Button onClick={onActionMock} secondary>
-              Ok, got it
+              Ok, got it!
             </Button>
           </Drawer.Footer>
         </Drawer>
       </ThemeProvider>,
     );
 
-    screen.getByText('Title');
-    screen.getByText('Subtitle');
+    const title = screen.getByText('Title');
+    const subtitle = screen.getByText('Subtitle');
 
-    await userEvent
-      .setup()
-      .click(screen.getByRole('button', { name: /Ok, got it/i }));
+    const button = screen.getByRole('button', { name: /Ok, got it!/i });
 
-    expect(onActionMock).toHaveBeenCalledTimes(1);
+    await userEvent.setup().click(button);
+
+    expect(title).toBeVisible();
+    expect(subtitle).toBeVisible();
+    expect(onActionMock).toBeCalledTimes(1);
   });
 
   describe('<Drawer.Header />', () => {
     afterEach(cleanup);
 
     it('should render close bottom', () => {
+      const onCloseActionMock = jest.fn();
+
       render(
         <ThemeProvider>
           <Drawer isOpen>
-            <Drawer.Header title="Title" onClose={onActionMock} />
+            <Drawer.Header title="Title" onClose={onCloseActionMock} />
           </Drawer>
         </ThemeProvider>,
       );
 
-      expect(screen.getByTestId('close-button-drawer')).toBeInTheDocument();
+      const closeButton = screen.getByRole('button', {
+        name: 'close-button-drawer',
+      });
+
+      expect(closeButton).toBeVisible();
     });
 
     it('should render back bottom', () => {
+      const backHandleActionMock = jest.fn();
+
       render(
         <ThemeProvider>
           <Drawer isOpen>
-            <Drawer.Header title="Title" onBack={onActionMock} />
+            <Drawer.Header title="Title" backHandler={backHandleActionMock} />
           </Drawer>
         </ThemeProvider>,
       );
 
-      expect(screen.getByTestId('back-button-drawer')).toBeInTheDocument();
+      const backButton = screen.getByRole('button', {
+        name: 'back-button-drawer',
+      });
+
+      expect(backButton).toBeVisible();
     });
 
     it('should render close and back bottons', () => {
+      const onCloseActionMock = jest.fn();
+      const backHandleActionMock = jest.fn();
+
       render(
         <ThemeProvider>
           <Drawer isOpen>
             <Drawer.Header
               title="Title"
-              onClose={onActionMock}
-              onBack={onActionMock}
+              onClose={onCloseActionMock}
+              backHandler={backHandleActionMock}
             />
           </Drawer>
         </ThemeProvider>,
       );
 
-      expect(screen.getByTestId('back-button-drawer')).toBeInTheDocument();
+      const backButton = screen.getByRole('button', {
+        name: 'back-button-drawer',
+      });
+      const closeButton = screen.getByRole('button', {
+        name: 'close-button-drawer',
+      });
+
+      expect(backButton).toBeVisible();
+      expect(closeButton).toBeVisible();
     });
 
     it('should render divider component', () => {
@@ -103,61 +129,108 @@ describe('<Drawer />', () => {
         </ThemeProvider>,
       );
 
-      expect(screen.getByTestId('divider-drawer')).toBeInTheDocument();
+      const divider = screen.getByRole('separator', { name: 'divider-drawer' });
+
+      expect(divider).toBeInTheDocument();
     });
 
     it('should render drawer without drawer.header', async () => {
+      const onButtonActionMock = jest.fn();
+
       render(
         <ThemeProvider>
           <Drawer isOpen>
             <Drawer.Content>Subtitle</Drawer.Content>
             <Drawer.Footer>
-              <Button onClick={onActionMock} secondary>
-                Ok, got it
+              <Button onClick={onButtonActionMock} secondary>
+                Ok, got it!
               </Button>
             </Drawer.Footer>
           </Drawer>
         </ThemeProvider>,
       );
 
+      const headerDrawer = screen.queryByRole('heading', {
+        name: 'header-drawer',
+      });
+
+      const subtitle = screen.getByText('Subtitle');
+
       await userEvent
         .setup()
-        .click(screen.getByRole('button', { name: /Ok, got it/i }));
+        .click(screen.getByRole('button', { name: /Ok, got it!/i }));
 
-      expect(screen.getByText('Subtitle')).toBeInTheDocument();
-      expect(onActionMock).toHaveBeenCalledTimes(2);
+      expect(onButtonActionMock).toBeCalledTimes(1);
+
+      expect(headerDrawer).not.toBeInTheDocument();
+      expect(subtitle).toBeVisible();
     });
 
-    it('should render all props', async () => {
+    it('should render onClose, backHandler and divider', async () => {
+      const onCloseActionMock = jest.fn();
+      const backHandleActionMock = jest.fn();
+
       render(
         <ThemeProvider>
           <Drawer isOpen>
             <Drawer.Header
               title="Title"
-              onClose={onActionMock}
-              onBack={onActionMock}
+              onClose={onCloseActionMock}
+              backHandler={backHandleActionMock}
               divider
             />
-            <Drawer.Content>Subtitle</Drawer.Content>
-            <Drawer.Footer>
-              <Button onClick={onActionMock} secondary>
-                Ok, got it
-              </Button>
-            </Drawer.Footer>
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      const closeButton = screen.getByRole('button', {
+        name: 'close-button-drawer',
+      });
+      const backButton = screen.getByRole('button', {
+        name: 'back-button-drawer',
+      });
+
+      const divider = screen.getByRole('separator', { name: 'divider-drawer' });
+
+      expect(closeButton).toBeVisible();
+      expect(backButton).toBeVisible();
+      expect(divider).toBeVisible();
+    });
+
+    it('should call onClose function', async () => {
+      const onCloseActionMock = jest.fn();
+
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Header title="Title" onClose={onCloseActionMock} />
           </Drawer>
         </ThemeProvider>,
       );
 
       await userEvent
         .setup()
-        .click(screen.getByRole('button', { name: /Ok, got it/i }));
+        .click(screen.getByRole('button', { name: 'close-button-drawer' }));
 
-      expect(onActionMock).toHaveBeenCalledTimes(3);
-      expect(screen.getByText('Title')).toBeInTheDocument();
-      expect(screen.getByText('Subtitle')).toBeInTheDocument();
-      expect(screen.getByTestId('close-button-drawer')).toBeInTheDocument();
-      expect(screen.getByTestId('divider-drawer')).toBeInTheDocument();
-      expect(screen.getByTestId('back-button-drawer')).toBeInTheDocument();
+      expect(onCloseActionMock).toBeCalledTimes(1);
+    });
+
+    it('should call backHandler function', async () => {
+      const backHandleActionMock = jest.fn();
+
+      render(
+        <ThemeProvider>
+          <Drawer isOpen>
+            <Drawer.Header title="Title" backHandler={backHandleActionMock} />
+          </Drawer>
+        </ThemeProvider>,
+      );
+
+      await userEvent
+        .setup()
+        .click(screen.getByRole('button', { name: 'back-button-drawer' }));
+
+      expect(backHandleActionMock).toBeCalledTimes(1);
     });
   });
 });

--- a/packages/yoga/src/Drawer/web/Drawer.test.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { screen, render, fireEvent, cleanup } from '@testing-library/react';
+import { screen, render, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ThemeProvider, Button } from '../..';
 
@@ -24,13 +25,13 @@ describe('<Drawer />', () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  it('should render a minimal drawer', () => {
+  it('should render a minimal drawer', async () => {
     const onActionMock = jest.fn();
 
     render(
       <ThemeProvider>
         <Drawer isOpen>
-          <Drawer.Header>Title</Drawer.Header>
+          <Drawer.Header title="Title" />
           <Drawer.Content>Subtitle</Drawer.Content>
           <Drawer.Footer>
             <Button onClick={onActionMock} secondary>
@@ -44,9 +45,9 @@ describe('<Drawer />', () => {
     screen.getByText('Title');
     screen.getByText('Subtitle');
 
-    const button = screen.getByRole('button', { name: /Ok, got it/i });
-
-    fireEvent.click(button);
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: /Ok, got it/i }));
 
     expect(onActionMock).toHaveBeenCalledTimes(1);
   });

--- a/packages/yoga/src/Drawer/web/Footer.jsx
+++ b/packages/yoga/src/Drawer/web/Footer.jsx
@@ -3,7 +3,18 @@ import React from 'react';
 import Box from '../../Box';
 
 function Footer(props) {
-  return <Box as="footer" width="100%" d="flex" {...props} />;
+  return (
+    <Box
+      as="footer"
+      width="100%"
+      d="flex"
+      paddingTop="small"
+      paddingRight="small"
+      paddingBottom="xxlarge"
+      paddingLeft="xxlarge"
+      {...props}
+    />
+  );
 }
 
 Footer.displayName = 'Drawer.Footer';

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -137,6 +137,7 @@ Header.defaultProps = {
   divider: false,
   hideCloseButton: false,
 };
+
 Header.displayName = 'Drawer.Header';
 
 export default Header;

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -4,14 +4,14 @@ import { Close, ArrowLeft } from '@gympass/yoga-icons';
 import Box from '../../Box';
 import { Button, Text, Divider, Row, Col } from '../..';
 
-function Header({ onClose, title, onBack, divider, hideCloseButton }) {
+function Header({ onClose, title, backHandler, divider, hideCloseButton }) {
   const showCloseButton = onClose && !hideCloseButton;
 
   function showDivider() {
     if (divider) {
       return (
         <Box marginTop="small">
-          <Divider data-testid="divider-drawer" />
+          <Divider aria-label="divider-drawer" />
         </Box>
       );
     }
@@ -26,7 +26,7 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
           icon={Close}
           inverted
           onClick={onClose}
-          data-testid="close-button-drawer"
+          aria-label="close-button-drawer"
         />
       );
     }
@@ -35,7 +35,7 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
   }
 
   function headerContent() {
-    if (title && onBack) {
+    if (title && backHandler) {
       return (
         <Row>
           <Col xxs={4}>
@@ -49,8 +49,8 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
               <Button.Icon
                 icon={ArrowLeft}
                 inverted
-                onClick={onBack}
-                data-testid="back-button-drawer"
+                onClick={backHandler}
+                aria-label="back-button-drawer"
               />
             </Box>
           </Col>
@@ -84,7 +84,7 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
       );
     }
 
-    if (title && !onBack) {
+    if (title && !backHandler) {
       return (
         <Box
           display="flex"
@@ -101,7 +101,7 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
       );
     }
 
-    if (!title && !onBack) {
+    if (!title && !backHandler) {
       return (
         <Box d="flex" justifyContent="flex-end" w="100%">
           {closeButton()}
@@ -112,7 +112,7 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
   }
 
   return (
-    <Box as="header" width="100%">
+    <Box as="header" role="heading" aria-label="header-drawer" width="100%">
       <Box paddingTop="small" paddingRight="small" paddingLeft="xxlarge">
         {headerContent()}
       </Box>
@@ -125,7 +125,7 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
 Header.propTypes = {
   onClose: func,
   title: string,
-  onBack: func,
+  backHandler: func,
   divider: bool,
   hideCloseButton: bool,
 };
@@ -133,7 +133,7 @@ Header.propTypes = {
 Header.defaultProps = {
   onClose: undefined,
   title: undefined,
-  onBack: undefined,
+  backHandler: undefined,
   divider: false,
   hideCloseButton: false,
 };

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -7,7 +7,14 @@ import { Divider, Heading } from '../..';
 function Header({ onClose, title, backHandler, divider, hideCloseButton }) {
   function showCloseButton() {
     if (onClose && !hideCloseButton) {
-      return <Heading.RightButton onClick={onClose} icon={Close} large />;
+      return (
+        <Heading.RightButton
+          aria-label="close-button-drawer"
+          onClick={onClose}
+          icon={Close}
+          large
+        />
+      );
     }
 
     return null;
@@ -20,7 +27,7 @@ function Header({ onClose, title, backHandler, divider, hideCloseButton }) {
           style={{
             letterSpacing: '1px',
             textTransform: 'uppercase',
-            fontSize: '12px', // xsmall
+            fontSize: '12px',
           }}
         >
           {title}
@@ -33,7 +40,12 @@ function Header({ onClose, title, backHandler, divider, hideCloseButton }) {
 
   function showBackButton() {
     if (backHandler) {
-      return <Heading.BackButton onClick={backHandler} />;
+      return (
+        <Heading.BackButton
+          aria-label="back-button-drawer"
+          onClick={backHandler}
+        />
+      );
     }
 
     return null;

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -11,7 +11,7 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
     if (divider) {
       return (
         <Box marginTop="small">
-          <Divider />
+          <Divider data-testid="divider-drawer" />
         </Box>
       );
     }
@@ -21,7 +21,14 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
 
   function closeButton() {
     if (showCloseButton) {
-      return <Button.Icon icon={Close} inverted onClick={onClose} />;
+      return (
+        <Button.Icon
+          icon={Close}
+          inverted
+          onClick={onClose}
+          data-testid="close-button-drawer"
+        />
+      );
     }
 
     return null;
@@ -39,7 +46,12 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
               width="100%"
               height="100%"
             >
-              <Button.Icon icon={ArrowLeft} inverted onClick={onBack} />
+              <Button.Icon
+                icon={ArrowLeft}
+                inverted
+                onClick={onBack}
+                data-testid="back-button-drawer"
+              />
             </Box>
           </Col>
 

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -1,11 +1,43 @@
 import React from 'react';
 import { bool, string, func } from 'prop-types';
-import { Close, ArrowLeft } from '@gympass/yoga-icons';
+import { Close } from '@gympass/yoga-icons';
 import Box from '../../Box';
-import { Button, Text, Divider, Row, Col } from '../..';
+import { Divider, Heading } from '../..';
 
 function Header({ onClose, title, backHandler, divider, hideCloseButton }) {
-  const showCloseButton = onClose && !hideCloseButton;
+  function showCloseButton() {
+    if (onClose && !hideCloseButton) {
+      return <Heading.RightButton onClick={onClose} icon={Close} large />;
+    }
+
+    return null;
+  }
+
+  function showTitle() {
+    if (title) {
+      return (
+        <Heading.Title
+          style={{
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            fontSize: '12px', // xsmall
+          }}
+        >
+          {title}
+        </Heading.Title>
+      );
+    }
+
+    return null;
+  }
+
+  function showBackButton() {
+    if (backHandler) {
+      return <Heading.BackButton onClick={backHandler} />;
+    }
+
+    return null;
+  }
 
   function showDivider() {
     if (divider) {
@@ -19,102 +51,16 @@ function Header({ onClose, title, backHandler, divider, hideCloseButton }) {
     return null;
   }
 
-  function closeButton() {
-    if (showCloseButton) {
-      return (
-        <Button.Icon
-          icon={Close}
-          inverted
-          onClick={onClose}
-          aria-label="close-button-drawer"
-        />
-      );
-    }
-
-    return null;
-  }
-
-  function headerContent() {
-    if (title && backHandler) {
-      return (
-        <Row>
-          <Col xxs={4}>
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="start"
-              width="100%"
-              height="100%"
-            >
-              <Button.Icon
-                icon={ArrowLeft}
-                inverted
-                onClick={backHandler}
-                aria-label="back-button-drawer"
-              />
-            </Box>
-          </Col>
-
-          <Col xxs={4}>
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              width="100%"
-              height="100%"
-            >
-              <Text textTransform="uppercase" fontSize="xsmall">
-                {title}
-              </Text>
-            </Box>
-          </Col>
-
-          <Col xxs={4}>
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="end"
-              width="100%"
-              height="100%"
-            >
-              {closeButton()}
-            </Box>
-          </Col>
-        </Row>
-      );
-    }
-
-    if (title && !backHandler) {
-      return (
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="center"
-          width="100%"
-        >
-          <Text textTransform="uppercase" fontSize="xsmall">
-            {title}
-          </Text>
-
-          {closeButton()}
-        </Box>
-      );
-    }
-
-    if (!title && !backHandler) {
-      return (
-        <Box d="flex" justifyContent="flex-end" w="100%">
-          {closeButton()}
-        </Box>
-      );
-    }
-    return null;
-  }
-
   return (
-    <Box as="header" role="heading" aria-label="header-drawer" width="100%">
+    <Box width="100%">
       <Box paddingTop="small" paddingRight="small" paddingLeft="xxlarge">
-        {headerContent()}
+        <Heading noPadding role="heading" aria-label="header-drawer">
+          {showBackButton()}
+
+          {showTitle()}
+
+          {showCloseButton()}
+        </Heading>
       </Box>
 
       {showDivider()}

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -4,7 +4,7 @@ import { Close, ArrowLeft } from '@gympass/yoga-icons';
 import Box from '../../Box';
 import { Button, Text, Divider, Row, Col } from '../..';
 
-function Header({ divider, title, onBack, onClose, hideCloseButton }) {
+function Header({ onClose, title, onBack, divider, hideCloseButton }) {
   const showCloseButton = onClose && !hideCloseButton;
 
   function showDivider() {
@@ -107,18 +107,18 @@ function Header({ divider, title, onBack, onClose, hideCloseButton }) {
 }
 
 Header.propTypes = {
-  divider: bool,
-  title: string,
   onClose: func,
+  title: string,
   onBack: func,
+  divider: bool,
   hideCloseButton: bool,
 };
 
 Header.defaultProps = {
-  divider: false,
-  title: undefined,
   onClose: undefined,
+  title: undefined,
   onBack: undefined,
+  divider: false,
   hideCloseButton: false,
 };
 Header.displayName = 'Drawer.Header';

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -9,7 +9,11 @@ function Header({ onClose, title, onBack, divider, hideCloseButton }) {
 
   function showDivider() {
     if (divider) {
-      return <Divider />;
+      return (
+        <Box marginTop="small">
+          <Divider />
+        </Box>
+      );
     }
 
     return null;

--- a/packages/yoga/src/Drawer/web/Header.jsx
+++ b/packages/yoga/src/Drawer/web/Header.jsx
@@ -1,10 +1,126 @@
 import React from 'react';
+import { bool, string, func } from 'prop-types';
+import { Close, ArrowLeft } from '@gympass/yoga-icons';
 import Box from '../../Box';
+import { Button, Text, Divider, Row, Col } from '../..';
 
-const Header = props => (
-  <Box as="header" width="100%" color="text.primary" {...props} />
-);
+function Header({ divider, title, onBack, onClose, hideCloseButton }) {
+  const showCloseButton = onClose && !hideCloseButton;
 
+  function showDivider() {
+    if (divider) {
+      return <Divider />;
+    }
+
+    return null;
+  }
+
+  function closeButton() {
+    if (showCloseButton) {
+      return <Button.Icon icon={Close} inverted onClick={onClose} />;
+    }
+
+    return null;
+  }
+
+  function headerContent() {
+    if (title && onBack) {
+      return (
+        <Row>
+          <Col xxs={4}>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="start"
+              width="100%"
+              height="100%"
+            >
+              <Button.Icon icon={ArrowLeft} inverted onClick={onBack} />
+            </Box>
+          </Col>
+
+          <Col xxs={4}>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              width="100%"
+              height="100%"
+            >
+              <Text textTransform="uppercase" fontSize="xsmall">
+                {title}
+              </Text>
+            </Box>
+          </Col>
+
+          <Col xxs={4}>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="end"
+              width="100%"
+              height="100%"
+            >
+              {closeButton()}
+            </Box>
+          </Col>
+        </Row>
+      );
+    }
+
+    if (title && !onBack) {
+      return (
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          width="100%"
+        >
+          <Text textTransform="uppercase" fontSize="xsmall">
+            {title}
+          </Text>
+
+          {closeButton()}
+        </Box>
+      );
+    }
+
+    if (!title && !onBack) {
+      return (
+        <Box d="flex" justifyContent="flex-end" w="100%">
+          {closeButton()}
+        </Box>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <Box as="header" width="100%">
+      <Box paddingTop="small" paddingRight="small" paddingLeft="xxlarge">
+        {headerContent()}
+      </Box>
+
+      {showDivider()}
+    </Box>
+  );
+}
+
+Header.propTypes = {
+  divider: bool,
+  title: string,
+  onClose: func,
+  onBack: func,
+  hideCloseButton: bool,
+};
+
+Header.defaultProps = {
+  divider: false,
+  title: undefined,
+  onClose: undefined,
+  onBack: undefined,
+  hideCloseButton: false,
+};
 Header.displayName = 'Drawer.Header';
 
 export default Header;

--- a/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
+++ b/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
@@ -212,7 +212,9 @@ exports[`<Drawer /> should match snapshot 1`] = `
           class="c1 c2 c3"
         >
           <header
+            aria-label="header-drawer"
             class="c4"
+            role="heading"
             width="100%"
           >
             <div
@@ -246,7 +248,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
             <button
               class="c11"
             >
-              Ok, got it
+              Ok, got it!
             </button>
           </footer>
         </section>

--- a/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
+++ b/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
@@ -175,8 +175,8 @@ exports[`<Drawer /> should match snapshot 1`] = `
   -ms-flex-item-align: end;
   align-self: flex-end;
   height: 100%;
-  padding: 0;
-  border-radius: 0;
+  padding: 0 !important;
+  border-radius: 0 !important;
   -webkit-transition: 0.25s ease-in-out;
   transition: 0.25s ease-in-out;
   -webkit-animation: content;

--- a/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
+++ b/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Drawer /> should match snapshot 1`] = `
-.c8 {
+.c10 {
   box-sizing: border-box;
   text-align: center;
   outline: none;
@@ -40,7 +40,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
   text-decoration: none;
 }
 
-.c8 svg {
+.c10 svg {
   width: 24px;
   height: 24px;
   fill: #FFFFFF;
@@ -49,26 +49,43 @@ exports[`<Drawer /> should match snapshot 1`] = `
   transition: fill 0.2s;
 }
 
-.c8:not([disabled]):hover,
-.c8:not([disabled]):focus {
+.c10:not([disabled]):hover,
+.c10:not([disabled]):focus {
   box-shadow: 0 4px 8px rgba(35,27,34,0.45);
 }
 
-.c8:active {
+.c10:active {
   background-color: rgba(35,27,34,0.75);
   color: #FFFFFF;
 }
 
-.c8:active svg {
+.c10:active svg {
   fill: #FFFFFF;
 }
 
 .c4 {
   width: 100%;
-  color: #231B22;
 }
 
 .c5 {
+  padding-top: 16px;
+  padding-right: 16px;
+  padding-left: 40px;
+}
+
+.c6 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c7 {
   margin-bottom: 32px;
   color: #6B6B78;
   font-size: 16px;
@@ -76,7 +93,11 @@ exports[`<Drawer /> should match snapshot 1`] = `
   text-align: center;
 }
 
-.c7 {
+.c9 {
+  padding-top: 16px;
+  padding-right: 16px;
+  padding-bottom: 40px;
+  padding-left: 40px;
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -132,32 +153,33 @@ exports[`<Drawer /> should match snapshot 1`] = `
 }
 
 .c3 {
-  padding: 16px 56px 40px 56px;
-  width: min(600px,100%);
-  border-radius: 0!important;
-  height: 100%;
+  position: absolute;
+  right: 0;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
-  position: absolute;
-  right: 0;
+  height: 100%;
+  padding: 0;
+  border-radius: 0;
+  -webkit-transition: 0.25s ease-in-out;
+  transition: 0.25s ease-in-out;
   -webkit-animation: content;
   animation: content;
   -webkit-animation-duration: 400ms;
   animation-duration: 400ms;
   -webkit-animation-fill-mode: forwards;
   animation-fill-mode: forwards;
-  -webkit-transition: 0.25s ease-in-out;
-  transition: 0.25s ease-in-out;
+  width: min(600px,100%);
 }
 
-.c6 {
-  margin: 0;
-  height: 100%;
+.c8 {
   width: 100%;
+  height: 100%;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
+  margin: 0;
+  padding-left: 40px;
   text-align: left;
 }
 
@@ -175,24 +197,30 @@ exports[`<Drawer /> should match snapshot 1`] = `
         >
           <header
             class="c4"
-            color="text.primary"
             width="100%"
           >
-            Title
+            <div
+              class="c5"
+            >
+              <div
+                class="c6"
+                d="flex"
+              />
+            </div>
           </header>
           <div
-            class="c5 c6"
+            class="c7 c8"
             color="text.secondary"
           >
             Subtitle
           </div>
           <footer
-            class="c7"
+            class="c9"
             d="flex"
             width="100%"
           >
             <button
-              class="c8"
+              class="c10"
             >
               Ok, got it
             </button>

--- a/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
+++ b/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Drawer /> should match snapshot 1`] = `
-.c10 {
+.c11 {
   box-sizing: border-box;
   text-align: center;
   outline: none;
@@ -40,7 +40,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
   text-decoration: none;
 }
 
-.c10 svg {
+.c11 svg {
   width: 24px;
   height: 24px;
   fill: #FFFFFF;
@@ -49,17 +49,17 @@ exports[`<Drawer /> should match snapshot 1`] = `
   transition: fill 0.2s;
 }
 
-.c10:not([disabled]):hover,
-.c10:not([disabled]):focus {
+.c11:not([disabled]):hover,
+.c11:not([disabled]):focus {
   box-shadow: 0 4px 8px rgba(35,27,34,0.45);
 }
 
-.c10:active {
+.c11:active {
   background-color: rgba(35,27,34,0.75);
   color: #FFFFFF;
 }
 
-.c10:active svg {
+.c11:active svg {
   fill: #FFFFFF;
 }
 
@@ -79,13 +79,17 @@ exports[`<Drawer /> should match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c7 {
+.c8 {
   margin-bottom: 32px;
   color: #6B6B78;
   font-size: 16px;
@@ -93,7 +97,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
   text-align: center;
 }
 
-.c9 {
+.c10 {
   padding-top: 16px;
   padding-right: 16px;
   padding-bottom: 40px;
@@ -103,6 +107,18 @@ exports[`<Drawer /> should match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c7 {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-family: Rubik;
+  color: #231B22;
+  font-size: 12px;
+  text-transform: uppercase;
 }
 
 .c1 {
@@ -172,7 +188,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
   width: min(600px,100%);
 }
 
-.c8 {
+.c9 {
   width: 100%;
   height: 100%;
   -webkit-align-self: flex-start;
@@ -204,23 +220,31 @@ exports[`<Drawer /> should match snapshot 1`] = `
             >
               <div
                 class="c6"
-                d="flex"
-              />
+                display="flex"
+                width="100%"
+              >
+                <p
+                  class="c7"
+                  font-size="xsmall"
+                >
+                  Title
+                </p>
+              </div>
             </div>
           </header>
           <div
-            class="c7 c8"
+            class="c8 c9"
             color="text.secondary"
           >
             Subtitle
           </div>
           <footer
-            class="c9"
+            class="c10"
             d="flex"
             width="100%"
           >
             <button
-              class="c10"
+              class="c11"
             >
               Ok, got it
             </button>

--- a/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
+++ b/packages/yoga/src/Drawer/web/__snapshots__/Drawer.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Drawer /> should match snapshot 1`] = `
-.c11 {
+.c14 {
   box-sizing: border-box;
   text-align: center;
   outline: none;
@@ -40,7 +40,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
   text-decoration: none;
 }
 
-.c11 svg {
+.c14 svg {
   width: 24px;
   height: 24px;
   fill: #FFFFFF;
@@ -49,17 +49,17 @@ exports[`<Drawer /> should match snapshot 1`] = `
   transition: fill 0.2s;
 }
 
-.c11:not([disabled]):hover,
-.c11:not([disabled]):focus {
+.c14:not([disabled]):hover,
+.c14:not([disabled]):focus {
   box-shadow: 0 4px 8px rgba(35,27,34,0.45);
 }
 
-.c11:active {
+.c14:active {
   background-color: rgba(35,27,34,0.75);
   color: #FFFFFF;
 }
 
-.c11:active svg {
+.c14:active svg {
   fill: #FFFFFF;
 }
 
@@ -73,8 +73,12 @@ exports[`<Drawer /> should match snapshot 1`] = `
   padding-left: 40px;
 }
 
-.c6 {
+.c8 {
   width: 100%;
+  text-align: center;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -83,13 +87,9 @@ exports[`<Drawer /> should match snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
 }
 
-.c8 {
+.c11 {
   margin-bottom: 32px;
   color: #6B6B78;
   font-size: 16px;
@@ -97,7 +97,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
   text-align: center;
 }
 
-.c10 {
+.c13 {
   padding-top: 16px;
   padding-right: 16px;
   padding-bottom: 40px;
@@ -109,16 +109,14 @@ exports[`<Drawer /> should match snapshot 1`] = `
   display: flex;
 }
 
-.c7 {
+.c9 {
   margin: 0;
   padding: 0;
   font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
+  font-weight: 500;
   font-family: Rubik;
   color: #231B22;
-  font-size: 12px;
-  text-transform: uppercase;
+  font-size: 14px;
 }
 
 .c1 {
@@ -168,6 +166,31 @@ exports[`<Drawer /> should match snapshot 1`] = `
   background-color: rgba(35,27,34,0.48);
 }
 
+.c6 {
+  background: #FFFFFF;
+  padding: 16px 20px;
+  width: 100%;
+  min-height: 56px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+}
+
+.c7 {
+  width: 24px;
+  height: 24px;
+}
+
 .c3 {
   position: absolute;
   right: 0;
@@ -188,7 +211,7 @@ exports[`<Drawer /> should match snapshot 1`] = `
   width: min(600px,100%);
 }
 
-.c9 {
+.c12 {
   width: 100%;
   height: 100%;
   -webkit-align-self: flex-start;
@@ -211,42 +234,56 @@ exports[`<Drawer /> should match snapshot 1`] = `
         <section
           class="c1 c2 c3"
         >
-          <header
-            aria-label="header-drawer"
+          <div
             class="c4"
-            role="heading"
             width="100%"
           >
             <div
               class="c5"
             >
-              <div
+              <header
+                aria-label="header-drawer"
                 class="c6"
-                display="flex"
-                width="100%"
+                role="heading"
               >
-                <p
+                <div
                   class="c7"
-                  font-size="xsmall"
+                />
+                <div
+                  class="c8"
                 >
-                  Title
-                </p>
-              </div>
+                  <h1
+                    class="c9"
+                    font-size="small"
+                    style="letter-spacing: 1px; text-transform: uppercase; font-size: 12px;"
+                  >
+                    Title
+                  </h1>
+                </div>
+                <div
+                  class="c10"
+                  display="flex"
+                >
+                  <div
+                    class="c7"
+                  />
+                </div>
+              </header>
             </div>
-          </header>
+          </div>
           <div
-            class="c8 c9"
+            class="c11 c12"
             color="text.secondary"
           >
             Subtitle
           </div>
           <footer
-            class="c10"
+            class="c13"
             d="flex"
             width="100%"
           >
             <button
-              class="c11"
+              class="c14"
             >
               Ok, got it!
             </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,11 +5317,6 @@ array-flatten@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
-array-flatten@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.us.gympass.cloud/repository/npm-group/array-flatten/-/array-flatten-3.0.0.tgz#6428ca2ee52c7b823192ec600fa3ed2f157cd541"
-  integrity sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==
-
 array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
@@ -8287,13 +8282,6 @@ decompress-response@^5.0.0:
   integrity sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==
   dependencies:
     mimic-response "^2.0.0"
-
-decompress-response@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.us.gympass.cloud/repository/npm-group/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
-  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
-  dependencies:
-    mimic-response "^3.1.0"
 
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
@@ -16177,11 +16165,6 @@ mimic-response@^2.0.0, mimic-response@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
-mimic-response@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.us.gympass.cloud/repository/npm-group/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
-  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
-
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -16946,7 +16929,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1, npmlog@^4.1.2:
+npmlog@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -20383,19 +20366,17 @@ shallowequal@^1.0.1, shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-sharp@^0.27.0:
-  version "0.27.2"
-  resolved "https://registry.us.gympass.cloud/repository/npm-group/sharp/-/sharp-0.27.2.tgz#a939775e630e88600c0b5e68f20593aea722252f"
-  integrity sha512-w3FVoONPG/x5MXCc3wsjOS+b9h3CI60qkus6EPQU4dkT0BDm0PyGhDCK6KhtfT3/vbeOMOXAKFNSw+I3QGWkMA==
+sharp@0.28.0, sharp@^0.27.0:
+  version "0.28.0"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/sharp/-/sharp-0.28.0.tgz#93297cec530b3709e11677cf41565d9a654075a0"
+  integrity sha512-kGTaWLNMCkLYxkH2Pv7s+5LQBnWQ4mRKXs1XD19AWOxShWvU8b78qaWqTR/4ryNcPORO+qBoBnFF/Lzda5HgkQ==
   dependencies:
-    array-flatten "^3.0.0"
     color "^3.1.3"
     detect-libc "^1.0.3"
     node-addon-api "^3.1.0"
-    npmlog "^4.1.2"
     prebuild-install "^6.0.1"
-    semver "^7.3.4"
-    simple-get "^4.0.0"
+    semver "^7.3.5"
+    simple-get "^3.1.0"
     tar-fs "^2.1.1"
     tunnel-agent "^0.6.0"
 
@@ -20462,21 +20443,12 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
-simple-get@^3.0.3:
+simple-get@^3.0.3, simple-get@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
   integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
   dependencies:
     decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
-
-simple-get@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.us.gympass.cloud/repository/npm-group/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
-  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
-  dependencies:
-    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4070,6 +4070,20 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
+"@testing-library/dom@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/@testing-library/dom/-/dom-9.2.0.tgz#0e1f45e956f2a16f471559c06edd8827c4832f04"
+  integrity sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^5.16.4":
   version "5.16.4"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz#938302d7b8b483963a3ae821f1c0808f872245cd"
@@ -4112,6 +4126,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
+
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -4176,6 +4195,11 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
   integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
+  integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -5292,6 +5316,11 @@ array-flatten@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
+
+array-flatten@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/array-flatten/-/array-flatten-3.0.0.tgz#6428ca2ee52c7b823192ec600fa3ed2f157cd541"
+  integrity sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -8258,6 +8287,13 @@ decompress-response@^5.0.0:
   integrity sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==
   dependencies:
     mimic-response "^2.0.0"
+
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
 
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
@@ -15079,6 +15115,11 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.25.0, magic-string@^0.25.1:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -16136,6 +16177,11 @@ mimic-response@^2.0.0, mimic-response@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -16900,7 +16946,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -20337,17 +20383,19 @@ shallowequal@^1.0.1, shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-sharp@0.28.0, sharp@^0.27.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.28.0.tgz#93297cec530b3709e11677cf41565d9a654075a0"
-  integrity sha512-kGTaWLNMCkLYxkH2Pv7s+5LQBnWQ4mRKXs1XD19AWOxShWvU8b78qaWqTR/4ryNcPORO+qBoBnFF/Lzda5HgkQ==
+sharp@^0.27.0:
+  version "0.27.2"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/sharp/-/sharp-0.27.2.tgz#a939775e630e88600c0b5e68f20593aea722252f"
+  integrity sha512-w3FVoONPG/x5MXCc3wsjOS+b9h3CI60qkus6EPQU4dkT0BDm0PyGhDCK6KhtfT3/vbeOMOXAKFNSw+I3QGWkMA==
   dependencies:
+    array-flatten "^3.0.0"
     color "^3.1.3"
     detect-libc "^1.0.3"
     node-addon-api "^3.1.0"
+    npmlog "^4.1.2"
     prebuild-install "^6.0.1"
-    semver "^7.3.5"
-    simple-get "^3.1.0"
+    semver "^7.3.4"
+    simple-get "^4.0.0"
     tar-fs "^2.1.1"
     tunnel-agent "^0.6.0"
 
@@ -20414,12 +20462,21 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
-simple-get@^3.0.3, simple-get@^3.1.0:
+simple-get@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
   integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
   dependencies:
     decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.us.gympass.cloud/repository/npm-group/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR I'm refactoring the drawer and adding some new props.

I realized that the Drawer receives the body of the Dialog as a base, but I needed to add some props to the `<Drawer.Header>`, so I thought about refactoring the `<Dialog.Header>` by changing a little how it works. This change also affected the `<BottomSheet.Header>`.

The `<Drawer.Header>` now has the option to `onClose`, `backHandler` and `title`.

`onClose` and `backHandler` are very similar, they receive a function, but each with its own icon:

`onClose` -> Close icon,
`backHandler` -> ArrowLeft icon,
`title` -> string

To use `<Drawer.Header>` just use its props.

This PR will trigger a  _**breaking change**_ <---
Need to adjust components that are using <Dialog.Header> and <BottomSheet.Header>


Obs: 

Added `@testing-library/user-event` and `@testing-library/dom` package to perform click actions on tests with `userEvent` as recommended by [testing library doc](https://testing-library.com/docs/user-event/intro/)

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [x] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

| Before | After |
| ------ | ----- |
|<img width="1440" alt="Screenshot 2023-04-06 at 15 53 52" src="https://user-images.githubusercontent.com/32910717/230469518-5040a5fe-7e63-4518-b91a-376bd5a976d7.png">|<img width="1440" alt="Screenshot 2023-04-06 at 15 54 10" src="https://user-images.githubusercontent.com/32910717/230469631-d0a61e6b-2aba-461a-a2e0-32c47afa2feb.png">|

### With back button

<img width="300" alt="Screenshot 2023-04-06 at 15 55 43" src="https://user-images.githubusercontent.com/32910717/230469861-ff751098-84d3-4e7d-a565-358e53a09c41.png">

### With divider on header

<img width="300" alt="Screenshot 2023-04-06 at 15 57 25" src="https://user-images.githubusercontent.com/32910717/230470203-7b66b473-e81b-4b61-9cc3-eaa5bf2104c5.png">

### With no close button

<img width="300" alt="Screenshot 2023-04-06 at 15 57 56" src="https://user-images.githubusercontent.com/32910717/230470304-3670c81d-9408-4e53-b03f-0d68b94fc4df.png">

### With no header

<img width="600" alt="Screenshot 2023-04-06 at 16 00 09" src="https://user-images.githubusercontent.com/32910717/230470847-0c87bd1b-fe64-4864-a303-86ee97d7237f.png">

