### PR TITLE
🚀  fix(Chips): set type in order to prevent unexpected behaviour

### DIFF
--- a/packages/yoga/src/Chips/native/Chips.jsx
+++ b/packages/yoga/src/Chips/native/Chips.jsx
@@ -81,7 +81,12 @@ const Chips = React.forwardRef(
     const [FirstIcon, SecondIcon] = icons;
 
     return (
-      <TouchableWithoutFeedback onPress={onPress} ref={ref} {...props}>
+      <TouchableWithoutFeedback
+        onPress={onPress}
+        ref={ref}
+        accessibilityRole="button"
+        {...props}
+      >
         <Wrapper disabled={disabled} selected={selected}>
           {SecondIcon && (
             <Icon

--- a/packages/yoga/src/Chips/native/__snapshots__/Chips.test.jsx.snap
+++ b/packages/yoga/src/Chips/native/__snapshots__/Chips.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
 <View
+  accessibilityRole="button"
   accessible={true}
   disabled={false}
   focusable={false}
@@ -67,6 +68,7 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
 exports[`<Chips /> Snapshots counter should match snapshot with more than one Chip 1`] = `
 Array [
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -128,6 +130,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -213,6 +216,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -303,6 +307,7 @@ Array [
 exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
 Array [
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -364,6 +369,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -425,6 +431,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -486,6 +493,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -547,6 +555,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -632,6 +641,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -717,6 +727,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -775,6 +786,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -837,6 +849,7 @@ Array [
 
 exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
 <View
+  accessibilityRole="button"
   accessible={true}
   disabled={false}
   focusable={false}
@@ -899,6 +912,7 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
 exports[`<Chips /> Snapshots selected should match snapshot with more than one Chip 1`] = `
 Array [
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -960,6 +974,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -1018,6 +1033,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -1080,6 +1096,7 @@ Array [
 
 exports[`<Chips /> Snapshots should match snapshot 1`] = `
 <View
+  accessibilityRole="button"
   accessible={true}
   disabled={false}
   focusable={false}
@@ -1144,6 +1161,7 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
 
 exports[`<Chips /> Snapshots should match snapshot with a long text 1`] = `
 <View
+  accessibilityRole="button"
   accessible={true}
   disabled={false}
   focusable={false}
@@ -1208,6 +1226,7 @@ exports[`<Chips /> Snapshots should match snapshot with a long text 1`] = `
 
 exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
 <View
+  accessibilityRole="button"
   accessible={true}
   disabled={true}
   focusable={false}
@@ -1274,6 +1293,7 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
 exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] = `
 Array [
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -1335,6 +1355,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}
@@ -1396,6 +1417,7 @@ Array [
     </Text>
   </View>,
   <View
+    accessibilityRole="button"
     accessible={true}
     disabled={false}
     focusable={false}

--- a/packages/yoga/src/Chips/web/Chips.jsx
+++ b/packages/yoga/src/Chips/web/Chips.jsx
@@ -134,6 +134,7 @@ const Chips = React.forwardRef(
         disabled={disabled}
         onClick={onClick}
         ref={ref}
+        type="button"
         {...props}
       >
         {SecondIcon && (

--- a/packages/yoga/src/Chips/web/__snapshots__/Chips.test.jsx.snap
+++ b/packages/yoga/src/Chips/web/__snapshots__/Chips.test.jsx.snap
@@ -64,6 +64,7 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
 <div>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -214,6 +215,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
 <div>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -223,6 +225,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -237,6 +240,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -392,6 +396,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
 <div>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -401,6 +406,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   </button>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -410,6 +416,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   </button>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -419,6 +426,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   </button>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -428,6 +436,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -442,6 +451,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -456,6 +466,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -465,6 +476,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -534,6 +546,7 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
 <div>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -655,6 +668,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
 <div>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -664,6 +678,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -673,6 +688,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
   </button>
   <button
     class="c2"
+    type="button"
   >
     <span
       class="c1"
@@ -747,6 +763,7 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
 <div>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -822,6 +839,7 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
   <button
     class="c0"
     disabled=""
+    type="button"
   >
     <span
       class="c1"
@@ -896,6 +914,7 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
 <div>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -905,6 +924,7 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
   </button>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"
@@ -914,6 +934,7 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
   </button>
   <button
     class="c0"
+    type="button"
   >
     <span
       class="c1"


### PR DESCRIPTION
## Description 📄

When using the Chips component, I expected the default behavior should do a normal click, but as it does not have the type declaration it was doing unexpected behavior like submitting a form as this component is a simple button, under the hood, it is expected to be `type="button"` even though is possible to override this config.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [X] Mobile

## Type of change 🔍

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
