### PR TITLE
🐞 fix(NavigationMenu): changed item tag font color

### DIFF
--- a/packages/yoga/src/NavigationMenu/web/Item/styles.ts
+++ b/packages/yoga/src/NavigationMenu/web/Item/styles.ts
@@ -36,10 +36,13 @@ export const StyledTag = styled(Tag)`
       },
     },
   }) => css`
-    text-transform: uppercase;
     background-color: ${backgroundColor.tag};
-    color: ${tag.color.default};
     border-radius: ${border.radius.tag}px;
+
+    p {
+      color: ${tag.color.default};
+      text-transform: uppercase;
+    }
   `}
 `;
 

--- a/packages/yoga/src/NavigationMenu/web/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/packages/yoga/src/NavigationMenu/web/__snapshots__/NavigationMenu.test.tsx.snap
@@ -226,10 +226,13 @@ exports[`<NavigationMenu /> Snapshots should match NavigationMenu 1`] = `
 }
 
 .c19 {
-  text-transform: uppercase;
   background-color: #231B22;
-  color: #FFFFFF;
   border-radius: 9999px;
+}
+
+.c19 p {
+  color: #FFFFFF;
+  text-transform: uppercase;
 }
 
 .c16 {


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/PAC-208)

## Description 📄
After updates made on `Tag` component for v3 Theme, the `NavigationMenu` component couldn't customize its `Item` tags font color, being unreadable.

## Platforms 📲
- [x] Web
- [ ] Mobile

## Type of change 🔍
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪
- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍
- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸
| Before | After |
| ------ | ----- |
| <img width="1125" alt="image" src="https://github.com/gympass/yoga/assets/26771441/2f8fb9ac-5d92-4c1a-8725-af202322c6b0"> | <img width="1127" alt="image" src="https://github.com/gympass/yoga/assets/26771441/93b4d4ea-c66f-4989-8f02-838a653a61fa"> |
