### PR TITLE
🚀 feat(Drawer|BottomSheet): add forwardRef to Drawer and BottomSheet

### DIFF
--- a/packages/yoga/src/BottomSheet/web/BottomSheet.jsx
+++ b/packages/yoga/src/BottomSheet/web/BottomSheet.jsx
@@ -29,7 +29,9 @@ const StyledBottomSheet = styled(Dialog)`
   }
 `;
 
-const BottomSheet = props => <StyledBottomSheet hideCloseButton {...props} />;
+const BottomSheet = React.forwardRef((props, forwardedRef) => (
+  <StyledBottomSheet hideCloseButton {...props} ref={forwardedRef} />
+));
 
 BottomSheet.propTypes = {
   children: node.isRequired,

--- a/packages/yoga/src/Drawer/web/Drawer.jsx
+++ b/packages/yoga/src/Drawer/web/Drawer.jsx
@@ -30,9 +30,9 @@ const StyledDrawer = styled(Dialog)`
   }
 `;
 
-function Drawer(props) {
-  return <StyledDrawer {...props} />;
-}
+const Drawer = React.forwardRef((props, forwardedRef) => (
+  <StyledDrawer {...props} ref={forwardedRef} />
+));
 
 Drawer.propTypes = {
   children: node.isRequired,


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/PPE-138)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

In the sequence of https://github.com/gympass/yoga/pull/651, i'm adding the `forwardRef` behaviour to `Drawer` and `BottomSheet`.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
