### PR TITLE
fix(checkbox): stop duplicating rest props onto the wrapper `div`

### DIFF
--- a/packages/yoga/src/Checkbox/web/Checkbox.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.jsx
@@ -277,12 +277,7 @@ const Checkbox = ({
   });
 
   return (
-    <CheckboxWrapper
-      style={style}
-      className={className}
-      disabled={disabled}
-      {...restWithoutEvents}
-    >
+    <CheckboxWrapper style={style} className={className} disabled={disabled}>
       <CheckboxStyled
         checked={checked}
         indeterminate={indeterminate}

--- a/packages/yoga/src/Checkbox/web/Checkbox.test.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.test.jsx
@@ -190,4 +190,20 @@ describe('<Checkbox />', () => {
       expect(onChangeMock).toHaveBeenCalled();
     });
   });
+
+  describe('Rest props', () => {
+    it('should forward extra props only to the input, not to the wrapper', () => {
+      const { container } = render(
+        <ThemeProvider>
+          <Checkbox {...data} id="terms" data-testid="terms-checkbox" />
+        </ThemeProvider>,
+      );
+
+      expect(container.querySelectorAll('#terms')).toHaveLength(1);
+      expect(container.querySelector('#terms').tagName).toBe('INPUT');
+      expect(
+        container.querySelectorAll('[data-testid="terms-checkbox"]'),
+      ).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[Enter the description of your changes]

- `Checkbox` spread the leftover props (`id`, `name`, `data-*`, etc.) onto both the outer wrapper `div` and the hidden `<input>`, so passing something like `id` duplicated it across two DOM nodes and produced invalid HTML (e.g. duplicate `id` attributes, `data-testid` matching more than one element). 
- Extra props now land only on the actual input element, which is the node they are meant to describe.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

- [x] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

N/A 
Because no visual changes.

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
