### PR TITLE
🚀 refactor(chips): adjust chips texts 

### DIFF
--- a/packages/yoga/src/Chips/native/Chips.jsx
+++ b/packages/yoga/src/Chips/native/Chips.jsx
@@ -58,11 +58,7 @@ const Wrapper = styled.View.attrs(({ theme: { yoga } }) => {
 `;
 
 const StyledChips = styled(Text)`
-  font-size: ${theme.fontSizes.xsmall}px;
-  line-height: ${theme.lineHeights.xsmall}px;
-
   flex-shrink: 1;
-
   ${({ disabled }) =>
     disabled
       ? css`
@@ -125,7 +121,7 @@ const Chips = React.forwardRef(
           )}
           <StyledChips
             disabled={disabled}
-            as={selected ? Text.Bold : Text}
+            as={selected ? Text.Overline : Text.Caption}
             selected={selected}
             numberOfLines={1}
           >

--- a/packages/yoga/src/Chips/native/Chips.jsx
+++ b/packages/yoga/src/Chips/native/Chips.jsx
@@ -121,7 +121,7 @@ const Chips = React.forwardRef(
           )}
           <StyledChips
             disabled={disabled}
-            as={selected ? Text.Overline : Text.Caption}
+            as={selected || disabled ? Text.Overline : Text.Caption}
             selected={selected}
             numberOfLines={1}
           >

--- a/packages/yoga/src/Chips/native/__snapshots__/Chips.test.jsx.snap
+++ b/packages/yoga/src/Chips/native/__snapshots__/Chips.test.jsx.snap
@@ -47,11 +47,7 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
   }
 >
   <Text
-    bold={false}
     disabled={false}
-    fontSize="medium"
-    inverted={false}
-    light={false}
     numberOfLines={1}
     selected={false}
     style={
@@ -59,14 +55,12 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
         {
           "color": "#231B22",
           "fontFamily": "Rubik",
-          "fontSize": 16,
+          "fontSize": 12,
           "fontWeight": "400",
-          "lineHeight": 24,
+          "lineHeight": 16,
         },
         {
           "flexShrink": 1,
-          "fontSize": 12,
-          "lineHeight": 16,
         },
       ]
     }
@@ -124,11 +118,7 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -136,14 +126,12 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -205,14 +193,13 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -301,14 +288,13 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -394,11 +380,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -406,14 +388,12 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -467,11 +447,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -479,14 +455,12 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -540,11 +514,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -552,14 +522,12 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -613,11 +581,7 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -625,14 +589,12 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -694,14 +656,13 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -790,14 +751,13 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -886,14 +846,13 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -955,14 +914,13 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -1028,14 +986,13 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
         {
           "color": "#231B22",
           "fontFamily": "Rubik",
-          "fontSize": 16,
-          "fontWeight": "700",
+          "fontSize": 12,
+          "fontWeight": "500",
+          "lineHeight": 16,
         },
         {
           "color": "#FFFFFF",
           "flexShrink": 1,
-          "fontSize": 12,
-          "lineHeight": 16,
         },
       ]
     }
@@ -1093,11 +1050,7 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -1105,14 +1058,12 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -1174,14 +1125,13 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -1243,14 +1193,13 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
-            "fontWeight": "700",
+            "fontSize": 12,
+            "fontWeight": "500",
+            "lineHeight": 16,
           },
           {
             "color": "#FFFFFF",
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -1308,11 +1257,7 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
   }
 >
   <Text
-    bold={false}
     disabled={false}
-    fontSize="medium"
-    inverted={false}
-    light={false}
     numberOfLines={1}
     selected={false}
     style={
@@ -1320,14 +1265,12 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
         {
           "color": "#231B22",
           "fontFamily": "Rubik",
-          "fontSize": 16,
+          "fontSize": 12,
           "fontWeight": "400",
-          "lineHeight": 24,
+          "lineHeight": 16,
         },
         {
           "flexShrink": 1,
-          "fontSize": 12,
-          "lineHeight": 16,
         },
       ]
     }
@@ -1384,11 +1327,7 @@ exports[`<Chips /> Snapshots should match snapshot with a long text 1`] = `
   }
 >
   <Text
-    bold={false}
     disabled={false}
-    fontSize="medium"
-    inverted={false}
-    light={false}
     numberOfLines={1}
     selected={false}
     style={
@@ -1396,14 +1335,12 @@ exports[`<Chips /> Snapshots should match snapshot with a long text 1`] = `
         {
           "color": "#231B22",
           "fontFamily": "Rubik",
-          "fontSize": 16,
+          "fontSize": 12,
           "fontWeight": "400",
-          "lineHeight": 24,
+          "lineHeight": 16,
         },
         {
           "flexShrink": 1,
-          "fontSize": 12,
-          "lineHeight": 16,
         },
       ]
     }
@@ -1461,11 +1398,7 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
   }
 >
   <Text
-    bold={false}
     disabled={true}
-    fontSize="medium"
-    inverted={false}
-    light={false}
     numberOfLines={1}
     selected={false}
     style={
@@ -1473,15 +1406,13 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
         {
           "color": "#231B22",
           "fontFamily": "Rubik",
-          "fontSize": 16,
-          "fontWeight": "400",
-          "lineHeight": 24,
+          "fontSize": 12,
+          "fontWeight": "500",
+          "lineHeight": 16,
         },
         {
           "color": "#D7D7E0",
           "flexShrink": 1,
-          "fontSize": 12,
-          "lineHeight": 16,
         },
       ]
     }
@@ -1539,11 +1470,7 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -1551,14 +1478,12 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -1612,11 +1537,7 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -1624,14 +1545,12 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }
@@ -1685,11 +1604,7 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
     }
   >
     <Text
-      bold={false}
       disabled={false}
-      fontSize="medium"
-      inverted={false}
-      light={false}
       numberOfLines={1}
       selected={false}
       style={
@@ -1697,14 +1612,12 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
           {
             "color": "#231B22",
             "fontFamily": "Rubik",
-            "fontSize": 16,
+            "fontSize": 12,
             "fontWeight": "400",
-            "lineHeight": 24,
+            "lineHeight": 16,
           },
           {
             "flexShrink": 1,
-            "fontSize": 12,
-            "lineHeight": 16,
           },
         ]
       }

--- a/packages/yoga/src/Chips/web/Chips.jsx
+++ b/packages/yoga/src/Chips/web/Chips.jsx
@@ -7,18 +7,10 @@ import { theme } from '../../Theme';
 import Icon from '../../Icon';
 
 import Counter from './Counter';
+import Text from '../../Text';
 
 const BORDER_OPACITY = 0.4;
 const BORDER_PRESSED_OPACITY = 0.6;
-
-const Text = styled.span`
-  display: inline-block;
-  box-sizing: border-box;
-
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
 
 const Wrapper = styled.button`
   height: 32px;
@@ -33,16 +25,7 @@ const Wrapper = styled.button`
   cursor: pointer;
 
   ${({ selected, justAnIcon, ...props }) => {
-    const {
-      spacing,
-      borders,
-      colors,
-      radii,
-      baseFont,
-      fontSizes,
-      fontWeights,
-      lineHeights,
-    } = theme(props);
+    const { spacing, borders, colors, radii } = theme(props);
 
     const commonStyles = `
 
@@ -55,18 +38,15 @@ const Wrapper = styled.button`
       border-radius: ${radii.circle}px;
       border-width: ${borders.small}px;
 
-      font-family: ${baseFont.family};
-      font-size: ${fontSizes.xsmall}px;
-      line-height: ${lineHeights.xsmall}px;
-
       :not(:last-child) {
         margin-right: ${spacing.xxsmall}px;
       }
 
       &[disabled] {
         background-color: ${colors.elements.backgroundAndDisabled};
-        color: ${colors.text.disabled};
-
+        p {
+          color: ${colors.text.disabled};
+        }
         border-color: ${colors.elements.backgroundAndDisabled};
 
         cursor: not-allowed;
@@ -85,12 +65,14 @@ const Wrapper = styled.button`
       return `
         ${commonStyles}
 
+        p {
+          color: ${colors.white};
+        }
+        
         background-color: ${colors.secondary};
-        color: ${colors.white};
+        
 
         border-color: transparent;
-
-        font-weight: ${fontWeights.bold};
 
         &:hover:enabled {
           border-color: ${colors.secondary};
@@ -112,17 +94,18 @@ const Wrapper = styled.button`
       border-color: ${hexToRgb(colors.secondary, BORDER_OPACITY)};
 
       background-color: ${colors.white};
-      color: ${colors.secondary};
-
-      font-weight: ${fontWeights.regular};
-
+      p {
+        color: ${colors.secondary};
+      }
       &:hover:enabled {
         border-color: ${colors.secondary};
       }
 
       &:active:enabled {
         border-color: ${hexToRgb(colors.secondary, BORDER_PRESSED_OPACITY)};
-        color: ${hexToRgb(colors.secondary, BORDER_PRESSED_OPACITY)};
+        p {
+          color: ${hexToRgb(colors.secondary, BORDER_PRESSED_OPACITY)};
+        }
 
         svg {
           fill: ${hexToRgb(colors.secondary, BORDER_PRESSED_OPACITY)};
@@ -173,7 +156,11 @@ const Chips = React.forwardRef(
             }}
           />
         )}
-        {children && <Text>{children}</Text>}
+        {children && (selected || disabled) ? (
+          <Text.Overline>{children}</Text.Overline>
+        ) : (
+          <Text.Caption>{children}</Text.Caption>
+        )}
         {selected && counter && !disabled && <Counter value={counter} />}
         {FirstIcon && (
           <Icon

--- a/packages/yoga/src/Chips/web/Chips.jsx
+++ b/packages/yoga/src/Chips/web/Chips.jsx
@@ -135,6 +135,8 @@ const Chips = React.forwardRef(
     const [FirstIcon, SecondIcon] = icons;
     const justAnIcon = (icons[0] || icons[1]) && !children;
 
+    const TextComponent = selected || disabled ? Text.Overline : Text.Caption;
+
     return (
       <Wrapper
         selected={selected}
@@ -156,11 +158,7 @@ const Chips = React.forwardRef(
             }}
           />
         )}
-        {children && (selected || disabled) ? (
-          <Text.Overline>{children}</Text.Overline>
-        ) : (
-          <Text.Caption>{children}</Text.Caption>
-        )}
+        {children && <TextComponent>{children}</TextComponent>}
         {selected && counter && !disabled && <Counter value={counter} />}
         {FirstIcon && (
           <Icon

--- a/packages/yoga/src/Chips/web/__snapshots__/Chips.test.jsx.snap
+++ b/packages/yoga/src/Chips/web/__snapshots__/Chips.test.jsx.snap
@@ -2,11 +2,13 @@
 
 exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
 .c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 400;
 }
 
 .c0 {
@@ -26,13 +28,8 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   border-color: rgba(35,27,34,0.4);
   background-color: #FFFFFF;
-  color: #231B22;
-  font-weight: 400;
 }
 
 .c0:not(:last-child) {
@@ -41,9 +38,12 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -56,12 +56,19 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
   flex-shrink: 0;
 }
 
+.c0 p {
+  color: #231B22;
+}
+
 .c0:hover:enabled {
   border-color: #231B22;
 }
 
 .c0:active:enabled {
   border-color: rgba(35,27,34,0.6);
+}
+
+.c0:active:enabled p {
   color: rgba(35,27,34,0.6);
 }
 
@@ -74,17 +81,37 @@ exports[`<Chips /> Snapshots counter should match snapshot 1`] = `
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
 </div>
 `;
 
 exports[`<Chips /> Snapshots counter should match snapshot with more than one Chip 1`] = `
+.c1 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 400;
+}
+
 .c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 500;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -113,14 +140,6 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
   background-color: #FFFFFF;
 }
 
-.c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .c0 {
   height: 32px;
   max-width: 216px;
@@ -138,13 +157,8 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   border-color: rgba(35,27,34,0.4);
   background-color: #FFFFFF;
-  color: #231B22;
-  font-weight: 400;
 }
 
 .c0:not(:last-child) {
@@ -153,9 +167,12 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -168,12 +185,19 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
   flex-shrink: 0;
 }
 
+.c0 p {
+  color: #231B22;
+}
+
 .c0:hover:enabled {
   border-color: #231B22;
 }
 
 .c0:active:enabled {
   border-color: rgba(35,27,34,0.6);
+}
+
+.c0:active:enabled p {
   color: rgba(35,27,34,0.6);
 }
 
@@ -198,13 +222,8 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   background-color: #231B22;
-  color: #FFFFFF;
   border-color: transparent;
-  font-weight: 700;
 }
 
 .c2:not(:last-child) {
@@ -213,9 +232,12 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
 
 .c2[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c2[disabled] p {
+  color: #D7D7E0;
 }
 
 .c2[disabled] svg {
@@ -226,6 +248,10 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+}
+
+.c2 p {
+  color: #FFFFFF;
 }
 
 .c2:hover:enabled {
@@ -242,23 +268,23 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
   <button
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Gyms and studios
-    </span>
+    </p>
     <span
-      class="c3"
+      class="c4"
     >
       52
     </span>
@@ -267,13 +293,13 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Personal trainers
-    </span>
+    </p>
     <span
-      class="c3"
+      class="c4"
     >
       +999
     </span>
@@ -282,7 +308,27 @@ exports[`<Chips /> Snapshots counter should match snapshot with more than one Ch
 `;
 
 exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
+.c1 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 400;
+}
+
 .c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 500;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -311,14 +357,6 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   background-color: #FFFFFF;
 }
 
-.c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .c0 {
   height: 32px;
   max-width: 216px;
@@ -336,13 +374,8 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   border-color: rgba(35,27,34,0.4);
   background-color: #FFFFFF;
-  color: #231B22;
-  font-weight: 400;
 }
 
 .c0:not(:last-child) {
@@ -351,9 +384,12 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -366,12 +402,19 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   flex-shrink: 0;
 }
 
+.c0 p {
+  color: #231B22;
+}
+
 .c0:hover:enabled {
   border-color: #231B22;
 }
 
 .c0:active:enabled {
   border-color: rgba(35,27,34,0.6);
+}
+
+.c0:active:enabled p {
   color: rgba(35,27,34,0.6);
 }
 
@@ -396,13 +439,8 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   background-color: #231B22;
-  color: #FFFFFF;
   border-color: transparent;
-  font-weight: 700;
 }
 
 .c2:not(:last-child) {
@@ -411,9 +449,12 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
 
 .c2[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c2[disabled] p {
+  color: #D7D7E0;
 }
 
 .c2[disabled] svg {
@@ -424,6 +465,10 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+}
+
+.c2 p {
+  color: #FFFFFF;
 }
 
 .c2:hover:enabled {
@@ -440,53 +485,53 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Location
-    </span>
+    </p>
   </button>
   <button
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
   <button
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Gyms and studios
-    </span>
+    </p>
   </button>
   <button
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Personal trainers
-    </span>
+    </p>
   </button>
   <button
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Activities
-    </span>
+    </p>
     <span
-      class="c3"
+      class="c4"
     >
       8
     </span>
@@ -495,13 +540,13 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Language
-    </span>
+    </p>
     <span
-      class="c3"
+      class="c4"
     >
       8
     </span>
@@ -510,32 +555,34 @@ exports[`<Chips /> Snapshots icon should match selected snapshot 1`] = `
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Categories
-    </span>
+    </p>
   </button>
   <button
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Availability
-    </span>
+    </p>
   </button>
 </div>
 `;
 
 exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
 .c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 500;
 }
 
 .c0 {
@@ -555,13 +602,8 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   background-color: #231B22;
-  color: #FFFFFF;
   border-color: transparent;
-  font-weight: 700;
 }
 
 .c0:not(:last-child) {
@@ -570,9 +612,12 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -583,6 +628,10 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+}
+
+.c0 p {
+  color: #FFFFFF;
 }
 
 .c0:hover:enabled {
@@ -599,22 +648,34 @@ exports[`<Chips /> Snapshots selected should match snapshot 1`] = `
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
 </div>
 `;
 
 exports[`<Chips /> Snapshots selected should match snapshot with more than one Chip 1`] = `
 .c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 400;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 500;
 }
 
 .c0 {
@@ -634,13 +695,8 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   border-color: rgba(35,27,34,0.4);
   background-color: #FFFFFF;
-  color: #231B22;
-  font-weight: 400;
 }
 
 .c0:not(:last-child) {
@@ -649,9 +705,12 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -664,12 +723,19 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
   flex-shrink: 0;
 }
 
+.c0 p {
+  color: #231B22;
+}
+
 .c0:hover:enabled {
   border-color: #231B22;
 }
 
 .c0:active:enabled {
   border-color: rgba(35,27,34,0.6);
+}
+
+.c0:active:enabled p {
   color: rgba(35,27,34,0.6);
 }
 
@@ -694,13 +760,8 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   background-color: #231B22;
-  color: #FFFFFF;
   border-color: transparent;
-  font-weight: 700;
 }
 
 .c2:not(:last-child) {
@@ -709,9 +770,12 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
 
 .c2[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c2[disabled] p {
+  color: #D7D7E0;
 }
 
 .c2[disabled] svg {
@@ -722,6 +786,10 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+}
+
+.c2 p {
+  color: #FFFFFF;
 }
 
 .c2:hover:enabled {
@@ -738,42 +806,44 @@ exports[`<Chips /> Snapshots selected should match snapshot with more than one C
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
   <button
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Gyms and studios
-    </span>
+    </p>
   </button>
   <button
     class="c2"
     type="button"
   >
-    <span
-      class="c1"
+    <p
+      class="c3"
     >
       Personal trainers
-    </span>
+    </p>
   </button>
 </div>
 `;
 
 exports[`<Chips /> Snapshots should match snapshot 1`] = `
 .c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 400;
 }
 
 .c0 {
@@ -793,13 +863,8 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   border-color: rgba(35,27,34,0.4);
   background-color: #FFFFFF;
-  color: #231B22;
-  font-weight: 400;
 }
 
 .c0:not(:last-child) {
@@ -808,9 +873,12 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -823,12 +891,19 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
   flex-shrink: 0;
 }
 
+.c0 p {
+  color: #231B22;
+}
+
 .c0:hover:enabled {
   border-color: #231B22;
 }
 
 .c0:active:enabled {
   border-color: rgba(35,27,34,0.6);
+}
+
+.c0:active:enabled p {
   color: rgba(35,27,34,0.6);
 }
 
@@ -841,22 +916,24 @@ exports[`<Chips /> Snapshots should match snapshot 1`] = `
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
 </div>
 `;
 
 exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
 .c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 500;
 }
 
 .c0 {
@@ -876,13 +953,8 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   border-color: rgba(35,27,34,0.4);
   background-color: #FFFFFF;
-  color: #231B22;
-  font-weight: 400;
 }
 
 .c0:not(:last-child) {
@@ -891,9 +963,12 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -906,12 +981,19 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
   flex-shrink: 0;
 }
 
+.c0 p {
+  color: #231B22;
+}
+
 .c0:hover:enabled {
   border-color: #231B22;
 }
 
 .c0:active:enabled {
   border-color: rgba(35,27,34,0.6);
+}
+
+.c0:active:enabled p {
   color: rgba(35,27,34,0.6);
 }
 
@@ -925,22 +1007,24 @@ exports[`<Chips /> Snapshots should match snapshot with disabled prop 1`] = `
     disabled=""
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
 </div>
 `;
 
 exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] = `
 .c1 {
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: #231B22;
+  font-family: Rubik;
+  font-weight: 400;
 }
 
 .c0 {
@@ -960,13 +1044,8 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
   padding: 8px 12px;
   border-radius: 9999px;
   border-width: 1px;
-  font-family: Rubik;
-  font-size: 12px;
-  line-height: 16px;
   border-color: rgba(35,27,34,0.4);
   background-color: #FFFFFF;
-  color: #231B22;
-  font-weight: 400;
 }
 
 .c0:not(:last-child) {
@@ -975,9 +1054,12 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
 
 .c0[disabled] {
   background-color: #F5F5FA;
-  color: #D7D7E0;
   border-color: #F5F5FA;
   cursor: not-allowed;
+}
+
+.c0[disabled] p {
+  color: #D7D7E0;
 }
 
 .c0[disabled] svg {
@@ -990,12 +1072,19 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
   flex-shrink: 0;
 }
 
+.c0 p {
+  color: #231B22;
+}
+
 .c0:hover:enabled {
   border-color: #231B22;
 }
 
 .c0:active:enabled {
   border-color: rgba(35,27,34,0.6);
+}
+
+.c0:active:enabled p {
   color: rgba(35,27,34,0.6);
 }
 
@@ -1008,31 +1097,31 @@ exports[`<Chips /> Snapshots should match snapshot with more than one Chip 1`] =
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Classes
-    </span>
+    </p>
   </button>
   <button
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Gyms and studios
-    </span>
+    </p>
   </button>
   <button
     class="c0"
     type="button"
   >
-    <span
+    <p
       class="c1"
     >
       Personal trainers
-    </span>
+    </p>
   </button>
 </div>
 `;


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR implements the update of text nomenclatures in chips, in accordance with the guidelines of the new rebranding. The changes were applied as follows:

- For chips in the `selected` or `disabled` state, the text style was changed from `Text.Bold` to `Text.Overline`.
- For chips in the default state, the text style was updated from `Text` to `Text.Caption`.

These changes ensure that the use of chips is aligned with the new visual identity and improves consistency across the user interface.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [x] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://www.figma.com/file/Hsrgmg4oLjJxYcJHaFeuJP/%F0%9F%8E%A8-Yoga-3?type=design&node-id=51-2839&mode=design&t=8eG1HEdhvAUluXgi-0)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

| Before | After |
| ------ | ----- |
|![Simulator Screenshot - iPhone 15 Pro - 2024-03-18 at 10 50 44](https://github.com/gympass/yoga/assets/120468000/66079202-147a-4e94-86df-b894edb00bed)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-18 at 10 49 53](https://github.com/gympass/yoga/assets/120468000/708c61c1-e687-4d37-8c1b-3ac116f0e33a)|
|![Simulator Screenshot - iPhone 15 Pro - 2024-03-18 at 10 50 48](https://github.com/gympass/yoga/assets/120468000/faf98036-c753-4bc3-a31c-583e8d99fe59)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-18 at 10 49 56](https://github.com/gympass/yoga/assets/120468000/69360083-3839-43c4-b182-8fa724fc3982)|

| Before | After |
| ------ | ----- |
|<img width="1411" alt="Captura de Tela 2024-03-18 às 10 56 29" src="https://github.com/gympass/yoga/assets/120468000/d43c087c-c702-45b2-93ea-a77eea975b73">|<img width="1411" alt="Captura de Tela 2024-03-18 às 10 55 18" src="https://github.com/gympass/yoga/assets/120468000/06f3f4a6-e4a8-46dc-ba02-5d3e0e454106">|
|<img width="1411" alt="Captura de Tela 2024-03-18 às 10 56 46" src="https://github.com/gympass/yoga/assets/120468000/42744e90-9ab5-4ec8-9066-9c56f1f63405">|<img width="1411" alt="Captura de Tela 2024-03-18 às 10 55 37" src="https://github.com/gympass/yoga/assets/120468000/e0c220cd-80f6-42ab-8dc2-0b953d1538bc">|
|<img width="1411" alt="Captura de Tela 2024-03-18 às 10 56 56" src="https://github.com/gympass/yoga/assets/120468000/9e705157-4bff-4695-a73b-e67b7c760827">|<img width="1411" alt="Captura de Tela 2024-03-18 às 10 56 01" src="https://github.com/gympass/yoga/assets/120468000/e715a676-7dbe-4dae-9b1f-7a187ce76f81">|
