### PR TITLE
🚀 style(accordion): refactor disabled styles structure

### DIFF
--- a/packages/yoga/src/Accordion/web/Accordion.jsx
+++ b/packages/yoga/src/Accordion/web/Accordion.jsx
@@ -6,7 +6,7 @@ import { Text, Divider } from '@gympass/yoga';
 import Content from './Content';
 
 const AccordionWrapper = styled.div`
-  background: ${({ theme }) => theme.yoga.colors.white};
+  background-color: ${({ theme }) => theme.yoga.colors.white};
   border: none;
   display: flex;
   flex-direction: column;
@@ -24,7 +24,7 @@ const AccordionWrapper = styled.div`
   }) =>
     disabled &&
     css`
-      background: ${elements.backgroundAndDisabled};
+      background-color: ${elements.backgroundAndDisabled};
     `}
 
   hr {

--- a/packages/yoga/src/Accordion/web/Accordion.jsx
+++ b/packages/yoga/src/Accordion/web/Accordion.jsx
@@ -6,6 +6,7 @@ import { Text, Divider } from '@gympass/yoga';
 import Content from './Content';
 
 const AccordionWrapper = styled.div`
+  background: ${({ theme }) => theme.yoga.colors.white};
   border: none;
   display: flex;
   flex-direction: column;
@@ -14,17 +15,17 @@ const AccordionWrapper = styled.div`
   z-index: 1;
 
   ${({
+    disabled,
     theme: {
       yoga: {
-        colors: { white, elements },
+        colors: { elements },
       },
     },
-    disabled,
-  }) => {
-    return `
-  background: ${disabled ? elements.backgroundAndDisabled : white}
-`;
-  }}
+  }) =>
+    disabled &&
+    css`
+      background: ${elements.backgroundAndDisabled};
+    `}
 
   hr {
     bottom: 0;

--- a/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
+++ b/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`<Accordion /> should correctly render the default version 1`] = `
 }
 
 .c0 {
+  background: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -17,7 +18,6 @@ exports[`<Accordion /> should correctly render the default version 1`] = `
   position: relative;
   width: 100%;
   z-index: 1;
-  background: #FFFFFF;
 }
 
 .c0 hr {
@@ -196,6 +196,7 @@ exports[`<Accordion /> should correctly render the default version with subtitle
 }
 
 .c0 {
+  background: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -207,7 +208,6 @@ exports[`<Accordion /> should correctly render the default version with subtitle
   position: relative;
   width: 100%;
   z-index: 1;
-  background: #FFFFFF;
 }
 
 .c0 hr {
@@ -392,6 +392,7 @@ exports[`<Accordion /> should correctly render the default version without side 
 }
 
 .c0 {
+  background: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -403,7 +404,6 @@ exports[`<Accordion /> should correctly render the default version without side 
   position: relative;
   width: 100%;
   z-index: 1;
-  background: #FFFFFF;
 }
 
 .c0 hr {
@@ -591,6 +591,7 @@ exports[`<Accordion /> should correctly render the small version 1`] = `
 }
 
 .c0 {
+  background: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -602,7 +603,6 @@ exports[`<Accordion /> should correctly render the small version 1`] = `
   position: relative;
   width: 100%;
   z-index: 1;
-  background: #FFFFFF;
 }
 
 .c0 hr {
@@ -785,6 +785,7 @@ exports[`<Accordion /> should correctly render the small version with subtitle 1
 }
 
 .c0 {
+  background: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -796,7 +797,6 @@ exports[`<Accordion /> should correctly render the small version with subtitle 1
   position: relative;
   width: 100%;
   z-index: 1;
-  background: #FFFFFF;
 }
 
 .c0 hr {
@@ -981,6 +981,7 @@ exports[`<Accordion /> should correctly render the small version without side pa
 }
 
 .c0 {
+  background: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -992,7 +993,6 @@ exports[`<Accordion /> should correctly render the small version without side pa
   position: relative;
   width: 100%;
   z-index: 1;
-  background: #FFFFFF;
 }
 
 .c0 hr {

--- a/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
+++ b/packages/yoga/src/Accordion/web/__snapshots__/Accordion.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<Accordion /> should correctly render the default version 1`] = `
 }
 
 .c0 {
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -196,7 +196,7 @@ exports[`<Accordion /> should correctly render the default version with subtitle
 }
 
 .c0 {
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -392,7 +392,7 @@ exports[`<Accordion /> should correctly render the default version without side 
 }
 
 .c0 {
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -591,7 +591,7 @@ exports[`<Accordion /> should correctly render the small version 1`] = `
 }
 
 .c0 {
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -785,7 +785,7 @@ exports[`<Accordion /> should correctly render the small version with subtitle 1
 }
 
 .c0 {
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -981,7 +981,7 @@ exports[`<Accordion /> should correctly render the small version without side pa
 }
 
 .c0 {
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border: none;
   display: -webkit-box;
   display: -webkit-flex;


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

This adjustment is necessary due to the new yoga document.

### The problem:
The new document was built using docusaurus and the way this style was done, docusaurus couldn't understand because support for css-in-js is still in development, so problems like this can happen.

### The solution:
After this refactoring, returning a css, docusaurus was able to understand and render the style.

In the future we will go through each component of Yoga with the new DOC to investigate possible issues like this.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
