### PR TITLE
style: create fixed color condition for new icons

### DIFF
--- a/packages/yoga/src/Icon/Icon.jsx
+++ b/packages/yoga/src/Icon/Icon.jsx
@@ -25,6 +25,8 @@ const Icon = ({
   ariaLabel,
   ...props
 }) => {
+  const fixedColorIcons = ['Attention', 'Delayed', 'Information', 'Success'];
+
   const componentWithTitle = propsTitle => {
     const titleId = `${ariaLabel}-titleId`;
     let ariaDescribedBy = titleId;
@@ -65,13 +67,16 @@ const Icon = ({
     return newSvg;
   };
 
+  const isColorable = !fixedColorIcons.includes(Component.name);
+
   return (
     <Box
       as={title && ariaLabel ? componentWithTitle : Component}
       width={get(theme.yoga.spacing, width, width)}
       height={get(theme.yoga.spacing, height, height)}
-      {...(fill && { fill: get(theme.yoga.colors, fill, fill) })}
-      {...(stroke && { stroke: get(theme.yoga.colors, stroke, stroke) })}
+      {...(fill && isColorable && { fill: get(theme.yoga.colors, fill, fill) })}
+      {...(stroke &&
+        isColorable && { stroke: get(theme.yoga.colors, stroke, stroke) })}
       {...props}
       aria-hidden={title ? undefined : true}
     />


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/DS-817)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Creates a new condition so that icons with fixed colors do not overwrite fill and stroke attributes with props

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [x] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
| <img width="1236" alt="Captura de Tela 2024-04-04 às 11 11 18" src="https://github.com/gympass/yoga/assets/141175689/01118a55-b260-48ce-acf6-d0cf5cfa0906"> | <img width="1236" alt="Captura de Tela 2024-04-04 às 11 11 43" src="https://github.com/gympass/yoga/assets/141175689/57811505-0988-4ac2-a33c-535f66ec76d6"> |
