### PR TITLE
fix(autocomplete): sync internal value state when value prop changes

### DIFF
--- a/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.jsx
@@ -186,6 +186,10 @@ const AutoComplete = React.forwardRef(
     }, []);
 
     useEffect(() => {
+      setUserValue(value);
+    }, [value]);
+
+    useEffect(() => {
       const handleKeyUp = ({ key }) => {
         return key === 'Escape' && handleCloseSuggestions();
       };

--- a/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
+++ b/packages/yoga/src/AutoComplete/web/AutoComplete.test.jsx
@@ -226,5 +226,23 @@ describe('<AutoComplete />', () => {
       expect(onSelectMock).toHaveBeenCalledTimes(2);
       expect(onSelectMock).toHaveBeenNthCalledWith(2, 'New York');
     });
+
+    it('should update the displayed value when the value prop changes externally', () => {
+      const { getByDisplayValue, rerender } = render(
+        <ThemeProvider>
+          <AutoComplete value="New" options={['New York']} />
+        </ThemeProvider>,
+      );
+
+      expect(getByDisplayValue('New')).toBeTruthy();
+
+      rerender(
+        <ThemeProvider>
+          <AutoComplete value="Rio" options={['Rio de Janeiro']} />
+        </ThemeProvider>,
+      );
+
+      expect(getByDisplayValue('Rio')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[Enter the description of your changes]

`AutoComplete` only used the `value` prop as the initial state for `userValue`, so updating `value` from a parent component after mount had no effect on the rendered selection. Added an effect to keep `userValue` in sync with `value` so the component behaves as a proper controlled input.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [x] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

- N/A
    - Because this is a behavioral fix with no visual changes.

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
