### PR TITLE
🚀 feat: added accordion button props so we can customize type

### DIFF
--- a/packages/yoga/src/Accordion/web/Accordion.jsx
+++ b/packages/yoga/src/Accordion/web/Accordion.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
-import { string, node, bool } from 'prop-types';
+import { string, node, bool, shape } from 'prop-types';
 import { ChevronDown } from '@gympass/yoga-icons';
 import { Text, Divider } from '../..';
 import Content from './Content';
@@ -206,6 +206,7 @@ const Accordion = ({
   expanded,
   small,
   hasHorizontalPadding,
+  headerProps,
   ...props
 }) => {
   const [open, setOpen] = useState(expanded);
@@ -220,9 +221,13 @@ const Accordion = ({
         disabled={disabled}
         onClick={() => {
           setOpen(o => !o);
+          if (typeof headerProps.onClick === 'function') {
+            headerProps.onClick();
+          }
         }}
         small={small}
         hasHorizontalPadding={hasHorizontalPadding}
+        {...headerProps}
       >
         {hasSummary ? (
           summary
@@ -270,6 +275,9 @@ Accordion.propTypes = {
   expanded: bool,
   small: bool,
   hasHorizontalPadding: bool,
+  /** if provided displays a button below the item text. It accepts all button
+   * element props */
+  headerProps: shape({}),
 };
 
 Accordion.defaultProps = {
@@ -279,6 +287,7 @@ Accordion.defaultProps = {
   expanded: false,
   small: false,
   hasHorizontalPadding: true,
+  headerProps: {},
 };
 
 export default Accordion;


### PR DESCRIPTION
## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Added header props to accordion

The goal of this PR is to help solve an issue related with the type of the button inside forms. 
The bug we have is trigger everytime we click on the accordion header (button) that causes the form to be submitted.
Behaviour we don't want. To avoid this I added the props of the button so we can modify it's type.

Also added the onClick function in case someone in the future requires to track the event fired by the button, this can be removed since we don't need it at the moment and just thought it was a nice addition.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

https://github.com/gympass/yoga/assets/11175904/aed06f94-8876-46d6-9068-202074ea06a2


[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
