### PR TITLE
fix(checkbox): add missing dependency array to indeterminate effect

### DIFF
--- a/packages/yoga/src/Checkbox/web/Checkbox.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.jsx
@@ -274,7 +274,7 @@ const Checkbox = ({
     if (inputRef.current) {
       inputRef.current.indeterminate = indeterminate;
     }
-  });
+  }, [indeterminate]);
 
   return (
     <CheckboxWrapper

--- a/packages/yoga/src/Checkbox/web/Checkbox.test.jsx
+++ b/packages/yoga/src/Checkbox/web/Checkbox.test.jsx
@@ -190,4 +190,57 @@ describe('<Checkbox />', () => {
       expect(onChangeMock).toHaveBeenCalled();
     });
   });
+
+  describe('Indeterminate', () => {
+    it('should only touch the native indeterminate property when the indeterminate prop changes', () => {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'indeterminate',
+      );
+      const setSpy = jest.fn(function set(value) {
+        descriptor.set.call(this, value);
+      });
+
+      Object.defineProperty(
+        window.HTMLInputElement.prototype,
+        'indeterminate',
+        {
+          ...descriptor,
+          set: setSpy,
+        },
+      );
+
+      try {
+        const { rerender } = render(
+          <ThemeProvider>
+            <Checkbox {...data} indeterminate />
+          </ThemeProvider>,
+        );
+
+        expect(setSpy).toHaveBeenCalledTimes(1);
+
+        rerender(
+          <ThemeProvider>
+            <Checkbox {...data} indeterminate label="Updated label" />
+          </ThemeProvider>,
+        );
+
+        expect(setSpy).toHaveBeenCalledTimes(1);
+
+        rerender(
+          <ThemeProvider>
+            <Checkbox {...data} indeterminate={false} label="Updated label" />
+          </ThemeProvider>,
+        );
+
+        expect(setSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        Object.defineProperty(
+          window.HTMLInputElement.prototype,
+          'indeterminate',
+          descriptor,
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
[![JIRA Issue](https://img.shields.io/badge/issue-JIRA-blue.svg)](https://gympass.atlassian.net/browse/)

<!--
Please consider using title EMOJIS in the PR title to favor visualisation
PR Title Pattern: ${CLASSIFICATION EMOJI} ${PULL REQUEST TITLE}

Classification emojis
  💣 Breaking Change - Critical
  🚀 Just another PR
  🐞 Hot Fixes
-->

## Description 📄

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[Enter the description of your changes]

The `useEffect` that syncs the native `indeterminate` property on the hidden checkbox input had no dependency array, so it ran on every render of `Checkbox`, even when `indeterminate` had not changed.
So Added `[indeterminate]` as its dependency array so it only runs when that value actually changes.

## Platforms 📲

<!-- Mark an `x` in the boxes that apply. You can also fill these out after
creating the PR.-->

- [x] Web
- [ ] Mobile

## Type of change 🔍

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? 🧪

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

[Enter the tips to test this PR]

Added a regression test that spies on the native indeterminate setter and asserts it is only invoked when the indeterminate prop itself changes, not on unrelated re-renders (e.g. a label change). 
Verified the test fails without the dependency array and passes with it.

- [x] Unit Test
- [ ] Snapshot Test

## Checklist: 🔍

- [x] My code follows the contribution guide of this project [Contributing Guide](https://github.com/Gympass/yoga/blob/master/CONTRIBUTING.md)
- [ ] Layout matches design prototype: [FIGMA](https://figma.com/file/YOUR_LINK)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Screenshots 📸

<!--
Load here screenshots for this PR
-->

N/A

[Upload your screenshots here]

| Before | After |
| ------ | ----- |
|        |       |
