### PR TITLE
🚀 feat(Dialog): add forwardRef and custom id to dialog

### DIFF
--- a/packages/doc/content/components/components/dialog/index.mdx
+++ b/packages/doc/content/components/components/dialog/index.mdx
@@ -39,7 +39,7 @@ render(() => {
 
       <Dialog
         isOpen={isOpen}
-      >       
+      >
        <Dialog.Header>
         We couldn't confirm your eligibility
        </Dialog.Header>
@@ -75,9 +75,9 @@ render(() => {
 
       <Dialog
         isOpen={isOpen}
-      >       
+      >
        <Dialog.Header>
-        Are you sure you want to downgrade to a Platinum plan? 
+        Are you sure you want to downgrade to a Platinum plan?
        </Dialog.Header>
        <Dialog.Content>
         Double check your info and company selection. If it still doesn’t work, contact your HR team.
@@ -113,7 +113,7 @@ render(() => {
       <Dialog
         isOpen={isOpen}
         onClose={handleOnClose}
-      >       
+      >
        <Dialog.Header>
         Are you sure you want to downgrade to a Platinum plan?
        </Dialog.Header>
@@ -150,13 +150,104 @@ render(() => {
 
       <Dialog
         isOpen={isOpen}
-      >       
+      >
        <Dialog.Header>
         Are you sure you want to downgrade to a Platinum plan?
        </Dialog.Header>
        <Dialog.Footer>
           <Button>Yes, downgrade</Button>
           <Button.Text onClick={handleOnClose}>Cancel</Button.Text>
+       </Dialog.Footer>
+      </Dialog>
+    </>
+  );
+});
+```
+
+### Dialog with custom ref
+
+```javascript state
+const { useRef, useEffect } = React;
+
+render(() => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dialogRef = useRef(null);
+  const buttonRef = useRef(null);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleOnClose = () => {
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if(isOpen && dialogRef.current && buttonRef.current) {
+      buttonRef.current.focus();
+    }
+  },[dialogRef, buttonRef, isOpen]);
+
+  return (
+    <>
+      <Button onClick={handleOpen} secondary>Dialog with custom ref</Button>
+
+      <Dialog
+        isOpen={isOpen}
+        ref={dialogRef}
+      >
+       <Dialog.Header>
+        I am an example on how a custom ref option can be used
+       </Dialog.Header>
+       <Dialog.Footer>
+          <Button ref={buttonRef}>I am auto focused</Button>
+          <Button.Text onClick={handleOnClose}>Close</Button.Text>
+       </Dialog.Footer>
+      </Dialog>
+    </>
+  );
+});
+```
+
+### Dialog with custom portal ID
+
+```javascript state
+const { useRef, useEffect } = React;
+
+render(() => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isNestedOpen, setIsNestedOpen] = useState(false);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleOnClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Button onClick={handleOpen} secondary>Dialog with custom id</Button>
+
+      <Dialog isOpen={isOpen}>
+       <Dialog.Header>
+         With a custom id I can open an isolated dialog
+       </Dialog.Header>
+
+       <Dialog.Footer>
+          <Button onClick={() => setIsNestedOpen(true)}>Open second dialog</Button>
+          <Button.Text onClick={handleOnClose}>Close</Button.Text>
+       </Dialog.Footer>
+      </Dialog>
+
+      <Dialog isOpen={isNestedOpen} dialogId="nested-id">
+       <Dialog.Header>
+        I am a nested dialog
+       </Dialog.Header>
+
+       <Dialog.Footer>
+          <Button.Text onClick={() => setIsNestedOpen(false)}>Close</Button.Text>
        </Dialog.Footer>
       </Dialog>
     </>

--- a/packages/yoga/src/Dialog/web/Dialog.test.jsx
+++ b/packages/yoga/src/Dialog/web/Dialog.test.jsx
@@ -94,4 +94,21 @@ describe('<Dialog />', () => {
     );
     expect(screen.queryByRole('button')).toBeNull();
   });
+
+  it('should render content isolated by dialog id', () => {
+    render(
+      <ThemeProvider>
+        <Dialog isOpen>
+          <Dialog.Header>Title</Dialog.Header>
+        </Dialog>
+
+        <Dialog isOpen dialogId="custom-id">
+          <Dialog.Header>Second Title</Dialog.Header>
+        </Dialog>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Second Title')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/PPE-138)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR updates `Dialog` to:
- Be a [forwardRef](https://react.dev/reference/react/forwardRef) so the parent can pass a ref object and perform operations on it. One simple use case is to [move focus to the modal](https://medium.com/@islam.sayed8/trap-focus-inside-a-modal-aa5230326c1b).
- Receive a custom id, so we can have multiple dialog content mounted on the same page.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [x] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

https://user-images.githubusercontent.com/796443/233376343-ffe137b8-75d2-4cc8-aed6-33bfd068239a.mov

| Before | After |
| ------ | ----- |
|        |       |
