### PR TITLE
[DS-838] - Font-Weight typing

### DIFF
--- a/packages/system/src/font-weight/fontWeight.android.ts
+++ b/packages/system/src/font-weight/fontWeight.android.ts
@@ -1,4 +1,4 @@
-import { getFontWeight, generator } from './theme';
+import { getFontWeight, generator } from '../theme';
 
 export const fontWeight = props =>
   generator({

--- a/packages/system/src/font-weight/fontWeight.ts
+++ b/packages/system/src/font-weight/fontWeight.ts
@@ -1,4 +1,4 @@
-import { getFontWeight, generator } from './theme';
+import { getFontWeight, generator } from '../theme';
 
 export const fontWeight = props =>
   generator({

--- a/packages/system/src/font-weight/index.ts
+++ b/packages/system/src/font-weight/index.ts
@@ -1,0 +1,2 @@
+export * from './fontWeight';
+export type { FontWeights } from './types';

--- a/packages/system/src/font-weight/types.ts
+++ b/packages/system/src/font-weight/types.ts
@@ -1,0 +1,8 @@
+import { fontWeights } from '@gympass/yoga-tokens';
+
+type FontWeightsValues = typeof fontWeights | string | number;
+
+export type FontWeights = {
+  fontWeight?: FontWeightsValues;
+  fw?: FontWeightsValues;
+};

--- a/packages/system/src/typography.js
+++ b/packages/system/src/typography.js
@@ -7,7 +7,7 @@ import {
   compose,
 } from './theme';
 
-import { fontWeight } from './fontWeight';
+import { fontWeight } from './font-weigh';
 
 const color = props =>
   generator({

--- a/packages/system/src/typography.js
+++ b/packages/system/src/typography.js
@@ -7,7 +7,7 @@ import {
   compose,
 } from './theme';
 
-import { fontWeight } from './font-weigh';
+import { fontWeight } from './font-weight';
 
 const color = props =>
   generator({

--- a/packages/system/src/typography.test.js
+++ b/packages/system/src/typography.test.js
@@ -9,7 +9,7 @@ import {
   textTransform,
 } from './typography';
 
-import { fontWeight as fontWeightAndroid } from './fontWeight.android';
+import { fontWeight as fontWeightAndroid } from './font-weight/fontWeight.android';
 
 const fontSizes = [10, 20, 40];
 


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/DS-838)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Add font-weight types

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [x] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Run the project and check the documentation

- [x] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

`not applicable`
