### PR TITLE
  🚀 feat: add highlightFirst prop in AutoComplete web component 

### DIFF
--- a/packages/doc/content/components/components/autocomplete/index.mdx
+++ b/packages/doc/content/components/components/autocomplete/index.mdx
@@ -45,7 +45,7 @@ render(() => {
 });
 ```
 
-#### With first option with highlighted index
+#### With first option highlighted
 
 ```javascript state
 render(() => {
@@ -54,7 +54,7 @@ render(() => {
   return (
     <AutoComplete
       value={value}
-      defaultHighlightedIndex={0}
+      highlightFirst
       onChange={value => setValue(value)}
       onSelect={selected => console.log(selected)}
       onClean={cleaned => console.log('cleaned', cleaned)}

--- a/packages/doc/content/components/components/autocomplete/index.mdx
+++ b/packages/doc/content/components/components/autocomplete/index.mdx
@@ -17,6 +17,8 @@ It inherit all the [Input](/components/input/default) props.
 
 ## Usage
 
+#### Default
+
 ```javascript state
 render(() => {
   const [value, setValue] = useState('');
@@ -24,6 +26,35 @@ render(() => {
   return (
     <AutoComplete
       value={value}
+      onChange={value => setValue(value)}
+      onSelect={selected => console.log(selected)}
+      onClean={cleaned => console.log('cleaned', cleaned)}
+      options={[
+        'Madrid',
+        'Milan',
+        'São Paulo',
+        'New York',
+        'Paris',
+        'Buenos Aires',
+        'Amsterdam',
+        'Los Angeles',
+        'Hollywood',
+      ]}
+    />
+  );
+});
+```
+
+#### With first option with highlighted index
+
+```javascript state
+render(() => {
+  const [value, setValue] = useState('');
+
+  return (
+    <AutoComplete
+      value={value}
+      defaultHighlightedIndex={0}
       onChange={value => setValue(value)}
       onSelect={selected => console.log(selected)}
       onClean={cleaned => console.log('cleaned', cleaned)}

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -1,7 +1,7 @@
 /* eslint react/no-array-index-key: 0 */
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import Downshift from 'downshift';
-import { arrayOf, string, func, bool, shape, number } from 'prop-types';
+import { arrayOf, string, func, bool, shape } from 'prop-types';
 import styled, { css } from 'styled-components';
 import { ChevronDown, ChevronUp } from '@gympass/yoga-icons';
 
@@ -165,7 +165,7 @@ const AutoComplete = React.forwardRef(
       error,
       openSuggestionsAriaLabel = 'Open suggestions',
       closeSuggestionsAriaLabel = 'Close suggestions',
-      defaultHighlightedIndex = null,
+      highlightFirst = false,
       shouldFilterOptions = true,
       ...props
     },
@@ -197,7 +197,7 @@ const AutoComplete = React.forwardRef(
     return (
       <Downshift
         selectedItem={userValue}
-        defaultHighlightedIndex={defaultHighlightedIndex}
+        defaultHighlightedIndex={highlightFirst ? 0 : null}
         onStateChange={changes => {
           const { selectedItem, inputValue } = changes;
 
@@ -336,8 +336,8 @@ AutoComplete.propTypes = {
   closeSuggestionsAriaLabel: string,
   /** flag to enable options filtering */
   shouldFilterOptions: bool,
-  /** the value to set the highlightedIndex to anytime downshift is reset */
-  defaultHighlightedIndex: number || null,
+  /** first highlighted option for whenever Autocomplete is restarted */
+  highlightFirst: bool,
 };
 
 export default AutoComplete;

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -1,7 +1,7 @@
 /* eslint react/no-array-index-key: 0 */
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import Downshift from 'downshift';
-import { arrayOf, string, func, bool, shape } from 'prop-types';
+import { arrayOf, string, func, bool, shape, number } from 'prop-types';
 import styled, { css } from 'styled-components';
 import { ChevronDown, ChevronUp } from '@gympass/yoga-icons';
 
@@ -165,6 +165,7 @@ const AutoComplete = React.forwardRef(
       error,
       openSuggestionsAriaLabel = 'Open suggestions',
       closeSuggestionsAriaLabel = 'Close suggestions',
+      defaultHighlightedIndex = null,
       shouldFilterOptions = true,
       ...props
     },
@@ -196,6 +197,7 @@ const AutoComplete = React.forwardRef(
     return (
       <Downshift
         selectedItem={userValue}
+        defaultHighlightedIndex={defaultHighlightedIndex}
         onStateChange={changes => {
           const { selectedItem, inputValue } = changes;
 
@@ -334,6 +336,8 @@ AutoComplete.propTypes = {
   closeSuggestionsAriaLabel: string,
   /** flag to enable options filtering */
   shouldFilterOptions: bool,
+  /** the value to set the highlightedIndex to anytime downshift is reset */
+  defaultHighlightedIndex: number || null,
 };
 
 export default AutoComplete;


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/DSC-2039)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a new prop called `highlightFirst` in the `Autocomplete` component to highlight the first option whenever Autocomplete is restarted.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit Test
- [x] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [x] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

The first one (Deaful) already exists, and the second one is with the prop `defaultHighlightedIndex={0}`

https://github.com/user-attachments/assets/4c31fc81-c776-4e73-8a2b-668609ca46f0

