### PR TITLE
🚀 fix(DS-794): phone input vertical center

### DIFF
--- a/packages/yoga/src/Input/web/Phone.style.js
+++ b/packages/yoga/src/Input/web/Phone.style.js
@@ -153,6 +153,7 @@ export const Container = styled.div`
       .flag-dropdown {
         border: none;
         width: inherit;
+        height: inherit;
         grid-area: dropdown;
 
         &.open {

--- a/packages/yoga/src/Input/web/__snapshots__/Phone.test.jsx.snap
+++ b/packages/yoga/src/Input/web/__snapshots__/Phone.test.jsx.snap
@@ -136,6 +136,7 @@ exports[`<Input.Phone /> Snapshots should match with default input 1`] = `
 .c2 .react-tel-input .flag-dropdown {
   border: none;
   width: inherit;
+  height: inherit;
   grid-area: dropdown;
 }
 


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/DS-794)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

This PR forces phone input `flag-dropdown` class to inherit the height of the parent element, so we ensure that dropdown content is always vertically aligned to center, in all applications that use it.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

https://github.com/gympass/yoga/assets/796443/e5ec1577-1a6d-4daa-9bc4-612ac8429839


| Before | After |
| ------ | ----- |
|        |       |
