### PR TITLE
  🚀 feat(banner/web): message prop now accepts react element

### DIFF
--- a/packages/yoga/src/Banner/web/Banner.jsx
+++ b/packages/yoga/src/Banner/web/Banner.jsx
@@ -5,8 +5,10 @@ import { borders, margins, paddings } from '@gympass/yoga-system';
 import {
   checkPropTypes,
   elementType,
+  element,
   func,
   oneOf,
+  oneOfType,
   shape,
   string,
 } from 'prop-types';
@@ -113,7 +115,7 @@ Banner.propTypes = {
   /** style the banner following the theme (success, informative, attention) */
   variant: oneOf(['success', 'informative', 'attention']),
   /** the message to display */
-  message: string.isRequired,
+  message: oneOfType([string, element]).isRequired,
   /** the label and action fuction are required for banner action buttons  */
   primaryButton: BannerActionButtonType,
   /** the secondary button should only be used assemble the primary button (the label and action fuction are required for banner action buttons).  */


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On the Darwin team, we have a scenario where we want to use the Banner component, but the message has a line break and bold in the middle. For this I'm letting the message property receive a React element.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

