### PR TITLE
🚀refactor: remove some warnings during development

### DIFF
--- a/packages/doc/content/components/icons/icons-web.mdx
+++ b/packages/doc/content/components/icons/icons-web.mdx
@@ -20,8 +20,8 @@ Remembering that icon groups are `objects` you can work with.
   <FlagsIcons.FlagBrazil width={26} height={26} />
 
   <Box d="flex" gap="small">
-    {Object.entries(FlagsIcons).map(([_, Component]) => (
-      <Component width={26} height={26} />
+    {Object.entries(FlagsIcons).map(([name, Component]) => (
+      <Component width={26} height={26} key={name} />
     ))}
   </Box>
 </Box>

--- a/packages/doc/src/components/Navigation/Navigation.jsx
+++ b/packages/doc/src/components/Navigation/Navigation.jsx
@@ -83,9 +83,9 @@ const StyledList = styled(MDXElements.Ul)`
   width: 100%;
 `;
 
-const ChevronContainer = styled.div.attrs({
-  rotation: props => (props.isOpen ? 180 : 0),
-})`
+const ChevronContainer = styled.div.attrs(props => ({
+  rotation: props.isOpen ? 180 : 0,
+}))`
   > svg {
     width: 0.6rem;
     transition: all 200ms ease-out;


### PR DESCRIPTION
## Description 📄

During development, there are some warning and errors being thrown to the console.
This PR has 2 fixed for them.

One in the Icon documentation page, where a key was missing to each list child:
  
![Captura de ecrã 2023-08-18, às 16 58 47](https://github.com/gympass/yoga/assets/135242379/661c8059-f7b9-4908-a6e2-73a09ad4e6f2)

The other one was a deprecation warning (from styled-components) in the implementation of the chevron icon used in sidebar tree to show each if each node is open or closed:
![Captura de ecrã 2023-08-18, às 17 16 13](https://github.com/gympass/yoga/assets/135242379/fa6a69a0-7dba-47e7-9aae-240674756d0c)

## Platforms 📲

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [X] Documentation

## How Has This Been Tested? 🧪

Manually, browsing the web page (http://localhost:8000/components/icons#web)
