### PR TITLE
Feat: add countries props for input phone component

### DIFF
--- a/packages/doc/content/components/components/input/phone-web.mdx
+++ b/packages/doc/content/components/components/input/phone-web.mdx
@@ -1,12 +1,10 @@
-### Usage
-
 ```javascript state
 render(() => {
   const [value, setValue] = useState('');
 
   return (
     <Input.Phone
-      defaultCountry='br'
+      defaultCountry="br"
       label="Mobile number"
       value={value}
       onChange={(value = '') => {
@@ -18,7 +16,3 @@ render(() => {
   );
 });
 ```
-
-### Props
-
-<PropsTable component="Input" platform="web" />

--- a/packages/doc/content/components/components/input/phone.mdx
+++ b/packages/doc/content/components/components/input/phone.mdx
@@ -10,4 +10,32 @@ import PhoneWeb from './phone-web.mdx';
 
 Input.Phone let users enter and edit telephone numbers contextualized to their country.
 
+### Default
+
 <PhoneWeb />
+
+### With countries props for filtering countries
+
+```javascript state
+render(() => {
+  const [value, setValue] = useState('');
+  const countries = ['br', 'pt'];
+  return (
+    <Input.Phone
+      defaultCountry="br"
+      label="Mobile number"
+      value={value}
+      countries={countries}
+      onChange={(value = '') => {
+        const newValue = value.length > 0 ? `+${value}` : '';
+        setValue(newValue);
+      }}
+      helper={'This is an helper text'}
+    />
+  );
+});
+```
+
+### Props
+
+<PropsTable component="Input" platform="web" />

--- a/packages/yoga/src/Input/web/Phone.jsx
+++ b/packages/yoga/src/Input/web/Phone.jsx
@@ -36,6 +36,7 @@ const Phone = React.forwardRef(
       label = '',
       placeholder = '+55 (11) 999999999',
       value = '',
+      countries = phoneBaseSettings.onlyCountries,
       onChange = noop,
       cleanable = true,
       ...rest
@@ -50,6 +51,10 @@ const Phone = React.forwardRef(
         currentCountry.current = countryCode;
       }
     }, []);
+
+    const availableCountries = {
+      onlyCountries: countries,
+    };
 
     return (
       <Input
@@ -69,7 +74,7 @@ const Phone = React.forwardRef(
       >
         <S.Container error={error} disabled={disabled} full={full}>
           <BasePhoneInput
-            {...phoneBaseSettings}
+            {...availableCountries}
             ref={phoneRef => {
               inputRef.current = phoneRef?.numberInputRef;
             }}
@@ -115,6 +120,8 @@ Phone.propTypes = {
   onChange: func,
   /** placeholder to show when the input is cleared */
   placeholder: string,
+  /** countries for mask field and dropdown, make sure to use ISO 3166-1 alpha-2 lowercase */
+  countries: PropTypes.arrayOf(string),
 };
 
 export default Phone;

--- a/packages/yoga/src/Input/web/Phone.jsx
+++ b/packages/yoga/src/Input/web/Phone.jsx
@@ -53,7 +53,8 @@ const Phone = React.forwardRef(
     }, []);
 
     const availableCountries = {
-      onlyCountries: countries,
+      onlyCountries:
+        countries?.length > 0 ? countries : phoneBaseSettings.onlyCountries,
     };
 
     return (

--- a/packages/yoga/src/Input/web/Phone.test.jsx
+++ b/packages/yoga/src/Input/web/Phone.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import { ThemeProvider, Input } from '../..';
 
@@ -80,15 +80,13 @@ describe('<Input.Phone />', () => {
     it(`Should only format countries numbers when props is given`, () => {
       const USPhone = numbersFormats[1];
 
-      render(
+      const { queryByDisplayValue } = render(
         <ThemeProvider>
           <Input.Phone countries={['br', 'pt']} value={USPhone.base} />
         </ThemeProvider>,
       );
 
-      expect(
-        screen.queryByDisplayValue(USPhone.expected),
-      ).not.toBeInTheDocument();
+      expect(queryByDisplayValue(USPhone.expected)).not.toBeInTheDocument();
     });
 
     it('should prefix the phone number with newly selected country dial code', async () => {

--- a/packages/yoga/src/Input/web/Phone.test.jsx
+++ b/packages/yoga/src/Input/web/Phone.test.jsx
@@ -89,6 +89,19 @@ describe('<Input.Phone />', () => {
       expect(queryByDisplayValue(USPhone.expected)).not.toBeInTheDocument();
     });
 
+    it(`Should return all countries validation if countries equals to empty array`, () => {
+      const USPhone = numbersFormats[1];
+
+      const { getAllByRole } = render(
+        <ThemeProvider>
+          <Input.Phone countries={[]} value={USPhone.base} />
+        </ThemeProvider>,
+      );
+
+      fireEvent.click(getAllByRole('button')[0]);
+      expect(getAllByRole('option').length).toBe(12);
+    });
+
     it('should prefix the phone number with newly selected country dial code', async () => {
       const { getByRole, getByText, getByDisplayValue } = render(
         <ThemeProvider>

--- a/packages/yoga/src/Input/web/Phone.test.jsx
+++ b/packages/yoga/src/Input/web/Phone.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 
 import { ThemeProvider, Input } from '../..';
 
@@ -75,6 +75,20 @@ describe('<Input.Phone />', () => {
 
         expect(getByDisplayValue(spec.expected)).toBeInTheDocument();
       });
+    });
+
+    it(`Should only format countries numbers when props is given`, () => {
+      const USPhone = numbersFormats[1];
+
+      render(
+        <ThemeProvider>
+          <Input.Phone countries={['br', 'pt']} value={USPhone.base} />
+        </ThemeProvider>,
+      );
+
+      expect(
+        screen.queryByDisplayValue(USPhone.expected),
+      ).not.toBeInTheDocument();
     });
 
     it('should prefix the phone number with newly selected country dial code', async () => {

--- a/packages/yoga/src/Input/web/Phone.test.jsx
+++ b/packages/yoga/src/Input/web/Phone.test.jsx
@@ -77,7 +77,7 @@ describe('<Input.Phone />', () => {
       });
     });
 
-    it(`Should only format countries numbers when props is given`, () => {
+    it(`Should only format and show countries numbers when props is given`, () => {
       const USPhone = numbersFormats[1];
 
       const { queryByDisplayValue } = render(

--- a/packages/yoga/src/Menu/web/__snapshots__/Menu.test.jsx.snap
+++ b/packages/yoga/src/Menu/web/__snapshots__/Menu.test.jsx.snap
@@ -80,7 +80,6 @@ exports[`<Menu /> should match snapshot Menu with a onMouseHover props false 1`]
 
 <div>
   <button
-    aria-disabled="false"
     aria-expanded="false"
     aria-haspopup="menu"
     class="c0"
@@ -180,7 +179,6 @@ exports[`<Menu /> should match snapshot Menu with an align props end 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -281,7 +279,6 @@ exports[`<Menu /> should match snapshot Menu with an align props start 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -382,7 +379,6 @@ exports[`<Menu /> should match snapshot Menu.Item with active 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -483,7 +479,6 @@ exports[`<Menu /> should match snapshot Menu.Item with disabled 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -584,7 +579,6 @@ exports[`<Menu /> should match snapshot Menu.Item with disabled and icon 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -685,7 +679,6 @@ exports[`<Menu /> should match snapshot Menu.Item with icon 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -786,7 +779,6 @@ exports[`<Menu /> should match snapshot Menu.Item with link 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -887,7 +879,6 @@ exports[`<Menu /> should match snapshot in default Menu 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

The goal of this PR is to add the prop countries so the child component of input phone can filter the countries options to show in the input phone field.

[Enter the description of your changes]

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [x] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸
![image](https://github.com/user-attachments/assets/9fa09bab-e398-40c9-ac35-2299ffba3e0b)

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
