### PR TITLE
Remove prop ariaLabel

### DIFF
--- a/packages/yoga/src/Button/web/Button.jsx
+++ b/packages/yoga/src/Button/web/Button.jsx
@@ -6,7 +6,6 @@ import StyledButton from './StyledButton';
 const Button = forwardRef(
   (
     {
-      ariaLabel,
       children,
       onClick,
       full,
@@ -32,7 +31,6 @@ const Button = forwardRef(
         ref={ref}
         disabled={disabled}
         aria-disabled={disabled}
-        aria-label={ariaLabel}
         full={full}
         inverted={inverted}
         onClick={onClick}
@@ -48,7 +46,6 @@ const Button = forwardRef(
 );
 
 Button.propTypes = {
-  ariaLabel: string,
   children: node,
   disabled: bool,
   full: bool,
@@ -62,7 +59,6 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  ariaLabel: undefined,
   children: 'Button',
   disabled: undefined,
   full: false,

--- a/packages/yoga/src/Button/web/Icon.jsx
+++ b/packages/yoga/src/Button/web/Icon.jsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { oneOfType, func, node, bool, string } from 'prop-types';
+import { oneOfType, func, node, bool } from 'prop-types';
 import styled, { withTheme } from 'styled-components';
 
 import StyledButton from './StyledButton';
@@ -39,7 +39,6 @@ const ButtonIcon = forwardRef(
       },
       small,
       disabled,
-      ariaLabel,
       ...props
     },
     ref,
@@ -51,7 +50,6 @@ const ButtonIcon = forwardRef(
         small={small}
         disabled={disabled}
         aria-disabled={disabled}
-        aria-label={ariaLabel}
       >
         <Icon
           as={icon}
@@ -68,7 +66,6 @@ ButtonIcon.propTypes = {
   secondary: bool,
   inverted: bool,
   icon: oneOfType([node, func]),
-  ariaLabel: string,
 };
 
 ButtonIcon.defaultProps = {
@@ -77,7 +74,6 @@ ButtonIcon.defaultProps = {
   secondary: false,
   inverted: false,
   icon: undefined,
-  ariaLabel: undefined,
 };
 
 ButtonIcon.displayName = 'Button.Icon';


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removes the ariaLabel prop for the aria-label attribute, thus leaving the native use of the attribute as an accessible element. The ariaLabel property will be maintained only for the Icon component as part of the accessible identifier for elements such as title and description.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Removes the ariaLabel prop for the aria-label attribute, thus leaving the native use of the attribute as an accessible element. The ariaLabel property will be maintained only for the Icon component as part of the accessible identifier for elements such as title and description.

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
