### PR TITLE
chore: add full path to exports in createPackageJson

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -20,14 +20,14 @@ const createPackageJson = () => {
 
   const newPackageData = {
     ...packageDataOther,
-    main: './cjs',
-    module: './esm',
+    main: './cjs/index.js',
+    module: './esm/index.js',
     types: './typings/index.d.ts',
     private: false,
     exports: {
       '.': {
-        require: './cjs',
-        import: './esm',
+        require: './cjs/index.js',
+        import: './esm/index.js',
       },
     },
   };


### PR DESCRIPTION
## Description 📄

Revert changes in _createPackageJson_ function to add the full path from modules exported in package.json for each package within npm.

Without them, webpack from other projects that use Yoga cannot find the modules:

![image](https://github.com/gympass/yoga/assets/135242379/df7d3869-213b-47b9-8625-e80ea4c5844f)
