### PR TITLE
chore: improve popover accessibility implementation

### DIFF
--- a/packages/yoga/src/Popover/web/Popover.jsx
+++ b/packages/yoga/src/Popover/web/Popover.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { node, number, oneOf, string } from 'prop-types';
 import { Text } from '@gympass/yoga';
 
-import { PopoverContainer, Wrapper } from './styles';
+import { PopoverContainer, PopoverButton, Wrapper } from './styles';
 
 function Popover({
   children,
@@ -11,26 +11,30 @@ function Popover({
   position,
   width,
   height,
+  zIndex,
+  a11yId,
   ...props
 }) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  function handleShowPopover() {
+  const handleShowPopover = () => {
     setIsPopoverOpen(true);
-  }
+  };
 
-  function handleHidePopover() {
+  const handleHidePopover = () => {
     setIsPopoverOpen(false);
-  }
+  };
 
   return (
     <Wrapper {...props}>
       {isPopoverOpen && (
         <PopoverContainer
+          {...(a11yId && { id: a11yId })}
           position={position}
           width={width}
           height={height}
           role="tooltip"
+          $zIndex={zIndex}
         >
           {!!title && (
             <Text.Small mb="xxxsmall" fw="medium" color="white">
@@ -43,22 +47,27 @@ function Popover({
         </PopoverContainer>
       )}
 
-      <button
-        type="button"
-        style={{ all: 'unset' }}
+      <PopoverButton
+        {...(a11yId && { 'aria-describedby': a11yId })}
         onMouseEnter={handleShowPopover}
         onMouseLeave={handleHidePopover}
         onTouchStart={handleShowPopover}
         onTouchEnd={handleHidePopover}
         onClick={event => event.preventDefault()}
+        onKeyDown={event => {
+          if (event.key === 'Enter') {
+            setIsPopoverOpen(current => !current);
+          }
+        }}
       >
         {children}
-      </button>
+      </PopoverButton>
     </Wrapper>
   );
 }
 
 Popover.propTypes = {
+  a11yId: string,
   children: node.isRequired,
   title: string,
   description: string.isRequired,
@@ -79,13 +88,16 @@ Popover.propTypes = {
   ]),
   width: number,
   height: number,
+  zIndex: number,
 };
 
 Popover.defaultProps = {
+  a11yId: undefined,
   title: undefined,
   position: 'bottom-center',
   width: 265,
-  height: 116,
+  height: 200,
+  zIndex: 1,
 };
 
 export default Popover;

--- a/packages/yoga/src/Popover/web/__snapshots__/Popover.test.jsx.snap
+++ b/packages/yoga/src/Popover/web/__snapshots__/Popover.test.jsx.snap
@@ -5,12 +5,24 @@ exports[`<Popover /> should match snapshot 1`] = `
   position: relative;
 }
 
+.c1 {
+  all: unset;
+}
+
+@media (hover:hover) and (pointer:fine) {
+  .c1:focus {
+    box-shadow: 0 2px 4px -1px rgba(152,152,166,0.2),0 4px 5px 0px rgba(152,152,166,0.14),0 1px 10px 0px rgba(152,152,166,0.12);
+    -webkit-transition: box-shadow ease 0.5s;
+    transition: box-shadow ease 0.5s;
+  }
+}
+
 <div>
   <div
     class="c0"
   >
     <button
-      style="all: unset;"
+      class="c1"
       type="button"
     >
       <svg

--- a/packages/yoga/src/Popover/web/styles.js
+++ b/packages/yoga/src/Popover/web/styles.js
@@ -75,9 +75,10 @@ export const PopoverContainer = styled.div`
     position,
     width,
     height,
+    $zIndex,
   }) => css`
     position: absolute;
-
+    overflow: auto;
     width: max-content;
     max-width: ${width}px;
     height: max-content;
@@ -86,7 +87,25 @@ export const PopoverContainer = styled.div`
     border-radius: ${radii.small}px;
     background-color: ${colors.stamina};
     padding: ${spacing.small}px;
+    z-index: ${$zIndex};
 
     ${popoverContainerPositionModifier[position]};
+  `}
+`;
+
+export const PopoverButton = styled.button.attrs({ type: 'button' })`
+  all: unset;
+
+  ${({
+    theme: {
+      yoga: { elevations },
+    },
+  }) => css`
+    @media (hover: hover) and (pointer: fine) {
+      &:focus {
+        box-shadow: ${elevations.small};
+        transition: box-shadow ease 0.5s;
+      }
+    }
   `}
 `;


### PR DESCRIPTION
This PR introduces some improvements to `Popover` implementation:
 
- adds zIndex property with default to 1, so popover content isn't overflowed by subsequent elements.
- included overflow: auto on container so user can scroll if content overflows.
- included a11yId so content is better described for accessibility users.
- adds popover toggle behaviour on enter if the user is using the keyboard to navigate and include basic focus style so user knows where he is while doing so.

[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[Enter the description of your changes]

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

### ZIndex
|Before|After|
|-|-|
|![popover-before](https://github.com/gympass/yoga/assets/796443/5ae88cdc-0d7a-4d37-be5a-142b2df106ca)|![popover-after](https://github.com/gympass/yoga/assets/796443/7626f093-0e55-4035-bd0d-87f6dd9e5e42)|

### Overflow: auto
![Screenshot 2023-07-12 at 17 26 50](https://github.com/gympass/yoga/assets/796443/45fa45f8-8e8b-4cb3-90d4-8df02e52e9df)

### Enter key + focus

https://github.com/gympass/yoga/assets/796443/812ede5e-938f-498e-a9ce-228002061ab2



[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
