### PR TITLE
🚀 [EUEG-3190 | DS-800] Update PlanCard component to use the correct font-weight

### DIFF
--- a/packages/yoga/src/Card/web/PlanCard/Content.jsx
+++ b/packages/yoga/src/Card/web/PlanCard/Content.jsx
@@ -12,7 +12,7 @@ const Wrapper = styled(Content)`
   flex: 1;
 `;
 
-const Title = styled(Text.Medium)`
+const Title = styled(Text.Body1)`
   ${props => {
     const {
       components: { card, cardweb },
@@ -90,7 +90,11 @@ const PlanCardContent = ({
 }) => (
   <Wrapper {...rest}>
     {subtitle && <Subtitle>{subtitle}</Subtitle>}
-    {title && <Title badgeColor={badgeColor}>{title}</Title>}
+    {title && (
+      <Title bold badgeColor={badgeColor}>
+        {title}
+      </Title>
+    )}
     {description && <Description>{description}</Description>}
     {!!price && (
       <Price>

--- a/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
+++ b/packages/yoga/src/Card/web/PlanCard/__snapshots__/PlanCard.test.jsx.snap
@@ -126,6 +126,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with default PlanCard 1`] 
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;
@@ -510,6 +511,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with suffix 1`] = `
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;
@@ -673,6 +675,7 @@ exports[`<PlanCard /> Snapshots should match snapshot with variant 1`] = `
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;
@@ -914,6 +917,7 @@ exports[`<PlanCard /> Snapshots should render list item content as button 1`] = 
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;
@@ -1293,6 +1297,7 @@ exports[`<PlanCard /> Snapshots should render the discount 1`] = `
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;
@@ -1439,6 +1444,7 @@ exports[`<PlanCard /> Snapshots should render the extra content 1`] = `
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;
@@ -1518,6 +1524,7 @@ exports[`<PlanCard /> Snapshots should render the title with a colored badge 1`]
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;
@@ -1549,6 +1556,7 @@ exports[`<PlanCard /> Snapshots should render the title without a colored badge 
   margin: 0;
   padding: 0;
   font-size: 16px;
+  line-height: 24px;
   color: #231B22;
   font-family: Rubik;
   font-weight: 500;


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/EUEG-3190)
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/DS-800)

## Description 📄


We are updating the PlanCard title component to use the correct new Text style component.


## Platforms 📲

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Screenshots 📸

The update was just on the title prop for PlanCard component

| v2 | v3 Before | v3 After |
|--------|--------|--------|
| <img src="https://github.com/gympass/yoga/assets/44280864/b5f9123f-b440-42e0-a25e-f5b97ad6c251" width="300px" /> | <img src="https://github.com/gympass/yoga/assets/44280864/683f997e-5e5e-4434-8e82-c5064b7a27d0" width="300px" /> | <img src="https://github.com/gympass/yoga/assets/44280864/d4dd54a8-01a2-4e4f-bc48-63ac0bb032a9" width="300px" /> |

