### PR TITLE
🐞 fix(icon): small sizes

### DIFF
--- a/packages/yoga/src/Icon/Icon.jsx
+++ b/packages/yoga/src/Icon/Icon.jsx
@@ -12,6 +12,20 @@ import get from 'lodash.get';
 
 import Box from '../Box';
 
+// Box resolves width/height against the same `spacing` scale again. That
+// object maps both token names (xxxsmall, small...) and numeric indexes
+// (0, 1, 2...) to pixel values, so a resolved number that happens to also be
+// a valid index (e.g. xxxsmall -> 4) would get looked up a second time and
+// silently swapped for a different size. Suffixing with "px" only when that
+// collision is possible keeps every other size byte-for-byte the same.
+const resolveSize = (spacing, value) => {
+  const resolved = get(spacing, value, value);
+  const collidesWithIndex =
+    typeof resolved === 'number' && get(spacing, resolved) !== undefined;
+
+  return collidesWithIndex ? `${resolved}px` : resolved;
+};
+
 const Icon = ({
   as: Component,
   size = 12,
@@ -68,8 +82,8 @@ const Icon = ({
   return (
     <Box
       as={title && ariaLabel ? componentWithTitle : Component}
-      width={get(theme.yoga.spacing, width, width)}
-      height={get(theme.yoga.spacing, height, height)}
+      width={resolveSize(theme.yoga.spacing, width)}
+      height={resolveSize(theme.yoga.spacing, height)}
       {...(fill && { fill: get(theme.yoga.colors, fill, fill) })}
       {...(stroke && { stroke: get(theme.yoga.colors, stroke, stroke) })}
       {...props}


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There was a bug on `Icon` component causing `xxxsmall` and `xxsmall` icon sizes to render with wrong sizes.

The bug was caused due to a collision between values and indexes during size resolution. `Box` uses index to value like "0->0", "1->4", "2->8", ... so when `xxxsmall`(4) or `xxsmall`(8) was resolved, the index resolution transformed them to the wrong value.

PS: the current implementation relies on `fontSizes`.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [X] Web
- [X] Mobile

## Type of change 🔍

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

No new tests required.

- [ ] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [X] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

| Before | After |
| --- | --- |
| <img width="795" height="287" alt="Captura de Tela 2026-07-15 às 10 41 13" src="https://github.com/user-attachments/assets/8184a8d1-814c-47fd-a895-6df02eedead1" /> | <img width="792" height="283" alt="Captura de Tela 2026-07-15 às 10 44 44" src="https://github.com/user-attachments/assets/6042029e-c528-4779-a19f-73d9bc90c655" /> |
