### PR TITLE
🚀 fix: snackbar z-index

### DIFF
--- a/packages/yoga/src/Snackbar/web/Snackbar.jsx
+++ b/packages/yoga/src/Snackbar/web/Snackbar.jsx
@@ -13,6 +13,15 @@ import Button from '../../Button';
 import Icon from '../../Icon';
 import Text from '../../Text';
 
+function getMaxZIndex() {
+  return Math.max(
+    ...Array.from(document.querySelectorAll('body *'), el =>
+      parseFloat(window.getComputedStyle(el).zIndex),
+    ).filter(zIndex => !Number.isNaN(zIndex)),
+    0,
+  );
+}
+
 const IconButtonWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -69,7 +78,7 @@ const StyledSnackbar = styled.div`
 
       background-color: ${snackbar.variant.color[variant]};
 
-      z-index: 100;
+      z-index: ${getMaxZIndex() + 1};
     `}
 
   ${media.md`

--- a/packages/yoga/src/Snackbar/web/__snapshots__/Snackbar.test.jsx.snap
+++ b/packages/yoga/src/Snackbar/web/__snapshots__/Snackbar.test.jsx.snap
@@ -99,7 +99,7 @@ exports[`<Snackbar /> should match snapshot 1`] = `
   border-radius: 8px;
   box-shadow: 0 2px 4px -1px rgba(152,152,166,0.2),0 4px 5px 0px rgba(152,152,166,0.14),0 1px 10px 0px rgba(152,152,166,0.12);
   background-color: #C1EEDB;
-  z-index: 100;
+  z-index: 1;
   -webkit-animation: bcCCNc 0.2s ease-in-out;
   animation: bcCCNc 0.2s ease-in-out;
 }


### PR DESCRIPTION
## Description 📄

The Snackbar in the web version had a fixed z-index value (of 100). If there is in the document any other fixed or absolute positioned element with a higher z-index, the snackbar is shown below it.
To avoid this, it is possible to calculate the z-index when the element is rendered traversing the document's nodes, checking the z-index of each one and returning the max value. 
Just to keep the old behavior and guarantee a high value for the property, the minimum value will be 100.

[Enter the description of your changes]

## Platforms 📲

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

Through the browser, creating a div with a high z-index value (200) in the .mdx

## Checklist: 🔍

- [X] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [X] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Screenshots 📸

Old behaviour:
![Captura de ecrã 2023-08-25, às 16 38 54](https://github.com/gympass/yoga/assets/135242379/18492a8c-1f4b-40d3-9f0d-8ab00ccbd07f)
Div with z-index greater than 100m snackbar is below.

New behaviour:
![Captura de ecrã 2023-08-25, às 16 45 11](https://github.com/gympass/yoga/assets/135242379/e027200d-98a9-420a-95bd-5625f0e5ced5)
