### PR TITLE
🐞  fix: multiple onChange being triggered on Checkbox

### DIFF
--- a/packages/yoga/src/Checkbox/web/Checkbox.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.jsx
@@ -251,7 +251,6 @@ const Checkbox = ({
   const inputRef = useRef(null);
 
   const { onChange, onClick, ...restWithoutEvents } = rest;
-  const events = { onChange, onClick };
 
   useEffect(() => {
     if (inputRef.current) {
@@ -296,7 +295,8 @@ const Checkbox = ({
             checked={checked}
             disabled={disabled}
             {...(value ? { value } : {})}
-            {...events}
+            onChange={onChange}
+            onClick={onClick}
           />
           {label}
         </Label>

--- a/packages/yoga/src/Checkbox/web/Checkbox.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.jsx
@@ -250,7 +250,8 @@ const Checkbox = ({
 }) => {
   const inputRef = useRef(null);
 
-  const { onChange, ...restWithoutOnChange } = rest;
+  const { onChange, onClick, ...restWithoutEvents } = rest;
+  const events = { onChange, onClick };
 
   useEffect(() => {
     if (inputRef.current) {
@@ -263,7 +264,7 @@ const Checkbox = ({
       style={style}
       className={className}
       disabled={disabled}
-      {...rest}
+      {...restWithoutEvents}
     >
       <CheckboxStyled
         checked={checked}
@@ -295,7 +296,7 @@ const Checkbox = ({
             checked={checked}
             disabled={disabled}
             {...(value ? { value } : {})}
-            {...restWithoutOnChange}
+            {...events}
           />
           {label}
         </Label>

--- a/packages/yoga/src/Checkbox/web/Checkbox.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.jsx
@@ -250,6 +250,8 @@ const Checkbox = ({
 }) => {
   const inputRef = useRef(null);
 
+  const { onChange, ...restWithoutOnChange } = rest;
+
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.indeterminate = indeterminate;
@@ -293,7 +295,7 @@ const Checkbox = ({
             checked={checked}
             disabled={disabled}
             {...(value ? { value } : {})}
-            {...rest}
+            {...restWithoutOnChange}
           />
           {label}
         </Label>


### PR DESCRIPTION
## Description 📄

This implementation fixes an undesired behavior in the Checkbox: the onChange event was being triggered twice in every user's click:

![ezgif-4-ec1c6f183e (1)](https://github.com/gympass/yoga/assets/135242379/62855df8-057f-4dfa-a4f1-12fd00e3be72)

The fix consists of creating a new object copied from rest but without the onChange property and passing it to the HiddenInput component. What was happening is that the rest was being passed to both CheckboxWrapper and HiddenInput, triggering the onChange twice.
I didn't remove the entire {...rest} passed as prop to HiddenInput to because I don't know if the other props are required in this component.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

Manually

## Checklist: 🔍

- [X] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [X] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

