### PR TITLE
fix(navigation-menu): remove div inside p

### DIFF
--- a/packages/doc/content/components/components/navigationmenu/props.ts
+++ b/packages/doc/content/components/components/navigationmenu/props.ts
@@ -104,10 +104,10 @@ export const SwitcherProps = [
     defaultValue: { value: 'transparent' },
   },
     {
-    name: 'loadingTitle',
+    name: 'isLoading',
     description: {
       text:
-        'Indicates whether the title is loading',
+        'Indicates whether the title and the subtitle are loading',
     },
     type: { name: 'bool' },
     required: false,

--- a/packages/doc/content/components/components/navigationmenu/props.ts
+++ b/packages/doc/content/components/components/navigationmenu/props.ts
@@ -40,7 +40,7 @@ export const MenuProps = [
     name: 'title',
     description: { text: 'Text to be displayed as title' },
     type: { name: 'string' },
-    required: true,
+    required: false,
   },
   {
     name: 'onClick',
@@ -103,6 +103,16 @@ export const SwitcherProps = [
     required: false,
     defaultValue: { value: 'transparent' },
   },
+    {
+    name: 'loadingTitle',
+    description: {
+      text:
+        'Indicates whether the title is loading',
+    },
+    type: { name: 'bool' },
+    required: false,
+    defaultValue: { value: 'false' },
+  },
   {
     name: 'sideOffset',
     description: {
@@ -122,7 +132,7 @@ export const SwitcherProps = [
     name: 'title',
     description: { text: 'Text to be displayed as title' },
     type: { name: 'string' },
-    required: true,
+    required: false,
   },
 ];
 

--- a/packages/yoga/src/NavigationMenu/web/Menu/Menu.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Menu/Menu.tsx
@@ -72,8 +72,9 @@ const StyledText = styled(Text.Small)`
 type MenuProps = {
   avatar: React.ReactElement;
   subtitle?: string;
-  title: string;
+  title?: string;
   onClick?: () => void;
+  isLoading?: boolean;
 };
 
 const Menu = ({ avatar: Avatar, subtitle, title, onClick }: MenuProps) => {
@@ -84,13 +85,8 @@ const Menu = ({ avatar: Avatar, subtitle, title, onClick }: MenuProps) => {
       {Avatar}
 
       <StyledTextContainer>
-        {title ? (
-          <StyledText>{title}</StyledText>
-        ) : (
-          <Skeleton type="text" variant="body2" width="100%" />
-        )}
-
-        <Text.Small color="deep">{subtitle}</Text.Small>
+        {title &&  <StyledText>{title}</StyledText>}
+        {subtitle && <Text.Small color="deep">{subtitle}</Text.Small>}
       </StyledTextContainer>
 
       {hasAction && <Icon as={ArrowRight} size="large" fill="vibin" />}

--- a/packages/yoga/src/NavigationMenu/web/Menu/Menu.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Menu/Menu.tsx
@@ -74,7 +74,6 @@ type MenuProps = {
   subtitle?: string;
   title?: string;
   onClick?: () => void;
-  isLoading?: boolean;
 };
 
 const Menu = ({ avatar: Avatar, subtitle, title, onClick }: MenuProps) => {
@@ -86,6 +85,7 @@ const Menu = ({ avatar: Avatar, subtitle, title, onClick }: MenuProps) => {
 
       <StyledTextContainer>
         {title &&  <StyledText>{title}</StyledText>}
+        
         {subtitle && <Text.Small color="deep">{subtitle}</Text.Small>}
       </StyledTextContainer>
 

--- a/packages/yoga/src/NavigationMenu/web/Menu/Menu.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Menu/Menu.tsx
@@ -60,14 +60,13 @@ const StyledText = styled(Text.Small)`
       },
     },
   }) =>
-    css `
+    css`
       font-weight: ${font.weight.medium};
       flex: 1;
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-    `
-  }
+    `}
 `;
 
 type MenuProps = {
@@ -85,9 +84,11 @@ const Menu = ({ avatar: Avatar, subtitle, title, onClick }: MenuProps) => {
       {Avatar}
 
       <StyledTextContainer>
-        <StyledText>
-          {title || <Skeleton type="text" variant="body2" width="100%" />}
-        </StyledText>
+        {title ? (
+          <StyledText>{title}</StyledText>
+        ) : (
+          <Skeleton type="text" variant="body2" width="100%" />
+        )}
 
         <Text.Small color="deep">{subtitle}</Text.Small>
       </StyledTextContainer>

--- a/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
@@ -67,7 +67,7 @@ type SwitcherProps = {
   actions?: SwitcherActionsProps[];
   avatar: React.ReactElement;
   fill?: string;
-  loadingTitle?: boolean;
+  isLoading?: boolean;
   sideOffset?: number;
   subtitle?: string;
   title?: string;
@@ -77,7 +77,7 @@ const Switcher = ({
   actions,
   avatar: Avatar,
   fill = 'transparent',
-  loadingTitle = false,
+  isLoading = false,
   sideOffset = 36,
   subtitle,
   title,
@@ -89,11 +89,22 @@ const Switcher = ({
       {Avatar}
 
       <StyledTextContainer>
-        {loadingTitle && <Skeleton type="text" variant="body2" width="100%" />}
-
-        {!loadingTitle && title && <StyledTitle>{title}</StyledTitle>}
-        
-        {subtitle && <Text.Tiny color="deep">{subtitle}</Text.Tiny>}
+        {isLoading ? (
+          <>
+            <Skeleton
+              type="text"
+              variant="overline"
+              width="100%"
+              marginBottom="4px"
+            />
+            <Skeleton type="text" variant="overline" width="100%" />
+          </>
+        ) : (
+          <>
+            {title && <StyledTitle>{title}</StyledTitle>}
+            {subtitle && <Text.Tiny color="deep">{subtitle}</Text.Tiny>}
+          </>
+        )}
       </StyledTextContainer>
 
       {hasActions && <Actions actions={actions} sideOffset={sideOffset} />}

--- a/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
@@ -67,15 +67,17 @@ type SwitcherProps = {
   actions?: SwitcherActionsProps[];
   avatar: React.ReactElement;
   fill?: string;
+  loadingTitle?: boolean;
   sideOffset?: number;
   subtitle?: string;
-  title: string;
+  title?: string;
 };
 
 const Switcher = ({
   actions,
   avatar: Avatar,
   fill = 'transparent',
+  loadingTitle = false,
   sideOffset = 36,
   subtitle,
   title,
@@ -87,13 +89,11 @@ const Switcher = ({
       {Avatar}
 
       <StyledTextContainer>
-        {title ? (
-          <StyledTitle>{title}</StyledTitle>
-        ) : (
-          <Skeleton type="text" variant="body2" width="100%" />
-        )}
+        {loadingTitle && <Skeleton type="text" variant="body2" width="100%" />}
 
-        <Text.Tiny color="deep">{subtitle}</Text.Tiny>
+        {!loadingTitle && title && <StyledTitle>{title}</StyledTitle>}
+        
+        {subtitle && <Text.Tiny color="deep">{subtitle}</Text.Tiny>}
       </StyledTextContainer>
 
       {hasActions && <Actions actions={actions} sideOffset={sideOffset} />}

--- a/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
@@ -87,9 +87,11 @@ const Switcher = ({
       {Avatar}
 
       <StyledTextContainer>
-        <StyledTitle>
-          {title || <Skeleton type="text" variant="body2" width="100%" />}
-        </StyledTitle>
+        {title ? (
+          <StyledTitle>{title}</StyledTitle>
+        ) : (
+          <Skeleton type="text" variant="body2" width="100%" />
+        )}
 
         <Text.Tiny color="deep">{subtitle}</Text.Tiny>
       </StyledTextContainer>


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes a warning caused by being inserted a `div` (skeleton) inside a `p`.


![image](https://github.com/gympass/yoga/assets/32453477/35ad3f06-30ea-407f-9f11-345b4a1d26ab)


## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

