### PR TITLE
🐞 fix(avatar-native): add propTypes and defaultProps to avatar native

### DIFF
--- a/packages/yoga/src/Avatar/native/Avatar.jsx
+++ b/packages/yoga/src/Avatar/native/Avatar.jsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import { BuildingFilled } from '@gympass/yoga-icons';
-import { string, func } from 'prop-types';
+import { string, func, number } from 'prop-types';
 import { ImagePropTypes } from 'deprecated-react-native-prop-types';
 import { Image, StyleSheet } from 'react-native';
 
@@ -46,9 +46,9 @@ const Avatar = forwardRef(
       children,
       fill,
       stroke,
-      borderRadius = 'small',
-      width = 48,
-      height = 48,
+      borderRadius,
+      width,
+      height,
       ...props
     },
     ref,
@@ -105,12 +105,18 @@ Avatar.propTypes = {
   src: ImagePropTypes.source,
   icon: func,
   fill: string,
+  width: number,
+  height: number,
+  borderRadius: string,
   ...Box.propTypes,
 };
 
 Avatar.defaultProps = {
   src: undefined,
   fill: 'white',
+  width: 48,
+  height: 48,
+  borderRadius: 'small',
   ...Box.defaultProps,
 };
 


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We used to encounter an error when trying to open the native avatar document because the propsTable component couldn't locate the newly added props in PR #703.

The solution was to include these new props in propTypes and defaultProps so that propsTable could recognize them.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [ ] Web
- [x] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

| Before | After |
| ------ | ----- |
|![Screenshot 2023-11-07 at 10 33 07](https://github.com/gympass/yoga/assets/32910717/adc22417-4714-41d0-85da-7aad3f87d174)|![image](https://github.com/gympass/yoga/assets/32910717/6c00c28e-bd7f-47b0-bbb7-fcc11dbd6c6e)|
