### PR TITLE
feat: [EXUX-930] Fix ellipsis/truncate problem on android

### DIFF
--- a/packages/yoga/src/Avatar/native/Avatar.jsx
+++ b/packages/yoga/src/Avatar/native/Avatar.jsx
@@ -50,6 +50,7 @@ const Avatar = forwardRef(
       borderRadius,
       width,
       height,
+      onLayout,
       ...props
     },
     ref,
@@ -63,6 +64,7 @@ const Avatar = forwardRef(
         justifyContent="center"
         width={width}
         height={height}
+        onLayout={onLayout}
         overflow="hidden"
         borderRadius={borderRadius}
         {...props}

--- a/packages/yoga/src/Result/native/Result/TextWithBadge.jsx
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge.jsx
@@ -1,0 +1,74 @@
+import React, { useCallback, useState } from 'react';
+import { useWindowDimensions } from 'react-native';
+import { string, number, node } from 'prop-types';
+
+import Text from '../../../Text';
+import Box from '../../../Box';
+import Badge from '../Badge';
+
+const SCREEN_PADDINGS = 20;
+const CONTENT_MARGINS = 20;
+const AVATAR_CONTENT_MARGINS = 16;
+const BADGE_LIMIT = 20;
+
+const TextWithBadge = ({ avatarWidth, badgeIcon, title }) => {
+  const [textSize, setTextSize] = useState(0);
+  const { width: windowWidth } = useWindowDimensions();
+
+  const textMaxSize =
+    windowWidth -
+    (SCREEN_PADDINGS + CONTENT_MARGINS + AVATAR_CONTENT_MARGINS + avatarWidth);
+  const shouldTruncate = textSize >= textMaxSize - BADGE_LIMIT;
+  const containerWidth = shouldTruncate ? null : textSize;
+  const textWidth = shouldTruncate ? '100%' : null;
+
+  const onTextLayout = useCallback(event => {
+    const { width } = event.nativeEvent.layout;
+
+    setTextSize(width);
+  }, []);
+
+  return (
+    <Box
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="flex-end"
+      position="relative"
+      width={containerWidth}
+    >
+      <Text.Body1
+        onLayout={onTextLayout}
+        bold
+        position="absolute"
+        left={0}
+        numberOfLines={1}
+        paddingRight="medium"
+        flex={1}
+        width={textWidth}
+      >
+        {title}
+      </Text.Body1>
+      <Badge
+        icon={badgeIcon}
+        fill="text.primary"
+        ml="xxxsmall"
+        bg="neon"
+        justifyContent="center"
+        alignItems="center"
+        borderRadius="circle"
+        w="small"
+        h="small"
+      />
+    </Box>
+  );
+};
+
+TextWithBadge.propTypes = {
+  avatarWidth: number.isRequired,
+  badgeIcon: node.isRequired,
+  title: string.isRequired,
+};
+
+TextWithBadge.defaultProps = {};
+
+export default TextWithBadge;

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/__snapshots__/index.test.tsx.snap
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,244 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextWithBadge should match snapshot 1`] = `
+<View
+  containerWidth={0}
+  style={
+    [
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "position": "relative",
+        "width": 0,
+      },
+    ]
+  }
+>
+  <Text
+    bold={true}
+    numberOfLines={1}
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "color": "#231B22",
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontFamily": "Rubik",
+          "fontSize": 16,
+          "fontWeight": "500",
+          "left": 0,
+          "lineHeight": 24,
+          "paddingRight": 20,
+          "position": "absolute",
+          "width": "",
+        },
+      ]
+    }
+    textWidth={null}
+  >
+    Text with badge
+  </Text>
+  <View
+    alignItems="center"
+    bg="neon"
+    borderRadius="circle"
+    h="small"
+    justifyContent="center"
+    ml="xxxsmall"
+    style={
+      [
+        {
+          "alignItems": "center",
+          "backgroundColor": "#DCFF79",
+          "borderRadius": 9999,
+          "height": 16,
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": 16,
+        },
+      ]
+    }
+    w="small"
+  >
+    <View
+      aria-hidden={true}
+      fill="#231B22"
+      height={10.67}
+      style={
+        [
+          {
+            "height": 10.67,
+            "width": 10.67,
+          },
+        ]
+      }
+      width={10.67}
+    />
+  </View>
+</View>
+`;
+
+exports[`TextWithBadge should match snapshot with long title 1`] = `
+<View
+  containerWidth={0}
+  style={
+    [
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "position": "relative",
+        "width": 0,
+      },
+    ]
+  }
+>
+  <Text
+    bold={true}
+    numberOfLines={1}
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "color": "#231B22",
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontFamily": "Rubik",
+          "fontSize": 16,
+          "fontWeight": "500",
+          "left": 0,
+          "lineHeight": 24,
+          "paddingRight": 20,
+          "position": "absolute",
+          "width": "",
+        },
+      ]
+    }
+    textWidth={null}
+  >
+    This is an example of a very long title that should be truncated
+  </Text>
+  <View
+    alignItems="center"
+    bg="neon"
+    borderRadius="circle"
+    h="small"
+    justifyContent="center"
+    ml="xxxsmall"
+    style={
+      [
+        {
+          "alignItems": "center",
+          "backgroundColor": "#DCFF79",
+          "borderRadius": 9999,
+          "height": 16,
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": 16,
+        },
+      ]
+    }
+    w="small"
+  >
+    <View
+      aria-hidden={true}
+      fill="#231B22"
+      height={10.67}
+      style={
+        [
+          {
+            "height": 10.67,
+            "width": 10.67,
+          },
+        ]
+      }
+      width={10.67}
+    />
+  </View>
+</View>
+`;
+
+exports[`TextWithBadge should match snapshot without badgeIcon 1`] = `
+<View
+  containerWidth={0}
+  style={
+    [
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "position": "relative",
+        "width": 0,
+      },
+    ]
+  }
+>
+  <Text
+    bold={true}
+    numberOfLines={1}
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "color": "#231B22",
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontFamily": "Rubik",
+          "fontSize": 16,
+          "fontWeight": "500",
+          "left": 0,
+          "lineHeight": 24,
+          "paddingRight": 20,
+          "position": "absolute",
+          "width": "",
+        },
+      ]
+    }
+    textWidth={null}
+  >
+    Title without Badge
+  </Text>
+  <View
+    alignItems="center"
+    bg="neon"
+    borderRadius="circle"
+    h="small"
+    justifyContent="center"
+    ml="xxxsmall"
+    style={
+      [
+        {
+          "alignItems": "center",
+          "backgroundColor": "#DCFF79",
+          "borderRadius": 9999,
+          "height": 16,
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": 16,
+        },
+      ]
+    }
+    w="small"
+  >
+    <View
+      aria-hidden={true}
+      fill="#231B22"
+      height={10.67}
+      style={
+        [
+          {
+            "height": 10.67,
+            "width": 10.67,
+          },
+        ]
+      }
+      width={10.67}
+    />
+  </View>
+</View>
+`;

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/__snapshots__/index.test.tsx.snap
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/__snapshots__/index.test.tsx.snap
@@ -63,20 +63,83 @@ exports[`TextWithBadge should match snapshot 1`] = `
     }
     w="small"
   >
-    <View
+    <RNSVGSvgView
       aria-hidden={true}
+      bbHeight={10.67}
+      bbWidth={10.67}
       fill="#231B22"
+      focusable={false}
       height={10.67}
       style={
         [
           {
-            "height": 10.67,
-            "width": 10.67,
+            "backgroundColor": "transparent",
+            "borderWidth": 0,
+          },
+          [
+            {
+              "height": 10.67,
+              "width": 10.67,
+            },
+          ],
+          {
+            "opacity": 1,
+          },
+          {
+            "flex": 0,
+            "height": 10,
+            "width": 10,
           },
         ]
       }
       width={10.67}
-    />
+    >
+      <RNSVGGroup
+        fill={
+          [
+            0,
+            4280490786,
+          ]
+        }
+        fillOpacity={1}
+        fillRule={1}
+        font={{}}
+        matrix={
+          [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ]
+        }
+        opacity={1}
+        originX={0}
+        originY={0}
+        propList={
+          [
+            "fill",
+          ]
+        }
+        rotation={0}
+        scaleX={1}
+        scaleY={1}
+        skewX={0}
+        skewY={0}
+        stroke={null}
+        strokeDasharray={null}
+        strokeDashoffset={null}
+        strokeLinecap={0}
+        strokeLinejoin={0}
+        strokeMiterlimit={4}
+        strokeOpacity={1}
+        strokeWidth={1}
+        vectorEffect={0}
+        x={0}
+        y={0}
+      />
+    </RNSVGSvgView>
   </View>
 </View>
 `;
@@ -144,20 +207,83 @@ exports[`TextWithBadge should match snapshot with long title 1`] = `
     }
     w="small"
   >
-    <View
+    <RNSVGSvgView
       aria-hidden={true}
+      bbHeight={10.67}
+      bbWidth={10.67}
       fill="#231B22"
+      focusable={false}
       height={10.67}
       style={
         [
           {
-            "height": 10.67,
-            "width": 10.67,
+            "backgroundColor": "transparent",
+            "borderWidth": 0,
+          },
+          [
+            {
+              "height": 10.67,
+              "width": 10.67,
+            },
+          ],
+          {
+            "opacity": 1,
+          },
+          {
+            "flex": 0,
+            "height": 10,
+            "width": 10,
           },
         ]
       }
       width={10.67}
-    />
+    >
+      <RNSVGGroup
+        fill={
+          [
+            0,
+            4280490786,
+          ]
+        }
+        fillOpacity={1}
+        fillRule={1}
+        font={{}}
+        matrix={
+          [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ]
+        }
+        opacity={1}
+        originX={0}
+        originY={0}
+        propList={
+          [
+            "fill",
+          ]
+        }
+        rotation={0}
+        scaleX={1}
+        scaleY={1}
+        skewX={0}
+        skewY={0}
+        stroke={null}
+        strokeDasharray={null}
+        strokeDashoffset={null}
+        strokeLinecap={0}
+        strokeLinejoin={0}
+        strokeMiterlimit={4}
+        strokeOpacity={1}
+        strokeWidth={1}
+        vectorEffect={0}
+        x={0}
+        y={0}
+      />
+    </RNSVGSvgView>
   </View>
 </View>
 `;

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { WellhubIcon } from '@gympass/yoga-icons/src/svg/icon_wellhub.svg';
+import { WellhubIcon } from '@gympass/yoga-icons';
 
 import { ThemeProvider } from '../../../../index';
 import TextWithBadge from '.';

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { WellhubIcon } from '@gympass/yoga-icons/src/svg/icon_wellhub.svg';
+
 import { ThemeProvider } from '../../../../index';
 import TextWithBadge from '.';
-
-import { WellhubIcon } from '@gympass/yoga-icons/src/svg/icon_wellhub.svg';
 
 describe('TextWithBadge', () => {
   it('should match snapshot', () => {

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ThemeProvider } from '../../../../index';
+import TextWithBadge from '.';
+
+import { WellhubIcon } from '../../../../../../icons/src/svg/icon_wellhub.svg';
+
+describe('TextWithBadge', () => {
+  it('should match snapshot', () => {
+    const { toJSON } = render(
+      <ThemeProvider>
+        <TextWithBadge
+          avatarWidth={50}
+          badgeIcon={WellhubIcon}
+          title="Text with badge"
+        />
+      </ThemeProvider>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should match snapshot with long title', () => {
+    const { toJSON } = render(
+      <ThemeProvider>
+        <TextWithBadge
+          avatarWidth={50}
+          badgeIcon={WellhubIcon}
+          title="This is an example of a very long title that should be truncated"
+        />
+      </ThemeProvider>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should match snapshot without badgeIcon', () => {
+    const { toJSON } = render(
+      <ThemeProvider>
+        <TextWithBadge
+          avatarWidth={50}
+          badgeIcon={null}
+          title="Title without Badge"
+        />
+      </ThemeProvider>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/index.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native';
 import { ThemeProvider } from '../../../../index';
 import TextWithBadge from '.';
 
-import { WellhubIcon } from '../../../../../../icons/src/svg/icon_wellhub.svg';
+import { WellhubIcon } from '@gympass/yoga-icons/src/svg/icon_wellhub.svg';
 
 describe('TextWithBadge', () => {
   it('should match snapshot', () => {

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/index.tsx
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/index.tsx
@@ -1,18 +1,27 @@
-import React, { useCallback, useState } from 'react';
+import React, { ReactNode, useCallback, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
-import { string, number, node } from 'prop-types';
 
-import Text from '../../../Text';
-import Box from '../../../Box';
-import Badge from '../Badge';
+import Badge from '../../Badge';
+
+import { StyledBoxContainer, StyledText } from './styles';
+
+interface TextWithBadgeProps {
+  avatarWidth: number;
+  badgeIcon: ReactNode;
+  title: string;
+}
 
 const SCREEN_PADDINGS = 20;
 const CONTENT_MARGINS = 20;
 const AVATAR_CONTENT_MARGINS = 16;
 const BADGE_LIMIT = 20;
 
-const TextWithBadge = ({ avatarWidth, badgeIcon, title }) => {
-  const [textSize, setTextSize] = useState(0);
+const TextWithBadge = ({
+  avatarWidth,
+  badgeIcon,
+  title,
+}: TextWithBadgeProps) => {
+  const [textSize, setTextSize] = useState<number>(0);
   const { width: windowWidth } = useWindowDimensions();
 
   const textMaxSize =
@@ -29,25 +38,15 @@ const TextWithBadge = ({ avatarWidth, badgeIcon, title }) => {
   }, []);
 
   return (
-    <Box
-      flexDirection="row"
-      alignItems="center"
-      justifyContent="flex-end"
-      position="relative"
-      width={containerWidth}
-    >
-      <Text.Body1
+    <StyledBoxContainer containerWidth={containerWidth}>
+      <StyledText
         onLayout={onTextLayout}
         bold
-        position="absolute"
-        left={0}
         numberOfLines={1}
-        paddingRight="medium"
-        flex={1}
-        width={textWidth}
+        textWidth={textWidth}
       >
         {title}
-      </Text.Body1>
+      </StyledText>
       <Badge
         icon={badgeIcon}
         fill="text.primary"
@@ -59,16 +58,8 @@ const TextWithBadge = ({ avatarWidth, badgeIcon, title }) => {
         w="small"
         h="small"
       />
-    </Box>
+    </StyledBoxContainer>
   );
 };
-
-TextWithBadge.propTypes = {
-  avatarWidth: number.isRequired,
-  badgeIcon: node.isRequired,
-  title: string.isRequired,
-};
-
-TextWithBadge.defaultProps = {};
 
 export default TextWithBadge;

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/index.tsx
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/index.tsx
@@ -31,11 +31,16 @@ const TextWithBadge = ({
   const containerWidth = shouldTruncate ? null : textSize;
   const textWidth = shouldTruncate ? '100%' : null;
 
-  const onTextLayout = useCallback(event => {
-    const { width } = event.nativeEvent.layout;
-
-    setTextSize(width);
-  }, []);
+  const onTextLayout = useCallback(
+    ({
+      nativeEvent: {
+        layout: { width },
+      },
+    }) => {
+      setTextSize(width);
+    },
+    [],
+  );
 
   return (
     <StyledBoxContainer containerWidth={containerWidth}>

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/styles.ts
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/styles.ts
@@ -18,7 +18,7 @@ export const StyledBoxContainer = styled(Box)<{
 `;
 
 export const StyledText = styled(Text.Body1)<{
-  onLayout: (event: any) => void;
+  onLayout: ({ nativeEvent: { layout } }) => void;
   textWidth?: string | null;
   numberOfLines: number;
   bold: boolean;

--- a/packages/yoga/src/Result/native/Result/TextWithBadge/styles.ts
+++ b/packages/yoga/src/Result/native/Result/TextWithBadge/styles.ts
@@ -1,0 +1,42 @@
+import React, { ReactNode } from 'react';
+import styled, { css } from 'styled-components';
+import Text from '../../../../Text';
+import Box from '../../../../Box';
+
+export const StyledBoxContainer = styled(Box)<{
+  containerWidth?: number | null;
+  children: ReactNode;
+}>`
+  ${({ containerWidth }) =>
+    css`
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-end;
+      position: relative;
+      width: ${containerWidth}px;
+    `}
+`;
+
+export const StyledText = styled(Text.Body1)<{
+  onLayout: (event: any) => void;
+  textWidth?: string | null;
+  numberOfLines: number;
+  bold: boolean;
+  children: React.ReactNode;
+}>`
+  ${({
+    textWidth,
+    theme: {
+      yoga: {
+        spacing: { medium },
+      },
+    },
+  }) =>
+    css`
+      position: absolute;
+      left: 0;
+      padding-right: ${medium};
+      flex: 1;
+      width: ${textWidth};
+    `}
+`;

--- a/packages/yoga/src/Result/native/Result/__snapshots__/index.test.jsx.snap
+++ b/packages/yoga/src/Result/native/Result/__snapshots__/index.test.jsx.snap
@@ -24,6 +24,7 @@ exports[`<Result /> should match snapshot 1`] = `
     display="flex"
     height={48}
     justifyContent="center"
+    onLayout={[Function]}
     overflow="hidden"
     style={
       [
@@ -533,16 +534,9 @@ exports[`<Result /> should match snapshot 1`] = `
       </View>
     </View>
     <View
-      alignItems="center"
-      flexDirection="row"
-      marginRight="zero"
       style={
         [
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "marginRight": 0,
-          },
+          {},
         ]
       }
     >
@@ -1056,6 +1050,7 @@ exports[`<Result /> should match snapshot without attendence 1`] = `
     display="flex"
     height={48}
     justifyContent="center"
+    onLayout={[Function]}
     overflow="hidden"
     style={
       [
@@ -1184,16 +1179,9 @@ exports[`<Result /> should match snapshot without attendence 1`] = `
     }
   >
     <View
-      alignItems="center"
-      flexDirection="row"
-      marginRight="zero"
       style={
         [
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "marginRight": 0,
-          },
+          {},
         ]
       }
     >
@@ -1573,6 +1561,7 @@ exports[`<Result /> should match snapshot without limitLabel prop 1`] = `
     display="flex"
     height={48}
     justifyContent="center"
+    onLayout={[Function]}
     overflow="hidden"
     style={
       [
@@ -2082,16 +2071,9 @@ exports[`<Result /> should match snapshot without limitLabel prop 1`] = `
       </View>
     </View>
     <View
-      alignItems="center"
-      flexDirection="row"
-      marginRight="zero"
       style={
         [
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "marginRight": 0,
-          },
+          {},
         ]
       }
     >

--- a/packages/yoga/src/Result/native/Result/index.jsx
+++ b/packages/yoga/src/Result/native/Result/index.jsx
@@ -25,11 +25,16 @@ const Result = ({
 }) => {
   const [avatarWidth, setAvatarWidth] = useState(0);
 
-  const onAvatarLayout = useCallback(event => {
-    const { width } = event.nativeEvent.layout;
-
-    setAvatarWidth(width);
-  }, []);
+  const onAvatarLayout = useCallback(
+    ({
+      nativeEvent: {
+        layout: { width },
+      },
+    }) => {
+      setAvatarWidth(width);
+    },
+    [],
+  );
 
   return (
     <StyledBox divided={divided} display="flex" flexDirection="row">

--- a/packages/yoga/src/Result/native/Result/index.jsx
+++ b/packages/yoga/src/Result/native/Result/index.jsx
@@ -1,13 +1,12 @@
-import React, { isValidElement, useState } from 'react';
-
+import React, { isValidElement, useCallback, useState } from 'react';
 import { arrayOf, string, shape, func, bool, node } from 'prop-types';
 
 import Text from '../../../Text';
 import Box from '../../../Box';
 import Attendances from '../Attendances';
-import Badge from '../Badge';
 
 import { Content, StyledBox } from './styles';
+import TextWithBadge from './TextWithBadge';
 
 /**
  * The Result component is used when you have a list to show. It is applied to
@@ -24,17 +23,25 @@ const Result = ({
   attendancesColor,
   badgeIcon,
 }) => {
-  const [textWidth, setTextWidth] = useState(0);
+  const [avatarWidth, setAvatarWidth] = useState(0);
 
-  const onTextLayout = event => {
+  const onAvatarLayout = useCallback(event => {
     const { width } = event.nativeEvent.layout;
 
-    setTextWidth(width);
-  };
+    setAvatarWidth(width);
+  }, []);
 
   return (
     <StyledBox divided={divided} display="flex" flexDirection="row">
-      {Avatar && <>{isValidElement(Avatar) ? Avatar : <Avatar />}</>}
+      {Avatar && (
+        <>
+          {isValidElement(Avatar) ? (
+            React.cloneElement(Avatar, { onLayout: onAvatarLayout })
+          ) : (
+            <Avatar onLayout={onAvatarLayout} />
+          )}
+        </>
+      )}
       <Content>
         {!!attendances?.length && (
           <Attendances
@@ -43,43 +50,19 @@ const Result = ({
             color={attendancesColor}
           />
         )}
-        <Box
-          flexDirection="row"
-          alignItems="center"
-          position="relative"
-          bg="yellow"
-        >
-          <Box flex={1}>
-            <Text.Body1
-              onLayout={onTextLayout}
-              numberOfLines={1}
-              bold
-              bg="cyan"
-            >
-              {/* Very very reallyveryveryveryveryeys long text text */}
-              {/* Veryaaaaaaffdfdf verysadddaaefesss reallyveryveryveryveryeysaaaa */}
-              {/* Medium text example */}
-              {/* Shortasasassdasas texttextreallyshortaf right here ellipsis */}
-              Short Text
-              {/* Academi a hahahah acomaaaan omegrandea sasadeverdade */}
+        {badgeIcon ? (
+          <TextWithBadge
+            avatarWidth={avatarWidth}
+            badgeIcon={badgeIcon}
+            title={title}
+          />
+        ) : (
+          <Box>
+            <Text.Body1 bold numberOfLines={1}>
+              {title}
             </Text.Body1>
           </Box>
-          {true && (
-            <Badge
-              left={textWidth - 24}
-              icon={badgeIcon}
-              fill="text.primary"
-              ml="xxxsmall"
-              bg="neon"
-              justifyContent="center"
-              alignItems="center"
-              borderRadius="circle"
-              w="small"
-              h="small"
-              position="absolute"
-            />
-          )}
-        </Box>
+        )}
         {subTitle && subTitle !== '' && (
           <Text.Body2 numberOfLines={1} color="deep">
             {subTitle}

--- a/packages/yoga/src/Result/native/Result/index.jsx
+++ b/packages/yoga/src/Result/native/Result/index.jsx
@@ -1,4 +1,4 @@
-import React, { isValidElement } from 'react';
+import React, { isValidElement, useState } from 'react';
 
 import { arrayOf, string, shape, func, bool, node } from 'prop-types';
 
@@ -23,48 +23,73 @@ const Result = ({
   children,
   attendancesColor,
   badgeIcon,
-}) => (
-  <StyledBox divided={divided} display="flex" flexDirection="row">
-    {Avatar && <>{isValidElement(Avatar) ? Avatar : <Avatar />}</>}
-    <Content>
-      {!!attendances?.length && (
-        <Attendances
-          attendances={attendances}
-          rate={rate}
-          color={attendancesColor}
-        />
-      )}
-      <Box
-        flexDirection="row"
-        alignItems="center"
-        marginRight={badgeIcon ? 'small' : 'zero'}
-      >
-        <Text.Body1 numberOfLines={1} bold>
-          {title}
-        </Text.Body1>
-        {badgeIcon && (
-          <Badge
-            icon={badgeIcon}
-            fill="text.primary"
-            ml="xxxsmall"
-            bg="neon"
-            justifyContent="center"
-            alignItems="center"
-            borderRadius="circle"
-            w="small"
-            h="small"
+}) => {
+  const [textWidth, setTextWidth] = useState(0);
+
+  const onTextLayout = event => {
+    const { width } = event.nativeEvent.layout;
+
+    setTextWidth(width);
+  };
+
+  return (
+    <StyledBox divided={divided} display="flex" flexDirection="row">
+      {Avatar && <>{isValidElement(Avatar) ? Avatar : <Avatar />}</>}
+      <Content>
+        {!!attendances?.length && (
+          <Attendances
+            attendances={attendances}
+            rate={rate}
+            color={attendancesColor}
           />
         )}
-      </Box>
-      {subTitle && subTitle !== '' && (
-        <Text.Body2 numberOfLines={1} color="deep">
-          {subTitle}
-        </Text.Body2>
-      )}
-      {children}
-    </Content>
-  </StyledBox>
-);
+        <Box
+          flexDirection="row"
+          alignItems="center"
+          position="relative"
+          bg="yellow"
+        >
+          <Box flex={1}>
+            <Text.Body1
+              onLayout={onTextLayout}
+              numberOfLines={1}
+              bold
+              bg="cyan"
+            >
+              {/* Very very reallyveryveryveryveryeys long text text */}
+              {/* Veryaaaaaaffdfdf verysadddaaefesss reallyveryveryveryveryeysaaaa */}
+              {/* Medium text example */}
+              {/* Shortasasassdasas texttextreallyshortaf right here ellipsis */}
+              Short Text
+              {/* Academi a hahahah acomaaaan omegrandea sasadeverdade */}
+            </Text.Body1>
+          </Box>
+          {true && (
+            <Badge
+              left={textWidth - 24}
+              icon={badgeIcon}
+              fill="text.primary"
+              ml="xxxsmall"
+              bg="neon"
+              justifyContent="center"
+              alignItems="center"
+              borderRadius="circle"
+              w="small"
+              h="small"
+              position="absolute"
+            />
+          )}
+        </Box>
+        {subTitle && subTitle !== '' && (
+          <Text.Body2 numberOfLines={1} color="deep">
+            {subTitle}
+          </Text.Body2>
+        )}
+        {children}
+      </Content>
+    </StyledBox>
+  );
+};
 
 Result.propTypes = {
   /** The component Avatar */


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/EXUX-930)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

Add new `TextWithBadge` component to `Result` component.

**Context**.
It was necessary to implement a new style for custom `TextWithBadge` component because, on Android, using the `Text` component with `numberOfLines={1}` did not correctly respect the timing for applying the truncation/ellipsis. Often, depending on the text length and spacing, the ellipsis/truncation was applied prematurely or extrapolates its container size, resulting in unnecessary empty space after the `Badge` or cutting it off.

This difference in behavior between iOS and Android is a peculiarity of how each platform handles text layout. On Android, spaces are considered in the calculation of when to apply ellipsis, while on iOS, the calculation is more based on the actual width of the rendered text.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [ ] Web
- [x] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [ ] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

**Some text sizes variations**

| Before | After |
| ------ | ----- |
|![image](https://github.com/gympass/yoga/assets/150721390/377cff46-3402-446f-886a-7a9d428b30f5)|![image](https://github.com/gympass/yoga/assets/150721390/6ab137e4-de81-4f10-be50-e281b76212d5)|
|![image](https://github.com/gympass/yoga/assets/150721390/8052d9fb-5c7a-41d5-821d-124fbd27287e)|![image](https://github.com/gympass/yoga/assets/150721390/be252044-f29a-44a8-8208-9f07255f2166)|
|![image](https://github.com/gympass/yoga/assets/150721390/39005738-edb9-43ec-a765-51deee12b0da)|![image](https://github.com/gympass/yoga/assets/150721390/9a971110-5afa-47b2-b277-0ace10d3c0f8)|
|![image](https://github.com/gympass/yoga/assets/150721390/00903df5-c74b-4939-8ede-0250142024e6)|![image](https://github.com/gympass/yoga/assets/150721390/e85c840d-fac4-41c1-b601-8dfa40a5860d)|
|![image](https://github.com/gympass/yoga/assets/150721390/21c3a635-c926-4564-a982-c9e788e2e074)|![image](https://github.com/gympass/yoga/assets/150721390/2d98db90-cc7c-458a-82cd-59512bc8e63b)|
|![image](https://github.com/gympass/yoga/assets/150721390/87a92a45-1aa3-4c9c-8ce1-1b030381eff2)|![image](https://github.com/gympass/yoga/assets/150721390/b8556f94-8ccd-42bd-a6a2-e7608367402e)|