### PR TITLE
fix(autocomplete): allow selecting an option that exactly matches the typed text

### DIFF
--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -201,15 +201,17 @@ const AutoComplete = React.forwardRef(
         onStateChange={changes => {
           const { selectedItem, inputValue } = changes;
 
-          if (selectedItem) {
+          if (Object.prototype.hasOwnProperty.call(changes, 'selectedItem')) {
             setUserValue(selectedItem);
+          }
+
+          if (selectedItem) {
             onSelect(selectedItem);
             onChange(selectedItem);
             handleCloseSuggestions();
           } else if (
             Object.prototype.hasOwnProperty.call(changes, 'inputValue')
           ) {
-            setUserValue(inputValue);
             onChange(inputValue);
           }
         }}

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
@@ -171,5 +171,60 @@ describe('<AutoComplete />', () => {
       expect(onChangeMock).toHaveBeenCalledWith('New York');
       expect(onCleanMock).not.toHaveBeenCalled();
     });
+
+    it('should call onSelectMock when the typed value exactly matches an option', () => {
+      const onSelectMock = jest.fn();
+      const onChangeMock = jest.fn();
+
+      const { getByRole } = render(
+        <ThemeProvider>
+          <AutoComplete
+            value=""
+            options={['New York']}
+            onSelect={onSelectMock}
+            onChange={onChangeMock}
+          />
+        </ThemeProvider>,
+      );
+
+      const input = getByRole('textbox');
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'New York' } });
+      fireEvent.click(getByRole('option'));
+
+      expect(onSelectMock).toHaveBeenCalledWith('New York');
+      expect(onChangeMock).toHaveBeenCalledWith('New York');
+    });
+
+    it('should allow selecting an option again after cleaning a previous selection', () => {
+      const onSelectMock = jest.fn();
+
+      const { getByDisplayValue, getByRole } = render(
+        <ThemeProvider>
+          <AutoComplete
+            value="New"
+            options={['New York']}
+            onSelect={onSelectMock}
+          />
+        </ThemeProvider>,
+      );
+
+      fireEvent.focus(getByDisplayValue('New'));
+      fireEvent.click(getByRole('option'));
+
+      expect(onSelectMock).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(getByRole('button', { name: /clear/i }));
+
+      fireEvent.change(getByDisplayValue(''), {
+        target: { value: 'New York' },
+      });
+      fireEvent.focus(getByDisplayValue('New York'));
+      fireEvent.click(getByRole('option'));
+
+      expect(onSelectMock).toHaveBeenCalledTimes(2);
+      expect(onSelectMock).toHaveBeenNthCalledWith(2, 'New York');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a bug where typing text that exactly matches an option in `AutoComplete` prevented the user from selecting it (click or Enter had no effect).
- Root cause: the typed text was synced into the same state used as Downshift's controlled `selectedItem`, so when it matched an option, Downshift's internal diffing saw "no change" and never fired the selection.
- Also fixes a related regression uncovered while testing: after selecting an option and using the clear (`clean`) button, the internal selection state stayed stuck on the previous item, preventing the same option from being selected again.

## Description
Root cause: The component synced the typed text on every keystroke into the same state variable used as `Downshift`'s controlled `selectedItem`. When the typed text matched an option, that controlled prop already equaled the value the selection would try to set — and `Downshift`, when comparing the new value against the current one before notifying changes, determined that "nothing changed" and never fired the selection.

Fix: The selection state (`selectedItem`) is now only updated when a selection actually occurs (or is cleared via clean), not on every keystroke. This removes the value collision and restores selection correctly, without changing the filtering/display behavior of the options while typing. The same change also fixed a side effect where the clear button (clean) left the internal selection state "stuck" on the last selected item.

## Test plan
- [x] Added regression test simulating typing until it matches an option, then selecting it via click
- [x] Added regression test covering select → clean → reselect the same option
- [x] Verified both new tests fail against the pre-fix code and pass after the fix
- [x] Full existing `AutoComplete` test suite passes (12/12)
- [x] Manually validated in the local docs playground (`yarn dev:web` → `/components/autocomplete`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)