### PR TITLE
feat: prepend element to Input

### DIFF
--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -105,8 +105,8 @@ const Input = React.forwardRef(
       rightIcon,
       a11yId,
       includeAriaAttributes,
-      prependElement,
-      prependElementWidth,
+      leftElement,
+      leftElementWidth,
       ...props
     },
     ref,
@@ -153,9 +153,7 @@ const Input = React.forwardRef(
           style={style}
           value={value}
         >
-          {prependElement && (
-            <PreprendElement>{prependElement}</PreprendElement>
-          )}
+          {leftElement && <PreprendElement>{leftElement}</PreprendElement>}
           {!children ? (
             <Field
               {...props}
@@ -172,9 +170,7 @@ const Input = React.forwardRef(
               value={value}
               onChange={onChange}
               {...a11yFieldProps}
-              style={
-                prependElementWidth ? { textIndent: prependElementWidth } : {}
-              }
+              style={leftElementWidth ? { textIndent: leftElementWidth } : {}}
             />
           ) : (
             children
@@ -261,10 +257,10 @@ Input.propTypes = {
   /** useful for components that extend the Input component and have their own ARIA attributes implementation (e.g. Dropdown) */
   includeAriaAttributes: bool,
 
-  /** prepend an element */
-  prependElement: node,
-  /** the width of the prepended element */
-  prependElementWidth: string,
+  /** element on the left */
+  leftElement: node,
+  /** the width of the element on the left */
+  leftElementWidth: string,
 };
 
 Input.defaultProps = {
@@ -287,8 +283,8 @@ Input.defaultProps = {
   rightIcon: undefined,
   a11yId: undefined,
   includeAriaAttributes: true,
-  prependElement: undefined,
-  prependElementWidth: undefined,
+  leftElement: undefined,
+  leftElementWidth: undefined,
 };
 
 export default Input;

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -78,7 +78,7 @@ const IconWrapper = styled.div`
   `}
 `;
 
-const PreprendElement = styled.div`
+const LeftElementWrapper = styled.div`
   position: absolute;
   left: 8px;
   top: 50%;
@@ -153,7 +153,9 @@ const Input = React.forwardRef(
           style={style}
           value={value}
         >
-          {leftElement && <PreprendElement>{leftElement}</PreprendElement>}
+          {leftElement && (
+            <LeftElementWrapper>{leftElement}</LeftElementWrapper>
+          )}
           {!children ? (
             <Field
               {...props}

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -78,6 +78,13 @@ const IconWrapper = styled.div`
   `}
 `;
 
+const PreprendElement = styled.div`
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
 const Input = React.forwardRef(
   (
     {
@@ -98,6 +105,8 @@ const Input = React.forwardRef(
       rightIcon,
       a11yId,
       includeAriaAttributes,
+      prependElement,
+      prependElementWidth,
       ...props
     },
     ref,
@@ -144,6 +153,9 @@ const Input = React.forwardRef(
           style={style}
           value={value}
         >
+          {prependElement && (
+            <PreprendElement>{prependElement}</PreprendElement>
+          )}
           {!children ? (
             <Field
               {...props}
@@ -160,6 +172,9 @@ const Input = React.forwardRef(
               value={value}
               onChange={onChange}
               {...a11yFieldProps}
+              style={
+                prependElementWidth ? { textIndent: prependElementWidth } : {}
+              }
             />
           ) : (
             children
@@ -184,6 +199,7 @@ const Input = React.forwardRef(
               height={20}
               role="button"
               hasIconRight={!!rightIcon}
+              prependElement={!!prependElement}
             >
               <Close aria-label="Clear" />
             </IconWrapper>
@@ -245,6 +261,11 @@ Input.propTypes = {
   a11yId: string,
   /** useful for components that extend the Input component and have their own ARIA attributes implementation (e.g. Dropdown) */
   includeAriaAttributes: bool,
+
+  /** prepend an element */
+  prependElement: node,
+  /** the width of the prepended element */
+  prependElementWidth: string,
 };
 
 Input.defaultProps = {
@@ -267,6 +288,8 @@ Input.defaultProps = {
   rightIcon: undefined,
   a11yId: undefined,
   includeAriaAttributes: true,
+  prependElement: undefined,
+  prependElementWidth: undefined,
 };
 
 export default Input;

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -79,10 +79,16 @@ const IconWrapper = styled.div`
 `;
 
 const LeftElementWrapper = styled.div`
-  position: absolute;
-  left: 8px;
-  top: 50%;
-  transform: translateY(-50%);
+  ${({
+    theme: {
+      yoga: { spacing },
+    },
+  }) => css`
+    position: absolute;
+    left: ${spacing.xxsmall}px;
+    top: 50%;
+    transform: translateY(-50%);
+  `}
 `;
 
 const Input = React.forwardRef(

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -199,7 +199,6 @@ const Input = React.forwardRef(
               height={20}
               role="button"
               hasIconRight={!!rightIcon}
-              prependElement={!!prependElement}
             >
               <Close aria-label="Clear" />
             </IconWrapper>

--- a/packages/yoga/src/Input/web/Input.jsx
+++ b/packages/yoga/src/Input/web/Input.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useLayoutEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import {
   arrayOf,
@@ -106,7 +106,6 @@ const Input = React.forwardRef(
       a11yId,
       includeAriaAttributes,
       leftElement,
-      leftElementWidth,
       ...props
     },
     ref,
@@ -143,6 +142,15 @@ const Input = React.forwardRef(
       a11yFieldProps = {};
     }
 
+    const leftElementRef = useRef(null);
+    const [leftElementTextIndent, setLeftElementTextIndent] = useState(0);
+
+    useLayoutEffect(() => {
+      if (leftElementRef.current) {
+        setLeftElementTextIndent(`${leftElementRef.current.offsetWidth}px`);
+      }
+    }, [leftElement]);
+
     return (
       <Control full={full}>
         <Fieldset
@@ -154,7 +162,9 @@ const Input = React.forwardRef(
           value={value}
         >
           {leftElement && (
-            <LeftElementWrapper>{leftElement}</LeftElementWrapper>
+            <LeftElementWrapper ref={leftElementRef}>
+              {leftElement}
+            </LeftElementWrapper>
           )}
           {!children ? (
             <Field
@@ -172,7 +182,7 @@ const Input = React.forwardRef(
               value={value}
               onChange={onChange}
               {...a11yFieldProps}
-              style={leftElementWidth ? { textIndent: leftElementWidth } : {}}
+              style={leftElement ? { textIndent: leftElementTextIndent } : {}}
             />
           ) : (
             children
@@ -261,8 +271,6 @@ Input.propTypes = {
 
   /** element on the left */
   leftElement: node,
-  /** the width of the element on the left */
-  leftElementWidth: string,
 };
 
 Input.defaultProps = {
@@ -286,7 +294,6 @@ Input.defaultProps = {
   a11yId: undefined,
   includeAriaAttributes: true,
   leftElement: undefined,
-  leftElementWidth: undefined,
 };
 
 export default Input;


### PR DESCRIPTION

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

Prepend any element to the Input element, inside the bordered area:
![Captura de ecrã 2023-09-04, às 10 06 46](https://github.com/gympass/yoga/assets/135242379/3f0e8c20-de9c-4659-a1ab-781087f694cf)

Added 2 props to the Input component:

- prependElement: which accepts a node (like the rightIcon prop) 
- prependElementWidth: the width of the element passed as prependElement

We proposed the name of the prop do use _prepend_ because other frameworks use this nomenclature, but it can be left to  keep consistency with the already existed _rightIcon_ prop; we used _Element_ to indicate that this prop accepts any element.

The prependElementWidth is used to add a text indent to the Field component, so the text will be indented (without this prop, the text would be placed above the prepended element). Also, there is some ways to avoid this prop, like calculate the size of the rendered element using the ResizeObserver or with the useLayoutEffect hook. But we thought this approach would be simpler and more effective, because the prepended element is well known by the parent component and it should now its size (and we avoid extra calculation).
![Captura de ecrã 2023-09-04, às 10 05 54](https://github.com/gympass/yoga/assets/135242379/2be61ae0-4676-423c-8058-4865ea44a9d4)
Also, the element is always vertically centered.

Code example:
 
<img width="894" alt="Captura de ecrã 2023-09-04, às 10 27 29" src="https://github.com/gympass/yoga/assets/135242379/18f20479-e490-4f38-aa33-a93bab367772">

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: 🔍

- [X] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
