### PR TITLE
🚀 Feat: ad aria label to right button

### DIFF
--- a/packages/yoga/src/Button/web/Button.jsx
+++ b/packages/yoga/src/Button/web/Button.jsx
@@ -26,6 +26,7 @@ const Button = forwardRef(
       secondary = false,
       icon: Icon,
       isLoading = false,
+      'aria-label': ariaLabel,
       ...props
     },
     ref,
@@ -49,6 +50,7 @@ const Button = forwardRef(
         small={small}
         secondary={secondary}
         isLoading={isLoading}
+        aria-label={ariaLabel}
         {...finalProps}
       >
         {Icon && <Icon role="img" />}
@@ -77,6 +79,7 @@ Button.propTypes = {
   /** an Icon from yoga-icons package */
   icon: oneOfType([node, func]),
   href: string,
+  'aria-label': string,
 };
 
 Button.displayName = 'Button';

--- a/packages/yoga/src/Heading/web/Heading.test.jsx
+++ b/packages/yoga/src/Heading/web/Heading.test.jsx
@@ -75,6 +75,24 @@ describe('<Heading />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should have aria-label', () => {
+    const { getAllByLabelText } = render(
+      <ThemeProvider>
+        <Heading noPadding>
+          <Title>Gympass</Title>
+          <BackButton onClick={onClick} />
+          <RightButton
+            icon={Upload2}
+            onClick={onClick}
+            aria-label="labelAriaText"
+          />
+        </Heading>
+      </ThemeProvider>,
+    );
+
+    expect(getAllByLabelText('labelAriaText')).toHaveLength(1);
+  });
+
   it('should override the background color', () => {
     const { container } = render(
       <ThemeProvider>

--- a/packages/yoga/src/Heading/web/RightButton.jsx
+++ b/packages/yoga/src/Heading/web/RightButton.jsx
@@ -58,8 +58,14 @@ const ButtonIcon = styled(Button)`
   }};
 `;
 
-const RightButton = ({ onClick, icon, ...props }) => (
-  <ButtonIcon onClick={onClick} secondary padding="xxxsmall" {...props}>
+const RightButton = ({ onClick, icon, 'aria-label': ariaLabel, ...props }) => (
+  <ButtonIcon
+    onClick={onClick}
+    secondary
+    padding="xxxsmall"
+    aria-label={ariaLabel}
+    {...props}
+  >
     <Box
       flex={1}
       display="flex"
@@ -77,6 +83,7 @@ const RightButton = ({ onClick, icon, ...props }) => (
 RightButton.propTypes = {
   onClick: PropTypes.func.isRequired,
   icon: PropTypes.elementType.isRequired,
+  'aria-label': PropTypes.string,
 };
 
 RightButton.displayName = 'Heading.RightButton';

--- a/packages/yoga/src/Menu/web/__snapshots__/Menu.test.jsx.snap
+++ b/packages/yoga/src/Menu/web/__snapshots__/Menu.test.jsx.snap
@@ -80,7 +80,6 @@ exports[`<Menu /> should match snapshot Menu with a onMouseHover props false 1`]
 
 <div>
   <button
-    aria-disabled="false"
     aria-expanded="false"
     aria-haspopup="menu"
     class="c0"
@@ -180,7 +179,6 @@ exports[`<Menu /> should match snapshot Menu with an align props end 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -281,7 +279,6 @@ exports[`<Menu /> should match snapshot Menu with an align props start 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -382,7 +379,6 @@ exports[`<Menu /> should match snapshot Menu.Item with active 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -483,7 +479,6 @@ exports[`<Menu /> should match snapshot Menu.Item with disabled 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -584,7 +579,6 @@ exports[`<Menu /> should match snapshot Menu.Item with disabled and icon 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -685,7 +679,6 @@ exports[`<Menu /> should match snapshot Menu.Item with icon 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -786,7 +779,6 @@ exports[`<Menu /> should match snapshot Menu.Item with link 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"
@@ -887,7 +879,6 @@ exports[`<Menu /> should match snapshot in default Menu 1`] = `
 <div>
   <div>
     <button
-      aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="menu"
       class="c0"


### PR DESCRIPTION
[![JIRA Issue](https://gympass.atlassian.net/jira/software/c/projects/ACS/boards/1348?assignee=712020%3A4448bab7-b24c-4e4b-bd76-7d9e3e1c3b36&selectedIssue=ACS-100)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

added aria label to the right button, making accessibility easier

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[Enter the description of your changes]

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [X] Unit Test
- [X] Snapshot Test

## Checklist: 🔍

- [ ] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

[Upload your screenshots here]

| ScreenShot |
| ----------- |
|        
![Captura de Tela 2025-02-05 às 10 58 15](https://github.com/user-attachments/assets/e51d8f20-101f-4160-b5cc-18b4c7bfc30b)

![image](https://github.com/user-attachments/assets/5231ff39-5dfd-4f78-9995-743789092107)
      |
