### PR TITLE
fix(package): moves yoga-icons dep to peer dependencies

### DIFF
--- a/packages/yoga/package.json
+++ b/packages/yoga/package.json
@@ -69,11 +69,6 @@
     "react-native": "0.72.3",
     "styled-components": "^4.4.0"
   },
-  "peerDependenciesMeta": {
-    "@gympass/yoga-icons": {
-      "optional": true
-    }
-  },
   "tsup": {
     "entry": [
       "src/index.ts",

--- a/packages/yoga/package.json
+++ b/packages/yoga/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@gympass/yoga-common": "^1.4.1",
     "@gympass/yoga-helpers": "^1.1.1",
-    "@gympass/yoga-icons": "^1.28.0",
     "@gympass/yoga-illustrations": "^0.7.1",
     "@gympass/yoga-system": "^0.25.0",
     "@gympass/yoga-tokens": "^3.6.4",
@@ -56,6 +55,7 @@
     "react-phone-input-2": "^2.15.1"
   },
   "devDependencies": {
+    "@gympass/yoga-icons": "^1.28.0",
     "@react-native-community/eslint-config": "^3.0.1",
     "@types/styled-components": "^5.1.34",
     "babel-plugin-inline-react-svg": "^1.1.1",
@@ -63,10 +63,16 @@
     "styled-components": "^4.4.0"
   },
   "peerDependencies": {
+    "@gympass/yoga-icons": "^1.28.0",
     "@react-native-picker/picker": "^2.4.9",
     "react": ">=16",
     "react-native": "0.72.3",
     "styled-components": "^4.4.0"
+  },
+  "peerDependenciesMeta": {
+    "@gympass/yoga-icons": {
+      "optional": true
+    }
   },
   "tsup": {
     "entry": [


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/CODEME-1567)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR only proposes making the dependency on `@gympass/yoga-icons` a peer dependency in `@gympass/yoga`.

Since client applications generally tend to depend directly on the `@gympass/yoga-icons` package, its presence as a direct dependency on the `@gympass/yoga` package often causes the application to have dependency duplication problems. In many cases, package managers such as Yarn do not resolve the conflict (see [_duplicate package errors_](https://microsoft.github.io/rnx-kit/docs/guides/bundling#running-the-bundler)) even by running deduplication programs, which can be problematic for optimizing the js bundle.

Below is evidence collected from initiatives in the Wellhub app.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [x] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [x] Maybe to clarify the need to install the icons package alongside yoga?

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Unit Test
- [x] Snapshot Test
- [x] By solving dependency duplicates in a client app

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Screenshots 📸

* After `dedupe` with `yoga-icons` base dependency pointing to a version lower than the `yoga` sub-dependency:

```
error @gympass/yoga-icons (found 4 copies)
warn   0.9.0 end-user-native/node_modules/@gympass/yoga-old/node_modules/@gympass/yoga-icons
warn   1.23.1 end-user-native/node_modules/@gympass/yoga-icons
warn   1.26.0 end-user-native/node_modules/@gympass/yoga/node_modules/@gympass/yoga-icons
warn   1.26.0 end-user-native/node_modules/@yoga-inner/native/node_modules/@gympass/yoga-icons
```

* After dedupe with `yoga-icons` base dependency pointing to a greater version

![unnamed](https://github.com/user-attachments/assets/b2a2bc35-76ff-40ea-bdff-6d54ceeeb613)

_> deduplication solved 2 copies_

* After moving to `peerDependencies`

<img width="1360" alt="Screenshot 2025-01-29 at 16 42 41" src="https://github.com/user-attachments/assets/176df4eb-b31e-4532-960e-c2817cdc4e5e" />

_> no duplication risk_
