### PR TITLE
🚀 [EXUX-749] - Fix border bottom color on Result component

### DIFF
--- a/packages/yoga/src/Result/native/Result.jsx
+++ b/packages/yoga/src/Result/native/Result.jsx
@@ -8,20 +8,16 @@ import Box from '../../Box';
 
 const StyledBox = styled(Box)`
   width: 100%;
-  ${({
-    divided,
+  border-bottom-width: ${({ divided }) => (divided ? 1 : 0)}px;
+  border-bottom-color: ${({
     theme: {
       yoga: {
-        colors: { light },
+        colors: {
+          elements: { lineAndBorders },
+        },
       },
     },
-  }) =>
-    divided
-      ? `
-          border-bottom-width: 1px;
-          border-bottom-color: ${light};
-        `
-      : ''}
+  }) => lineAndBorders};
 `;
 
 const Content = styled.View`

--- a/packages/yoga/src/Result/native/__snapshots__/Result.test.jsx.snap
+++ b/packages/yoga/src/Result/native/__snapshots__/Result.test.jsx.snap
@@ -1019,6 +1019,8 @@ exports[`<Result /> should match snapshot without attendence 1`] = `
   style={
     [
       {
+        "borderBottomColor": "#D7D7E0",
+        "borderBottomWidth": 0,
         "display": "flex",
         "flexDirection": "row",
         "width": "100%",


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR replaces wrong color token on Result component with the correct one (`lineAndBorders`).

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [ ] Web
- [x] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|    <img src="https://github.com/gympass/yoga/assets/152918348/fe1f6beb-83d1-4234-be62-8132e4c26e78" width="300" />    |   <img src="https://github.com/gympass/yoga/assets/152918348/4eb2d4f0-3825-4414-ac15-365ab5843619" width="300" />   |
