### PR TITLE
 🚀 fix/feat: downsize "zIndex" values on NavigationMenu and allow it to be configurable

### DIFF
--- a/packages/doc/content/components/components/navigationmenu/props.ts
+++ b/packages/doc/content/components/components/navigationmenu/props.ts
@@ -19,6 +19,13 @@ export const NavigationMenuProps = [
     required: false,
     defaultValue: { value: 'true' },
   },
+  {
+    name: '$zIndex',
+    description: { text: `Value of z-index of the menu` },
+    type: { name: 'number' },
+    required: false,
+    defaultValue: { value: "2" },
+  },
 ];
 
 export const MenuProps = [
@@ -76,6 +83,13 @@ export const SwitcherActionProps = [
     },
     type: { name: 'func' },
     required: true,
+  },
+  {
+    name: '$zIndex',
+    description: { text: `Value of z-index of the switcher actions menu` },
+    type: { name: 'number' },
+    required: false,
+    defaultValue: { value: "1" },
   },
 ];
 
@@ -223,6 +237,13 @@ export const BottomItemsProps = [
     description: { text: 'Items to be displayed in the mobile bottom bar' },
     type: { name: 'node' },
     required: true,
+  },
+  {
+    name: '$zIndex',
+    description: { text: `Value of z-index of the bottom items menu` },
+    type: { name: 'number' },
+    required: false,
+    defaultValue: { value: "2" },
   },
 ];
 

--- a/packages/yoga/src/NavigationMenu/web/BottomItems/BottomItems.tsx
+++ b/packages/yoga/src/NavigationMenu/web/BottomItems/BottomItems.tsx
@@ -7,6 +7,10 @@ const StyledItemsContainer = styled.nav`
   ${media.lg`display: none`}
 `;
 
+type BottomItemsStyledProps = React.HTMLAttributes<HTMLUListElement> & {
+  $zIndex?: number;
+}
+
 const StyledItems = styled.ul`
   ${({
     theme: {
@@ -25,22 +29,22 @@ const StyledItems = styled.ul`
     align-items: center;
     width: 100%;
     height: 56px;
-    background-color: ${backgroundColor.white};;
+    background-color: ${backgroundColor.white};
     margin: 0;
     padding: 0;
     border: 1px solid ${border.color.default};
     gap: ${gap.xxxsmall}px;
-    z-index: 15;
+    z-index: ${({ $zIndex }) => $zIndex ?? 2};
   `}
 `;
 
-type BottomItemsProps = {
+type BottomItemsProps = BottomItemsStyledProps & {
   children: React.ReactNode;
 };
 
-const BottomItems = ({ children }: BottomItemsProps) => {
+const BottomItems = ({ children, ...containerProps }: BottomItemsProps) => {
   return (
-    <StyledItemsContainer>
+    <StyledItemsContainer {...containerProps}>
       <StyledItems>{children}</StyledItems>
     </StyledItemsContainer>
   );

--- a/packages/yoga/src/NavigationMenu/web/NavigationMenu.tsx
+++ b/packages/yoga/src/NavigationMenu/web/NavigationMenu.tsx
@@ -33,12 +33,14 @@ const DeskTopContainer = css`
   `}
 `;
 
-const StyledNavigationMenu = styled(Box)<{
+type NavigationMenuStyledProps = {
   isOpenOnMobile: boolean;
   isResponsive: boolean;
-  children: React.ReactNode;
-}>`
-  ${({ isOpenOnMobile, isResponsive }) => css`
+  $zIndex?: number;
+}
+
+const StyledNavigationMenu = styled.div<NavigationMenuStyledProps>`
+  ${({ isOpenOnMobile, isResponsive, $zIndex }) => css`
     ${DeskTopContainer};
 
     ${isResponsive &&
@@ -46,7 +48,7 @@ const StyledNavigationMenu = styled(Box)<{
       position: fixed;
       width: 100%;
       height: calc(100% - 56px);
-      z-index: 10;
+      z-index: ${$zIndex ?? 1};
       top: 0;
       right: ${isOpenOnMobile ? '0' : '-100%'};
 
@@ -115,19 +117,20 @@ const StyledFooter = styled(Box)`
   `}
 `;
 
-type NavigationMenuProps = {
-  children: React.ReactNode;
-  openOnMobile?: boolean;
-  responsive?: boolean;
-};
+type NavigationMenuProps = React.HTMLAttributes<HTMLDivElement> &
+  NavigationMenuStyledProps & {
+    children: React.ReactNode;
+  };
 
 const NavigationMenu = ({
   children,
   openOnMobile = false,
   responsive = true,
+  ...htmlAttributes
 }: NavigationMenuProps) => {
   return (
     <StyledNavigationMenu
+      {...htmlAttributes}
       isOpenOnMobile={openOnMobile}
       isResponsive={responsive}
     >

--- a/packages/yoga/src/NavigationMenu/web/Switcher/Actions.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Switcher/Actions.tsx
@@ -1,12 +1,12 @@
+import { Menu as YogaMenu } from '@gympass/yoga';
+import { MenuMore } from '@gympass/yoga-icons';
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { MenuMore } from '@gympass/yoga-icons';
-import { Menu as YogaMenu } from '@gympass/yoga';
-import { SwitcherActionsProps } from './Switcher';
-import Icon from '../../../Icon';
-import Box from '../../../Box';
 
-const StyledAction = styled(Box)`
+import Icon from '../../../Icon';
+import { SwitcherActionsProps } from './Switcher';
+
+const StyledAction = styled.div`
   ${({
     theme: {
       yoga: {
@@ -34,12 +34,23 @@ const StyledAction = styled(Box)`
     `}
 `;
 
-type ActionsProps = {
-  actions: SwitcherActionsProps[];
-  sideOffset: number;
+type SwitcherActionsProps = {
+  id: string;
+  label: string;
+  onClick: () => void;
 };
 
-const Actions = ({ actions, sideOffset }: ActionsProps) => {
+export type ActionsProps = {
+  actions?: SwitcherActionsProps[];
+  sideOffset: number;
+  $zIndex?: number;
+};
+
+function Actions({ actions, sideOffset, $zIndex }: ActionsProps) {
+  if (!actions?.length) {
+    return null;
+  }
+
   return (
     <YogaMenu onMouseHover={false}>
       <YogaMenu.Action>
@@ -48,7 +59,11 @@ const Actions = ({ actions, sideOffset }: ActionsProps) => {
         </StyledAction>
       </YogaMenu.Action>
 
-      <YogaMenu.List side="right" sideOffset={sideOffset} zIndex="10">
+      <YogaMenu.List
+        side="right"
+        sideOffset={sideOffset}
+        zIndex={`${$zIndex ?? 2}`}
+      >
         {actions.map(({ id, label, onClick }) => (
           <YogaMenu.Item key={id} onClick={onClick}>
             {label}
@@ -57,6 +72,6 @@ const Actions = ({ actions, sideOffset }: ActionsProps) => {
       </YogaMenu.List>
     </YogaMenu>
   );
-};
+}
 
 export default Actions;

--- a/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
+++ b/packages/yoga/src/NavigationMenu/web/Switcher/Switcher.tsx
@@ -57,18 +57,10 @@ const StyledTitle = styled(Text.Small)`
     `}
 `;
 
-export type SwitcherActionsProps = {
-  id: string;
-  label: string;
-  onClick: () => void;
-};
-
-type SwitcherProps = {
-  actions?: SwitcherActionsProps[];
+type SwitcherProps = React.ComponentProps<typeof Actions> & {
   avatar: React.ReactElement;
   fill?: string;
   isLoading?: boolean;
-  sideOffset?: number;
   subtitle?: string;
   title?: string;
 };
@@ -78,9 +70,9 @@ const Switcher = ({
   avatar: Avatar,
   fill = 'transparent',
   isLoading = false,
-  sideOffset = 36,
   subtitle,
   title,
+  ...actionsProps
 }: SwitcherProps) => {
   const hasActions = actions?.length;
 
@@ -107,7 +99,7 @@ const Switcher = ({
         )}
       </StyledTextContainer>
 
-      {hasActions && <Actions actions={actions} sideOffset={sideOffset} />}
+      {hasActions && <Actions actions={actions} {...actionsProps} />}
     </StyledSwitcher>
   );
 };

--- a/packages/yoga/src/NavigationMenu/web/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/packages/yoga/src/NavigationMenu/web/__snapshots__/NavigationMenu.test.tsx.snap
@@ -497,7 +497,7 @@ exports[`<NavigationMenu /> Snapshots should match NavigationMenu 1`] = `
   padding: 0;
   border: 1px solid #D7D7E0;
   gap: 4px;
-  z-index: 15;
+  z-index: 2;
 }
 
 .c33 {
@@ -651,7 +651,7 @@ exports[`<NavigationMenu /> Snapshots should match NavigationMenu 1`] = `
   position: fixed;
   width: 100%;
   height: calc(100% - 56px);
-  z-index: 10;
+  z-index: 1;
   top: 0;
   right: -100%;
   -webkit-transition: right 300ms ease-in-out;


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/PPE-641)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

This PR updates NavigationMenu, so the `z-index` values are - by default - to the least amount possible, so it doesn't overlap with other components on a page. Then, i make configurable via prop, so it can be customized by each app.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
